### PR TITLE
JenkinsRule.getLog should return an empty string if the log file has not yet even been written

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1189,6 +1189,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * and also does not strip console annotations which are a distraction in test output.
      */
     public static String getLog(Run run) throws IOException {
+        if (!run.getLogFile().exists()) {
+            return "";
+        }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         run.getLogText().writeLogTo(0, baos);
         return baos.toString(run.getCharset().name());


### PR DESCRIPTION
Fixes a regression from #20 observed to affect `ExecutorStepTest.queueTaskVisibility`, which calls `waitForMessage` immediately after `QueueTaskFuture.waitForStart` and thus has a race condition.

@reviewbybees