### PR TITLE
Define Jenkins repository and Jenkins plugins repository in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,32 @@ THE SOFTWARE.
     <tag>HEAD</tag>
   </scm>
 
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
   <dependencies>
     <dependency>
       <!--


### PR DESCRIPTION
I'm fiddling with this module for the first time due to JENKINS-32571. I've used clean environment - empty Maven's settings.xml and empty local repo. 

Tried to build it like:
mvn clean install -Dmaven.repo.local=local-repo

It ends with an error:
Non-resolvable parent POM: Failure to find org.jenkins-ci:jenkins:pom:1.35 in http://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced and 'parent.relativePath' points at wrong local POM @ line 28, column 11 -> [Help 2]

I've copied to pom.xml the same repositories as defined in jenkins pom.xml and the issue is resolved.