### PR TITLE
Jetty 9.2 upgrade follow-up fix

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -547,9 +547,9 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     protected LoginService configureUserRealm() {
         HashLoginService realm = new HashLoginService();
         realm.setName("default");   // this is the magic realm name to make it effective on everywhere
-        realm.update("alice", new Password("alice"), new String[]{"female"});
-        realm.update("bob", new Password("bob"), new String[]{"male"});
-        realm.update("charlie", new Password("charlie"), new String[]{"male"});
+        realm.update("alice", new Password("alice"), new String[]{"user","female"});
+        realm.update("bob", new Password("bob"), new String[]{"user","male"});
+        realm.update("charlie", new Password("charlie"), new String[]{"user","male"});
 
         return realm;
     }

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -649,9 +649,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     protected LoginService configureUserRealm() {
         HashLoginService realm = new HashLoginService();
         realm.setName("default");   // this is the magic realm name to make it effective on everywhere
-        realm.update("alice", new Password("alice"), new String[]{"female"});
-        realm.update("bob", new Password("bob"), new String[]{"male"});
-        realm.update("charlie", new Password("charlie"), new String[]{"male"});
+        realm.update("alice", new Password("alice"), new String[]{"user","female"});
+        realm.update("bob", new Password("bob"), new String[]{"user","male"});
+        realm.update("charlie", new Password("charlie"), new String[]{"user","male"});
 
         return realm;
     }


### PR DESCRIPTION
After running this new version of test harness with Jenkins core, I
discovered one issue around the authentication managed by servlet
container.

When Jenkins is configured to delegate authentication to servlet
container, Jetty 8.x used to allow any user, regardless of the roles
they have in Jetty, to qualify. This was because web.xml has the
following and Jetty interpreted '*' to "any role regardless of whether
the role is defined in this web.xml or not"
```
    <security-constraint>
        <web-resource-collection>
            <web-resource-name>Hudson</web-resource-name>
            <url-pattern>/loginEntry</url-pattern>
            <!--http-method>GET</http-method-->
        </web-resource-collection>
        <auth-constraint>
            <role-name>*</role-name>
        </auth-constraint>
    </security-constraint>
```
Apparently this was one of the ambiguity in the servlet spec, and as of
servlet 3.1, the spec has locked this down and resolved against what
Jetty used to do. Now role-name="*" means "any role defined in web.xml",
and defined role-name="**" to mean "any role".

The net result is that, with the user realm setup here, none of the
users can log on to Jenkins. So I'm adding back "user" role so that
these users pass role-name="*" check.

Jenkins 2 will use the new role-name="**" but that is not available in
servlet 2.5 that Jenkins 1.x uses.