### PR TITLE
Make dependency declaration less error prone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@ THE SOFTWARE.
           <artifactId>sshd</artifactId>
         </exclusion>
       </exclusions>
+      <!--
+        To ensure consistent set of core artifacts are used, force the users to declare
+        a dependency to war-for-test
+      -->
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
If a plugin explicitly declares a dependency on core, war, or some combination of it, but without declaring a dependency to war-for-test, unit tests end up running with one version of the core jar file and another version of the war file. This results in a strange error that's hard to diagnose.

It's very unlikely that plugins using test harness just so happens to be based on 1.580.1, so it's better not to let this module brings in war-for-test, and instead let the caller declare it explicitly, like the plugin parent POM is doing.