### PR TITLE
Listen to connections on localhost only

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -607,6 +607,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
         SocketConnector connector = new SocketConnector();
         connector.setHeaderBufferSize(12*1024); // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
+        connector.setHost("localhost");
         if (System.getProperty("port")!=null)
             connector.setPort(Integer.parseInt(System.getProperty("port")));
 


### PR DESCRIPTION
Otherwise the tested Jenkins instance could be accessed from other hosts doing port scanning.

@reviewbybees