### PR TITLE
If TemporaryDirectoryAllocator() fails, try again

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
@@ -50,8 +50,15 @@ public class TemporaryDirectoryAllocator {
     }
 
     public TemporaryDirectoryAllocator() {
-        this.base = new File(System.getProperty("java.io.tmpdir"), "jenkinsTests.tmp");
-        base.mkdirs();
+        File tempDir = new File(System.getProperty("java.io.tmpdir"), "jenkinsTests.tmp");
+        if (tempDir.mkdirs() == false) {
+            try {
+                File tempDir2 = java.nio.file.Files.createTempDirectory("jenkinsTests").toFile();
+                tempDir = tempDir2;
+            } catch (IOException ioe) {
+            }
+        }
+        this.base = tempDir;
     }
 
     /**


### PR DESCRIPTION
Multi-user system with a shared temporary directory (like many Linux
computers) may have several users running Jenkins unit tests.  The first
user to create /tmp/jenkinsTests.tmp owns it, and other users then are
unable to run their tests.

This change attempts to retain previous behaviors as much as possible.
If directory creation fails on the first attempt (jenkinsTest.tmp) and
then fails on the second attempt (Files.createTemporaryDirectory), the
base directory assignment will still be jenkinsTest.tmp as it was before.