### PR TITLE
[JENKINS-41631] Deleting the Maven Embedder dependency from the test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,10 +73,6 @@ THE SOFTWARE.
 
   <dependencies>
     <dependency>
-      <!--
-        put hudson.war in the classpath. we can't pull in the war artifact directly
-        because Maven excludes all wars from classpath automatically. so we need a jar artifact.
-      -->
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
       <version>1.580.1</version>
@@ -89,7 +85,7 @@ THE SOFTWARE.
       </exclusions>
       <!--
         To ensure consistent set of core artifacts are used, force the users to declare
-        a dependency to war-for-test
+        a dependency to war
       -->
       <optional>true</optional>
     </dependency>
@@ -148,22 +144,6 @@ THE SOFTWARE.
       <groupId>com.github.stephenc.findbugs</groupId>
       <artifactId>findbugs-annotations</artifactId>
       <version>1.3.9-1</version>
-    </dependency>
-    <dependency> <!-- TODO can we switch this to use Aether directly? -->
-      <groupId>org.jenkins-ci.lib</groupId>
-      <artifactId>lib-jenkins-maven-embedder</artifactId>
-      <version>3.11</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-guice</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency> <!-- lib-jenkins-maven-embedder uses sisuInjectVersion=0.0.0.M2a which has uses ASM 3.0 which clashes with 4.0 on ClassVisitor -->
-      <groupId>org.eclipse.sisu</groupId>
-      <artifactId>org.eclipse.sisu.plexus</artifactId>
-      <version>0.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
Critical for [JENKINS-41631](https://issues.jenkins-ci.org/browse/JENKINS-41631) since some of the harder problems relate to random libraries pulled in via the `lib-jenkins-maven-embedder` dependency.

Taking a closer look at the harness code using this library, I could not find any realistic cases where it would actually be used. We already look up test dependencies from the classpath. Furthermore, the group IDs covered are old Hudson names no longer used by Jenkins.

@reviewbybees