### PR TITLE
[JENKINS-41196] added alternate bootstrap logic

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -525,7 +525,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         context.setResourceBase(explodedWarDir.getPath());
         context.setClassLoader(getClass().getClassLoader());
         context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
-        context.addBean(new NoListenerConfiguration(context));
+        context.addBean(new AltWebXmlConfiguration(context));
         server.setHandler(context);
         context.setMimeTypes(MIME_TYPES);
         context.getSecurityHandler().setLoginService(configureUserRealm());

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -632,7 +632,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         WebAppContext context = new WebAppContext(WarExploder.getExplodedDir().getPath(), contextPath);
         context.setClassLoader(getClass().getClassLoader());
         context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
-        context.addBean(new NoListenerConfiguration(context));
+        context.addBean(new AltWebXmlConfiguration(context));
         server.setHandler(context);
         context.setMimeTypes(MIME_TYPES);
         context.getSecurityHandler().setLoginService(configureUserRealm());


### PR DESCRIPTION
With more servlets and filters initialized from within WebAppMain, test
harness needs to adjust as well.

This change is a pre-requisite of https://github.com/jenkinsci/jenkins/pull/2754