### PR TITLE
[JENKINS-38297] Support DataBoundSetter fields

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1545,6 +1545,15 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     private Map<String, Class<?>> extractDataBoundSetterProperties(@Nonnull Class<?> c) {
         Map<String, Class<?>> ret = new HashMap<String, Class<?>>();
         for ( ;c != null; c = c.getSuperclass()) {
+
+            for (Field f: c.getDeclaredFields()) {
+                if (f.getAnnotation(DataBoundSetter.class) == null) {
+                    continue;
+                }
+                f.setAccessible(true);
+                ret.put(f.getName(), f.getType());
+           }
+
             for (Method m: c.getDeclaredMethods()) {
                 AbstractMap.SimpleEntry<String, Class<?>> nameAndType = extractDataBoundSetter(m);
                 if (nameAndType == null) {

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -39,8 +39,10 @@ public class JenkinsRuleTest {
     public void assertEqualDataBoundBeansWithSetters() throws Exception {
         SomeClassWithSetters l = new SomeClassWithSetters("value1");
         l.setSetterParam("value2");
+        l.setterField = "value3";
         SomeClassWithSetters r = new SomeClassWithSetters("value1");
         r.setSetterParam("value2");
+        r.setterField = "value3";
         j.assertEqualDataBoundBeans(l, r);
     }
 
@@ -48,14 +50,29 @@ public class JenkinsRuleTest {
     public void assertEqualDataBoundBeansWithSettersFail() throws Exception {
         SomeClassWithSetters l = new SomeClassWithSetters("value1");
         l.setSetterParam("value2");
+        l.setterField = "value4";
         SomeClassWithSetters r = new SomeClassWithSetters("value1");
         r.setSetterParam("value3");     // mismatch!
+        r.setterField = "value4";
+        j.assertEqualDataBoundBeans(l, r);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void assertEqualDataBoundBeansWithSettersFailForField() throws Exception {
+        SomeClassWithSetters l = new SomeClassWithSetters("value1");
+        l.setSetterParam("value2");
+        l.setterField = "value3";
+        SomeClassWithSetters r = new SomeClassWithSetters("value1");
+        r.setSetterParam("value2");     // mismatch!
+        l.setterField = "value4";
         j.assertEqualDataBoundBeans(l, r);
     }
 
     public static class SomeClassWithSetters {
         private String ctorParam;
         private String setterParam;
+        @DataBoundSetter
+        public String setterField;
 
         @DataBoundConstructor
         public SomeClassWithSetters(String ctorParam) {


### PR DESCRIPTION
[JENKINS-38297](https://issues.jenkins-ci.org/browse/JENKINS-38297)

Make `assertEqualsDataBoundBeans` also assert fields annotated with `DataBoundSetter`.

`DataBoundSetter` for fields is introduced since stapler-1.220, stapler/stapler@425314ba247ab90791ca3ba0507ab5b8e25d2a2d
