### PR TITLE
Add a WithOS annotation.

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/junit/RuleAnnotation.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/RuleAnnotation.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jvnet.hudson.test.junit;
+
+import org.junit.rules.TestRule;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Meta-annotation for annotations that introduces a {@link TestRule} for test.
+ *
+ * <p>
+ * This allows annotations on test class/method to add additional setup/shutdown behaviours.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+@Retention(RUNTIME)
+@Target(ANNOTATION_TYPE)
+@Documented
+public @interface RuleAnnotation {
+    /**
+     * The rule class that defines the setup/shutdown behaviour.
+     *
+     * The instance is obtained through Guice.
+     */
+    Class<? extends TestRule> value();
+
+    /**
+     * Optional ordering among rules.
+     *
+     * Annotation with <tt>priority >= 0</tt> are guaranteed to be run after
+     * Jenkins is up. Negative priorities are run before startup on best effort
+     * basis. (It might not happen before for ExistingJenkinsController,
+     * PooledJenkinsController and possibly others).
+     *
+     * Annotations that skips execution are encouraged to run before Jenkins is
+     * booted up to save time. Note, that these implementations can not inject
+     * Jenkins for obvious reasons.
+     */
+    int priority() default 0;
+}

--- a/src/main/java/org/jvnet/hudson/test/junit/WithOS.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/WithOS.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jvnet.hudson.test.junit;
+
+import org.apache.commons.lang.SystemUtils;
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ *
+ * Indicates that the test must be running on one of the operating systems
+ * provided. If this condition is not met, this test will be skipped.
+ * 
+ **/
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+@Inherited
+@Documented
+@RuleAnnotation(value = WithOS.RuleImpl.class, priority = -10)
+public @interface WithOS {
+
+    public enum OS {
+        WINDOWS,
+        LINUX,
+        MAC
+    }
+
+    OS[] os();
+
+    public class RuleImpl implements TestRule {
+        @Override
+        public Statement apply(final Statement base, final Description d) {
+            return new Statement() {
+
+                @Override
+                public void evaluate() throws Throwable {
+                    Class<?> testSuite = d.getTestClass();
+                    check(d.getAnnotation(WithOS.class), testSuite);
+                    check(testSuite.getAnnotation(WithOS.class), testSuite);
+
+                    base.evaluate();
+                }
+
+                private void check(WithOS withos, Class<?> testCase) {
+                    if (withos == null) return;
+
+                    String errorMsg = "Test must be running on any of the following operating systems: " + Arrays.toString(withos.os());
+                    for (OS _os : withos.os()) {
+                        switch (_os) {
+                            case LINUX:
+                                if (!SystemUtils.IS_OS_LINUX) {
+                                    throw new AssumptionViolatedException(errorMsg);
+                                }
+                                break;
+                            case WINDOWS:
+                                if (!SystemUtils.IS_OS_WINDOWS) {
+                                    throw new AssumptionViolatedException(errorMsg);
+                                }
+                                break;
+                            case MAC:
+                                if (!SystemUtils.IS_OS_MAC) {
+                                    throw new AssumptionViolatedException(errorMsg);
+                                }
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
This is basically a copy of WithOS from the ATH (along with the
RuleAnnotation class it needs) - I've hit cases where I'd like unit
tests to be able to run on some OSes but be skipped on others without
the tests actually failing. The immediate example of this is trying to
build plugins that have unit tests using Docker Pipeline while on OS
X, because ow, lots of problems (like
https://issues.jenkins-ci.org/browse/JENKINS-36802). Fun!

cc @reviewbybees