### PR TITLE
Pick up jetty-io and jetty-util from our specified version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,16 @@ THE SOFTWARE.
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness-htmlunit</artifactId>
       <version>2.18-1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson</groupId>


### PR DESCRIPTION
Currently `9.2.15.v20160210`. Not whatever gets pulled in via jenkins-test-harness-htmlunit, currently `9.2.12.v20150709`. (Does not stop `websocker-{api,client,common}` from being used as of the older version, but probably no one is using these anyway.)

@reviewbybees