### PR TITLE
[FIXED JENKINS-44453] - JenkinsRule should ensure that Jenkins reaches the COMPLETED milestone.

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -374,7 +374,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             // So we just fail the test.
             if (jenkins.getInitLevel() != InitMilestone.COMPLETED) {
                 throw new Exception("Jenkins initialization has not reached the COMPLETED initialization stage. Current state is " + jenkins.getInitLevel() +
-                        ". Likely there is and issue with the Initialization task graph (e.g. usage of @Initializer(after = InitMilestone.COMPLETED)). See JENKINS-37759 for more info");
+                        ". Likely there is an issue with the Initialization task graph (e.g. usage of @Initializer(after = InitMilestone.COMPLETED)). See JENKINS-37759 for more info");
             }
         } catch (Exception e) {
             // if Hudson instance fails to initialize, it leaves the instance field non-empty and break all the rest of the tests, so clean that up.


### PR DESCRIPTION
It should make issues like https://issues.jenkins-ci.org/browse/JENKINS-37759 much more explicit in functional tests. From what I see there is no valid use-case for proceeding with the test if the initialization fails.

https://issues.jenkins-ci.org/browse/JENKINS-44453

@reviewbybees 