### PR TITLE
Actively look for a plugin that failed to start.

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/PluginAutomaticTestBuilder.java
+++ b/src/main/java/org/jvnet/hudson/test/PluginAutomaticTestBuilder.java
@@ -23,6 +23,7 @@
  */
 package org.jvnet.hudson.test;
 
+import hudson.PluginManager.FailedPlugin;
 import hudson.PluginWrapper;
 import hudson.cli.CLICommand;
 import java.io.File;
@@ -86,8 +87,13 @@ public class PluginAutomaticTestBuilder {
         public void testPluginActive() {
             String plugin = (String) params.get("artifactId");
             if (plugin != null) {
+                // did any plugin fail to start?
+                for (FailedPlugin fp : Jenkins.getInstance().getPluginManager().getFailedPlugins()) {
+                    throw new Error("Plugin "+fp.name+" failed to start", fp.cause);
+                }
+
                 PluginWrapper pw = Jenkins.getInstance().getPluginManager().getPlugin(plugin);
-                assertNotNull(pw);
+                assertNotNull(plugin+" failed to start", pw);
                 assertTrue(plugin + " was not active", pw.isActive());
             }
         }


### PR DESCRIPTION
In particular, I had a situation where a plugin under test failed to start, which isn't obvious to diagnose in this case

@reviewbybees 