### PR TITLE
Add way to record and mock http apis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,11 @@ THE SOFTWARE.
       <artifactId>wiremock</artifactId>
       <version>2.1.12</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@ THE SOFTWARE.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.2.15.v20160210</jetty.version>
+    <recordMocks>false</recordMocks>
   </properties>
 
   <licenses>
@@ -167,6 +168,17 @@ THE SOFTWARE.
       <version>1.0.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>2.1.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -189,6 +201,7 @@ THE SOFTWARE.
               <hudson.maven.debug>${mavenDebug}</hudson.maven.debug>
               <buildDirectory>${project.build.directory}</buildDirectory>
               <ignore.random.failures>${ignore.random.failures}</ignore.random.failures>
+              <toRecord>${recordMocks}</toRecord>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -172,12 +172,6 @@ THE SOFTWARE.
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
       <version>2.1.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>19.0</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@ THE SOFTWARE.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.2.15.v20160210</jetty.version>
-    <recordMocks>false</recordMocks>
+    <wiremock.record/>
   </properties>
 
   <licenses>
@@ -195,7 +195,7 @@ THE SOFTWARE.
               <hudson.maven.debug>${mavenDebug}</hudson.maven.debug>
               <buildDirectory>${project.build.directory}</buildDirectory>
               <ignore.random.failures>${ignore.random.failures}</ignore.random.failures>
-              <toRecord>${recordMocks}</toRecord>
+              <wiremock.record>${wiremock.record}</wiremock.record>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -170,13 +170,8 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
-      <version>2.1.12</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>2.4.1</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/jvnet/hudson/WireMockRuleFactory.java
+++ b/src/main/java/org/jvnet/hudson/WireMockRuleFactory.java
@@ -1,0 +1,60 @@
+package org.jvnet.hudson.test;
+
+import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+/**
+ * Provides a way to record and mock REST calls.  The underlying structure is 
+ * <a href="http://wiremock.org/">WireMock</a>.  To use: 
+ * <pre>
+ * {@code
+ * WireMockRuleFactory wmrf = new WireMockRuleFactory(api_to_mock);
+ * @Rule
+ * WireMockRule = wmrf.getRule(8089); //port is configurable  
+ * }
+ * </pre>
+ *
+ * Point your system to "http://localhost:8089/" to see mocked responses.
+ *
+ * To record mocks: {@code mvn clean test -DrecordMocks=true}  Clearing 
+ * previously recorded mocks before generating new ones is recommended. 
+ */
+public class WireMockRuleFactory {
+    private String prop = System.getProperty("toRecord");
+    private String urlToMock;
+
+    /**
+     * @param url  The source to mock through this particular WireMock instance
+     */
+    public WireMockRuleFactory(String url){
+        urlToMock = url;
+    } 
+
+    public WireMockRule getRule(int port){
+        return getRule(wireMockConfig().port(port));
+    }
+
+    public WireMockRule getRule(Options options) {
+        if(prop.equalsIgnoreCase("true")) {
+            return new WireMockRecorderRule(options, urlToMock);
+        } else {
+            return new WireMockRule(options);
+        }
+    }
+
+
+    private class WireMockRecorderRule extends WireMockRule {
+        //needed for WireMockRule file location
+        private String mappingLocation = "src/test/resources";
+
+        public WireMockRecorderRule(Options options, String url){
+            super(options);
+            this.stubFor(get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom(url)));
+            this.enableRecordMappings(new SingleRootFileSource(mappingLocation + "/mappings"), new SingleRootFileSource(mappingLocation + "/__files"));
+        }
+    }
+}

--- a/src/main/java/org/jvnet/hudson/test/WireMockRuleFactory.java
+++ b/src/main/java/org/jvnet/hudson/test/WireMockRuleFactory.java
@@ -1,15 +1,14 @@
 package org.jvnet.hudson.test;
 
 import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
-import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 /**
- * Provides a way to record and mock REST calls.  The underlying structure is 
- * <a href="http://wiremock.org/">WireMock</a>.  To use: 
+ * Provides a way to record and mock REST calls. The underlying structure is 
+ * <a href="http://wiremock.org/">WireMock</a>. To use: 
  * <pre>
  * {@code
  * WireMockRuleFactory wmrf = new WireMockRuleFactory();
@@ -20,17 +19,27 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
  *
  * Point your system to "http://localhost:8089/" to see mocked responses.
  *
- * To record mocks: {@code mvn test -Dwiremock.record="http://api_url"}  Clearing 
+ * To record mocks: {@code mvn test -Dwiremock.record="http://api_url"} Clearing 
  * previously recorded mocks before generating new ones is recommended. 
+ *
+ * The mocks are defaultly written to `src/test/resources`. Use the 2nd 
+ * constructor option to set an alternative location:
+ * <pre>
+ * {@code
+ * WireMockRuleFactory wmrf = new WireMockRuleFactory();
+ * @Rule
+ * WireMockRule wireMockRule = wmrf.getRule("src/test/resources/mockLoc")
+ * }
+ * </pre>
  */
 public class WireMockRuleFactory {
     private String urlToMock = System.getProperty("wiremock.record");
 
     public WireMockRule getRule(int port) {
-        return getRule(wireMockConfig().port(port));
+        return getRule(WireMockConfiguration.wireMockConfig().port(port));
     }
 
-    public WireMockRule getRule(Options options) {
+    public WireMockRule getRule(WireMockConfiguration options) {
         if(urlToMock != null && !urlToMock.isEmpty()) {
             return new WireMockRecorderRule(options, urlToMock);
         } else {
@@ -38,13 +47,34 @@ public class WireMockRuleFactory {
         }
     }
 
+    public WireMockRule getRule(String mapLoc) {
+        return getRule(mapLoc, WireMockConfiguration.wireMockConfig());
+    }
+
+    public WireMockRule getRule(String mapLoc, WireMockConfiguration options) {
+        if(urlToMock != null && !urlToMock.isEmpty()) {
+            return new WireMockRecorderRule(options, urlToMock, mapLoc);
+        } else {
+            return new WireMockRule(options
+               .usingFilesUnderClasspath(mapLoc));
+        }
+    }
+
 
     private class WireMockRecorderRule extends WireMockRule {
-        //needed for WireMockRule file location
         private String mappingLocation = "src/test/resources";
 
-        public WireMockRecorderRule(Options options, String url) {
+        public WireMockRecorderRule(WireMockConfiguration options, String url) {
             super(options);
+            finshWireMockRuleSetup(options, url, this.mappingLocation);
+        }
+
+        public WireMockRecorderRule(WireMockConfiguration options, String url, String mappingLocation) {
+            super(options);
+            finshWireMockRuleSetup(options, url, mappingLocation);
+        }
+
+        private void finshWireMockRuleSetup(WireMockConfiguration options, String url, String mappingLocation) {
             this.stubFor(get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom(url)));
             this.enableRecordMappings(new SingleRootFileSource(mappingLocation + "/mappings"), new SingleRootFileSource(mappingLocation + "/__files"));
         }

--- a/src/main/java/org/jvnet/hudson/test/WireMockRuleFactory.java
+++ b/src/main/java/org/jvnet/hudson/test/WireMockRuleFactory.java
@@ -12,7 +12,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
  * <a href="http://wiremock.org/">WireMock</a>.  To use: 
  * <pre>
  * {@code
- * WireMockRuleFactory wmrf = new WireMockRuleFactory(api_to_mock);
+ * WireMockRuleFactory wmrf = new WireMockRuleFactory();
  * @Rule
  * WireMockRule = wmrf.getRule(8089); //port is configurable  
  * }
@@ -20,26 +20,18 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
  *
  * Point your system to "http://localhost:8089/" to see mocked responses.
  *
- * To record mocks: {@code mvn clean test -DrecordMocks=true}  Clearing 
+ * To record mocks: {@code mvn test -wiremock.record="http://api_url"}  Clearing 
  * previously recorded mocks before generating new ones is recommended. 
  */
 public class WireMockRuleFactory {
-    private String prop = System.getProperty("toRecord");
-    private String urlToMock;
-
-    /**
-     * @param url  The source to mock through this particular WireMock instance
-     */
-    public WireMockRuleFactory(String url){
-        urlToMock = url;
-    } 
+    private String urlToMock = System.getProperty("wiremock.record");
 
     public WireMockRule getRule(int port){
         return getRule(wireMockConfig().port(port));
     }
 
     public WireMockRule getRule(Options options) {
-        if(prop.equalsIgnoreCase("true")) {
+        if(urlToMock != null && !urlToMock.isEmpty()) {
             return new WireMockRecorderRule(options, urlToMock);
         } else {
             return new WireMockRule(options);

--- a/src/main/java/org/jvnet/hudson/test/WireMockRuleFactory.java
+++ b/src/main/java/org/jvnet/hudson/test/WireMockRuleFactory.java
@@ -14,13 +14,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
  * {@code
  * WireMockRuleFactory wmrf = new WireMockRuleFactory();
  * @Rule
- * WireMockRule = wmrf.getRule(8089); //port is configurable  
+ * WireMockRule wireMockRule = wmrf.getRule(8089); //port is configurable  
  * }
  * </pre>
  *
  * Point your system to "http://localhost:8089/" to see mocked responses.
  *
- * To record mocks: {@code mvn test -wiremock.record="http://api_url"}  Clearing 
+ * To record mocks: {@code mvn test -Dwiremock.record="http://api_url"}  Clearing 
  * previously recorded mocks before generating new ones is recommended. 
  */
 public class WireMockRuleFactory {

--- a/src/main/java/org/jvnet/hudson/test/WireMockRuleFactory.java
+++ b/src/main/java/org/jvnet/hudson/test/WireMockRuleFactory.java
@@ -26,7 +26,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 public class WireMockRuleFactory {
     private String urlToMock = System.getProperty("wiremock.record");
 
-    public WireMockRule getRule(int port){
+    public WireMockRule getRule(int port) {
         return getRule(wireMockConfig().port(port));
     }
 
@@ -43,7 +43,7 @@ public class WireMockRuleFactory {
         //needed for WireMockRule file location
         private String mappingLocation = "src/test/resources";
 
-        public WireMockRecorderRule(Options options, String url){
+        public WireMockRecorderRule(Options options, String url) {
             super(options);
             this.stubFor(get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom(url)));
             this.enableRecordMappings(new SingleRootFileSource(mappingLocation + "/mappings"), new SingleRootFileSource(mappingLocation + "/__files"));

--- a/src/main/java/org/jvnet/hudson/test/WireMockRuleFactory.java
+++ b/src/main/java/org/jvnet/hudson/test/WireMockRuleFactory.java
@@ -66,15 +66,15 @@ public class WireMockRuleFactory {
 
         public WireMockRecorderRule(WireMockConfiguration options, String url) {
             super(options);
-            finshWireMockRuleSetup(options, url, this.mappingLocation);
+            finishWireMockRuleSetup(options, url, this.mappingLocation);
         }
 
         public WireMockRecorderRule(WireMockConfiguration options, String url, String mappingLocation) {
             super(options);
-            finshWireMockRuleSetup(options, url, mappingLocation);
+            finishWireMockRuleSetup(options, url, mappingLocation);
         }
 
-        private void finshWireMockRuleSetup(WireMockConfiguration options, String url, String mappingLocation) {
+        private void finishWireMockRuleSetup(WireMockConfiguration options, String url, String mappingLocation) {
             this.stubFor(get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom(url)));
             this.enableRecordMappings(new SingleRootFileSource(mappingLocation + "/mappings"), new SingleRootFileSource(mappingLocation + "/__files"));
         }


### PR DESCRIPTION
Added support for recording & mocking http responses with Wiremock.  This particular rule allows a test to serve up prerendered files which correspond to particular api responses.  If a response is not saved (trying to access an unmocked url), the test will fail.  You can enable a "recording" mode in which you can run your test through on a live server and save the responses for later offline testing.  The recordings are saved to `/src/test/resources/` of whatever project uses this rule.

While the particular constructors I've included are the ones that have been the most useful to me, they too can be expanded.  Other options for the server can be found on [wiremock.org](http://wiremock.org)

@reviewbybees 
