### PR TITLE
[JENKINS-24064] Replace war-for-test classifier with executable-war type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>2.0-20170524.211828-1</version> <!-- TODO https://github.com/jenkinsci/maven-hpi-plugin/pull/65 -->
+        <version>2.0</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
       <version>1.580.1</version>
-      <classifier>war-for-test</classifier>
+      <type>executable-war</type>
       <exclusions>
         <exclusion>
           <groupId>org.jenkins-ci.modules</groupId>
@@ -181,6 +181,12 @@ THE SOFTWARE.
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <version>2.0-20170524.211828-1</version> <!-- TODO https://github.com/jenkinsci/maven-hpi-plugin/pull/65 -->
+        <extensions>true</extensions>
+      </plugin>
       <plugin>
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>maven-stapler-plugin</artifactId>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/maven-hpi-plugin/pull/65. Supersedes #43.

@reviewbybees