### PR TITLE
Fix wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Jenkins Unit Test Harness
 Defines test harness for Jenkins core and plugins that you can use during the `mvn test` phase.
-See [wiki page](wiki.jenkins-ci.org/display/JENKINS/Unit+Test)
+See [wiki page](//wiki.jenkins-ci.org/display/JENKINS/Unit+Test)


### PR DESCRIPTION
Make it a protocol-less absolute link instead of a relative link, which didn't work.