### PR TITLE
use a subdirectory of the temp directory by default.

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
@@ -50,7 +50,8 @@ public class TemporaryDirectoryAllocator {
     }
 
     public TemporaryDirectoryAllocator() {
-        this(new File(System.getProperty("java.io.tmpdir")));
+        this.base = new File(System.getProperty("java.io.tmpdir"), "jenkinsTests.tmp");
+        base.mkdirs();
     }
 
     /**
@@ -61,7 +62,7 @@ public class TemporaryDirectoryAllocator {
      */
     public synchronized File allocate() throws IOException {
         try {
-            File f = File.createTempFile("hudson", "test", base);
+            File f = File.createTempFile("jenkins", "test", base);
             f.delete();
             f.mkdirs();
             tmpDirectories.add(f);


### PR DESCRIPTION
1) we are Jenkins :-)
2) put all the files in a directory inside temp rather than directly in
temp.

The problem with using the temporary directory directly is that you can not add
exclusions with wildcards in many anti virus products.  By using a
subdirectory you can add an exclusion to your PATH_TO_TEMP\jenkinsTests.tmp
which will then allow you to exclude jenkinsTests.tmp but still allowing
scanning of your temporary directory (which is desired).

The downside of this is that you will always have a jenkinsTests.tmp directory inside your temp directory - but well the cleanup does not work correctly anyway - so this is nothing new (on windows) - and rather than hundreds of directories you have one directory - which is easier to clean...

@reviewbybees