### PR TITLE
Use a fixed number of selectors and acceptors regardless of CPU count

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -659,7 +659,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         context.getSecurityHandler().setLoginService(configureUserRealm());
         context.setResourceBase(WarExploder.getExplodedDir().getPath());
 
-        ServerConnector connector = new ServerConnector(server);
+        ServerConnector connector = new ServerConnector(server, 1, 1);
         HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
         config.setRequestHeaderSize(12 * 1024);


### PR DESCRIPTION
Without this you can see symptoms of [JENKINS-43666](https://issues.jenkins-ci.org/browse/JENKINS-43666) in certain build environments; observed test failures in a VM claiming (falsely) to have 16 cores (cf. https://github.com/jenkinsci/jenkins/pull/3019#discussion_r138538546). Necessary after #63.

@reviewbybees