### PR TITLE
Avoid any fixed timeout on waitUntilNoActivity

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1632,11 +1632,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
     /**
      * Waits until Hudson finishes building everything, including those in the queue.
-     * <p>
-     * This method uses a default time out to prevent infinite hang in the automated test execution environment.
      */
     public void waitUntilNoActivity() throws Exception {
-        waitUntilNoActivityUpTo(60*1000);
+        waitUntilNoActivityUpTo(Integer.MAX_VALUE);
     }
 
     /**


### PR DESCRIPTION
`JenkinsRule` already imposes a 3m default test timeout unless are running in a debugger, so this timeout is superfluous. It is very annoying to be stepping through something in a debugger only to have the test abruply fail 1m after `waitUntilNoActivity` was called, right before you found the bug!

@reviewbybees