### PR TITLE
[JENKINS-30395] Apply workaround also to HudsonTestCase

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -292,6 +292,10 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
     @Override
     protected void  setUp() throws Exception {
+        if (Thread.interrupted()) { // JENKINS-30395
+            LOGGER.warning("was interrupted before start");
+        }
+
         if(Functions.isWindows()) {
             // JENKINS-4409.
             // URLConnection caches handles to jar files by default,


### PR DESCRIPTION
Extends https://github.com/jenkinsci/jenkins/pull/1967 to work even on `HudsonTestCase`, which is necessary for `InjectedTest` as [here](https://jenkins.ci.cloudbees.com/job/plugins/job/workflow-plugin/org.jenkins-ci.plugins.workflow$workflow-aggregator/2306/testReport/junit/org.jvnet.hudson.test.junit/FailedTest/org_jvnet_hudson_test_JellyTestSuiteBuilder$JellyTestSuite/):

```
java.nio.channels.ClosedByInterruptException: null
	at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202)
	at sun.nio.ch.FileChannelImpl.size(FileChannelImpl.java:315)
	at org.apache.commons.io.FileUtils.doCopyFile(FileUtils.java:1142)
	at org.apache.commons.io.FileUtils.copyFile(FileUtils.java:1091)
	at org.apache.commons.io.FileUtils.copyFile(FileUtils.java:1038)
	at org.jvnet.hudson.test.HudsonTestCase$7.decorateHome(HudsonTestCase.java:1347)
	at org.jvnet.hudson.test.HudsonTestCase.newHudson(HudsonTestCase.java:486)
	at org.jvnet.hudson.test.HudsonTestCase.setUp(HudsonTestCase.java:318)
	at org.jvnet.hudson.test.JellyTestSuiteBuilder$JellyTestSuite.setUp(JellyTestSuiteBuilder.java:143)
	at org.jvnet.hudson.test.junit.GroupedTest.run(GroupedTest.java:49)
	at …
```

@reviewbybees