### PR TITLE
Fixing 'unmappable character for encoding ASCII' ('...')

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1603,7 +1603,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                         return Which.jarFile(manifest);
                 }
 
-                // For snapshot plugin dependencies, an IDE may have replaced ~/.m2/repository/…/${artifactId}.hpi with …/${artifactId}-plugin/target/classes/
+                // For snapshot plugin dependencies, an IDE may have replaced ~/.m2/repository/.../${artifactId}.hpi with .../${artifactId}-plugin/target/classes/
                 // which unfortunately lacks META-INF/MANIFEST.MF so try to find index.jelly (which every plugin should include) and thus the ${artifactId}.hpi:
                 Enumeration<URL> jellies = getClass().getClassLoader().getResources("index.jelly");
                 while (jellies.hasMoreElements()) {

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTest.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTest.java
@@ -57,7 +57,7 @@ public class JenkinsRuleTimeoutTest {
 
     @Test
     public void hangInterruptiblyInShutdown() throws Exception {
-        System.err.println("Test itself passed…");
+        System.err.println("Test itself passed...");
     }
     @TestExtension("hangInterruptiblyInShutdown")
     public static class HangsInterruptibly extends ItemListener {
@@ -75,7 +75,7 @@ public class JenkinsRuleTimeoutTest {
     @Ignore("TODO ditto")
     @Test
     public void hangUninterruptiblyInShutdown() throws Exception {
-        System.err.println("Test itself passed…");
+        System.err.println("Test itself passed...");
     }
     @TestExtension("hangUninterruptiblyInShutdown")
     public static class HangsUninterruptibly extends ItemListener {


### PR DESCRIPTION
I'm fiddling with this module for the first time due to JENKINS-32571 but building failed (use OpenJDK - fedora-2.5.3.0.fc20-x86_64 u71-b14) due to:
error: unmappable character for encoding ASCII

It seems the special character '...' is the root cause, so I've changed its occurrence to "...".