### PR TITLE
[JENKINS-38306] Add a parameter to LocalData to use instead of method name

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/recipes/LocalData.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/LocalData.java
@@ -63,6 +63,11 @@ import static java.lang.annotation.ElementType.METHOD;
  * In <tt>org/acme/FooTest.zip</tt> as a zip file.
  * </ol>
  *
+ * You can specify a value to use instead of the method name
+ * with the parameter of annotation. Should be a valid java identifier.
+ * E.g. <tt>@LocalData("commonData")</tt> results using
+ * <tt>org/acme/FooTest/commonData(.zip)</tt>.
+ *
  * <p>
  * Search is performed in this specific order. The fall back mechanism allows you to write
  * one test class that interacts with different aspects of the same data set, by associating
@@ -79,15 +84,17 @@ import static java.lang.annotation.ElementType.METHOD;
 @Target(METHOD)
 @Retention(RUNTIME)
 public @interface LocalData {
+    String value() default "";
+
     class RunnerImpl extends Recipe.Runner<LocalData> {
         public void setup(HudsonTestCase testCase, LocalData recipe) throws Exception {
-            testCase.with(new Local(testCase.getClass().getMethod(testCase.getName())));
+            testCase.with(new Local(testCase.getClass().getMethod(testCase.getName()), recipe.value()));
         }
     }
     class RuleRunnerImpl extends JenkinsRecipe.Runner<LocalData> {
         public void setup(JenkinsRule jenkinsRule, LocalData recipe) throws Exception {
             Description desc = jenkinsRule.getTestDescription();
-            jenkinsRule.with(new Local(desc.getTestClass().getMethod(desc.getMethodName())));
+            jenkinsRule.with(new Local(desc.getTestClass().getMethod(desc.getMethodName()), recipe.value()));
         }
     }
 }

--- a/src/test/java/org/jvnet/hudson/test/recipes/LocalDataTest.java
+++ b/src/test/java/org/jvnet/hudson/test/recipes/LocalDataTest.java
@@ -43,4 +43,16 @@ public class LocalDataTest {
         assertNotNull(r.jenkins.getItem("somejob"));
     }
 
+    @LocalData
+    @Test
+    public void methodData() throws Exception {
+        assertEquals("This is Jenkins in LocalDataTest#methodData", r.jenkins.getSystemMessage());
+    }
+
+    @LocalData("methodData")
+    @Test
+    public void otherData() throws Exception {
+        assertEquals("This is Jenkins in LocalDataTest#methodData", r.jenkins.getSystemMessage());
+    }
+
 }

--- a/src/test/resources/org/jvnet/hudson/test/recipes/LocalDataTest/methodData/config.xml
+++ b/src/test/resources/org/jvnet/hudson/test/recipes/LocalDataTest/methodData/config.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <version>1.580.1</version>
+  <systemMessage>This is Jenkins in LocalDataTest#methodData</systemMessage>
+</hudson>


### PR DESCRIPTION
[JENKINS-38306](https://issues.jenkins-ci.org/browse/JENKINS-38306)

It's often the case that I want to use a same local data in multiple test cases,
but not in all test cases in the test.
(e.g. some tests want to use other local data)

This change allows to specify the name of the directory to use
instead of method name
```
public class Test {
    @Rule public JenkinsRule j = new JenkinsRule();

    @Test
    @LocalData("config1")
    public void config1_test1() throws Exception {...}

    @Test
    @LocalData("config1")
    public void config1_test2() throws Exception {...}

    @Test
    @LocalData("config2")
    public void config2_test1() throws Exception {...}

    @Test
    @LocalData("config2")
    public void config2_test2() throws Exception {...}
}
```
