### PR TITLE
Fixing LoggerRule

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -208,6 +208,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.net.HttpURLConnection;
 import java.nio.channels.ClosedByInterruptException;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
 import jenkins.model.ParameterizedJobMixIn;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.rules.Timeout;
@@ -330,6 +332,12 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * @throws Throwable if setup fails (which will disable {@code after}
      */
     public void before() throws Throwable {
+        for (Handler h : Logger.getLogger("").getHandlers()) {
+            if (h instanceof ConsoleHandler) {
+                ((ConsoleHandler) h).setFormatter(new SupportLogFormatter());
+            }
+        }
+
         if (Thread.interrupted()) { // JENKINS-30395
             LOGGER.warning("was interrupted before start");
         }

--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -36,7 +36,6 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
-import java.util.logging.StreamHandler;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.ExternalResource;
@@ -53,7 +52,7 @@ import org.junit.rules.RuleChain;
  */
 public class LoggerRule extends ExternalResource {
 
-    private final Handler consoleHandler = new StreamHandler(System.err, new SupportLogFormatter());
+    private final Handler consoleHandler = new ConsoleHandler();
     private final Map<Logger,Level> loggers = new HashMap<Logger,Level>();
     // initialized iff capture is called:
     private RingBufferLogHandler ringHandler;
@@ -63,6 +62,7 @@ public class LoggerRule extends ExternalResource {
      * Initializes the rule, by default not recording anything.
      */
     public LoggerRule() {
+        consoleHandler.setFormatter(new SupportLogFormatter());
         consoleHandler.setLevel(Level.ALL);
         // For consistency, adjust format of default console handler (INFO+) too:
         for (Handler h : Logger.getLogger("").getHandlers()) {

--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -64,12 +64,6 @@ public class LoggerRule extends ExternalResource {
     public LoggerRule() {
         consoleHandler.setFormatter(new SupportLogFormatter());
         consoleHandler.setLevel(Level.ALL);
-        // For consistency, adjust format of default console handler (INFO+) too:
-        for (Handler h : Logger.getLogger("").getHandlers()) {
-            if (h instanceof ConsoleHandler) {
-                ((ConsoleHandler) h).setFormatter(new SupportLogFormatter());
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Corrects a regression in #68 to display `FINE`—`FINEST` messages again; and also improves on it to apply the format to `INFO`+ messages unconditionally.

@reviewbybees