### PR TITLE
More readable timestamps in log messages during tests

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/BuildWatcher.java
+++ b/src/main/java/org/jvnet/hudson/test/BuildWatcher.java
@@ -148,6 +148,8 @@ public final class BuildWatcher extends ExternalResource {
         }
 
         @Override protected void eol(byte[] b, int len) throws IOException {
+            logger.append(SupportLogFormatter.elapsedTime());
+            logger.write(' ');
             logger.append(prefix);
             logger.write(b, 0, len);
         }

--- a/src/main/java/org/jvnet/hudson/test/SupportLogFormatter.java
+++ b/src/main/java/org/jvnet/hudson/test/SupportLogFormatter.java
@@ -33,11 +33,8 @@ package org.jvnet.hudson.test;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.TimeZone;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
 /***********************************************
@@ -52,23 +49,20 @@ import java.util.logging.LogRecord;
  */
 class SupportLogFormatter extends Formatter {
 
-    private final static ThreadLocal<SimpleDateFormat> threadLocalDateFormat = new ThreadLocal<SimpleDateFormat>() {
-        @Override
-        protected SimpleDateFormat initialValue() {
-            SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
-            f.setTimeZone(TimeZone.getTimeZone("UTC"));
-            return f;
-        }
-    };
+    private static long start = System.nanoTime();
+    static String elapsedTime() { // modified from original
+        return String.format("%8.3f", (System.nanoTime() - start) / 1_000_000_000.0);
+    }
 
-    private final Object[] args = new Object[6];
+    SupportLogFormatter() {
+        start = System.nanoTime(); // reset for each test, if using LoggerRule
+    }
 
     @Override
     //@SuppressFBWarnings(value = {"DE_MIGHT_IGNORE"}, justification = "The exception wasn't thrown on our stack frame")
     public String format(LogRecord record) {
         StringBuilder builder = new StringBuilder();
-        SimpleDateFormat format = threadLocalDateFormat.get();
-        builder.append(format.format(new Date(record.getMillis())));
+        builder.append(elapsedTime());
         builder.append(" [id=").append(record.getThreadID()).append("]");
 
         builder.append("\t").append(record.getLevel().getName()).append("\t");


### PR DESCRIPTION
Amends #68. Before:

```
=== Starting coalescedQueue(org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStepTest)
Picking up existing exploded jenkins.war at /…/jenkinsci/pipeline-build-step-plugin/target/jenkins-for-test
2017-09-18 17:29:16.030+0000 [id=15]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:37353/jenkins/
2017-09-18 17:29:16.212+0000 [id=22]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
2017-09-18 17:29:21.983+0000 [id=27]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
2017-09-18 17:29:22.040+0000 [id=28]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
2017-09-18 17:29:22.080+0000 [id=22]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
2017-09-18 17:29:25.884+0000 [id=22]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
2017-09-18 17:29:25.898+0000 [id=26]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
2017-09-18 17:29:26.261+0000 [id=25]	INFO	o.j.main.modules.sshd.SSHD#start: Started SSHD at port 39621
2017-09-18 17:29:26.261+0000 [id=23]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
2017-09-18 17:29:26.274+0000 [id=47]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
2017-09-18 17:29:26.276+0000 [id=50]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
2017-09-18 17:29:26.282+0000 [id=47]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
2017-09-18 17:29:26.283+0000 [id=47]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
2017-09-18 17:29:26.283+0000 [id=47]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
2017-09-18 17:29:26.283+0000 [id=47]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
2017-09-18 17:29:26.284+0000 [id=47]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
[us #1] Started
[us #1] [Pipeline] build (Building ds)
[us #1] Scheduling project: ds
[us #2] Started
[us #2] [Pipeline] build (Building ds)
[us #2] Scheduling project: ds
[ds #1] Started by upstream project "us" build number 1
[ds #1] Started by upstream project "us" build number 2
[ds #1] Building in workspace /tmp/jenkinsTests.tmp/jenkins1633568552996920739test/workspace/ds
[ds #1] Sleeping 3000ms
[us #1] Starting building: ds #1
[us #2] Starting building: ds #1
2017-09-18 17:29:34.203+0000 [id=37]	INFO	hudson.model.Run#execute: ds #1 main build action completed: SUCCESS
[ds #1] Finished: SUCCESS
2017-09-18 17:29:34.273+0000 [id=65]	INFO	o.j.p.workflow.job.WorkflowRun#finish: us #2 completed: SUCCESS
2017-09-18 17:29:34.275+0000 [id=79]	INFO	o.j.p.workflow.job.WorkflowRun#finish: us #1 completed: SUCCESS
[us #1] [Pipeline] echo
[us #2] [Pipeline] echo
[us #1] triggered #1
[us #2] triggered #1
[us #1] [Pipeline] End of Pipeline
[us #2] [Pipeline] End of Pipeline
[us #1] Finished: SUCCESS
[us #2] Finished: SUCCESS
```

After:

```
=== Starting coalescedQueue(org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStepTest)
Picking up existing exploded jenkins.war at /…/jenkinsci/pipeline-build-step-plugin/target/jenkins-for-test
   0.376 [id=15]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:37885/jenkins/
   0.589 [id=22]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   6.138 [id=28]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   6.194 [id=23]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   6.231 [id=22]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
  10.138 [id=26]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
  10.148 [id=26]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
  10.522 [id=24]	INFO	o.j.main.modules.sshd.SSHD#start: Started SSHD at port 41099
  10.522 [id=22]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
  10.537 [id=47]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
  10.538 [id=49]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  10.541 [id=53]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
  10.541 [id=48]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
  10.541 [id=48]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
  10.541 [id=48]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
  10.542 [id=48]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
  10.706 [us #1] Started
  11.720 [us #1] [Pipeline] build (Building ds)
  12.579 [us #1] Scheduling project: ds
  12.629 [us #2] Started
  12.730 [us #2] [Pipeline] build (Building ds)
  13.743 [us #2] Scheduling project: ds
  15.514 [ds #1] Started by upstream project "us" build number 1
  15.514 [ds #1] Started by upstream project "us" build number 2
  15.515 [ds #1] Building in workspace /tmp/jenkinsTests.tmp/jenkins6043347611856530712test/workspace/ds
  15.515 [ds #1] Sleeping 3000ms
  15.565 [us #1] Starting building: ds #1
  15.718 [us #2] Starting building: ds #1
  18.541 [id=37]	INFO	hudson.model.Run#execute: ds #1 main build action completed: SUCCESS
  18.565 [ds #1] Finished: SUCCESS
  18.611 [id=81]	INFO	o.j.p.workflow.job.WorkflowRun#finish: us #1 completed: SUCCESS
  18.611 [id=45]	INFO	o.j.p.workflow.job.WorkflowRun#finish: us #2 completed: SUCCESS
  18.614 [us #2] [Pipeline] echo
  18.614 [us #2] triggered #1
  18.614 [us #2] [Pipeline] End of Pipeline
  18.614 [us #2] Finished: SUCCESS
  18.616 [us #1] [Pipeline] echo
  18.616 [us #1] triggered #1
  18.617 [us #1] [Pipeline] End of Pipeline
  18.618 [us #1] Finished: SUCCESS
```

@reviewbybees