### PR TITLE
Better report `java.lang.IllegalArgumentException: URI is not hierarchical`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TestPluginManager.java
+++ b/src/main/java/org/jvnet/hudson/test/TestPluginManager.java
@@ -114,7 +114,12 @@ public class TestPluginManager extends PluginManager {
                 String line;
                 while ((line=r.readLine())!=null) {
                 	final URL url = new URL(index, line + ".jpi");
-					File f = new File(url.toURI());
+					File f;
+                    try {
+                        f = new File(url.toURI());
+                    } catch (IllegalArgumentException x) {
+                        throw new IOException(index + " contains bogus line " + line, x);
+                    }
                 	if(f.exists()){
                 		copyBundledPlugin(url, line + ".jpi");
                 	}else{


### PR DESCRIPTION
@abayer encountered this in IntelliJ. I have in the past in NetBeans, though I am not sure how to reproduce it offhand. IIRC it happens when you have a snapshot test dependency which you have not properly built (`mvn -DskipTests install`)—though I cannot reproduce that at the moment.

@reviewbybees