### PR TITLE
Add multiple methods to ease the use of Basic & ApiToken

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,8 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
-      <version>1.580.1</version>
+      <!--to have access to User.getById-->
+      <version>1.651.2</version>
       <type>executable-war</type>
       <exclusions>
         <exclusion>

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2356,7 +2356,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
          * @since TODO
          */
         public @NonNull WebClient withBasicCredentials(@NonNull String loginAndPassword, @NonNull ThrowingConsumer<WebClient> closure) throws Exception {
-            return withBasicCredentials(loginAndPassword, closure);
+            return withBasicCredentials(loginAndPassword, loginAndPassword, closure);
         }
 
         /**

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2325,12 +2325,32 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         }
 
         /**
+         * To be used with try-with-resource
+         * @see #usingBasicCredentials(String, String)
+         * @since TODO
+         */
+        public @NonNull AutoCloseable withBasicCredentials(@Nonnull String login, @Nonnull String passwordOrToken){
+            usingBasicCredentials(login, passwordOrToken);
+            return this::removeBasicAuthorizationHeader;
+        }
+
+        /**
          * Retrieve the {@link ApiTokenProperty} from the user, derive credentials from it and place it in Basic authorization header
          * @see #usingBasicCredentials(String, String)
          * @since TODO
          */
         public @NonNull WebClient usingBasicApiToken(@NonNull User user){
             return usingBasicCredentials(user.getId(), user.getProperty(ApiTokenProperty.class).getApiToken());
+        }
+
+        /**
+         * To be used with try-with-resource
+         * @see #usingBasicApiToken(User)
+         * @since TODO
+         */
+        public @NonNull AutoCloseable withBasicApiToken(@Nonnull User user){
+            usingBasicApiToken(user);
+            return this::removeBasicAuthorizationHeader;
         }
 
         /**
@@ -2342,6 +2362,16 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             User u = User.getById(userId, false);
             assertNotNull("The userId must correspond to an already created User", u);
             return usingBasicApiToken(u);
+        }
+
+        /**
+         * To be used with try-with-resource
+         * @see #usingBasicApiToken(String)
+         * @since TODO
+         */
+        public @NonNull AutoCloseable withBasicApiToken(@Nonnull String userId){
+            usingBasicApiToken(userId);
+            return this::removeBasicAuthorizationHeader;
         }
 
         /**

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -84,11 +84,6 @@ public class JenkinsRuleTest {
     public void testTokenHelperMethods() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
 
-        standardMethods();
-        closureMethods();
-    }
-
-    private void standardMethods() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
 
         User alice = User.getById("alice", true);
@@ -127,39 +122,6 @@ public class JenkinsRuleTest {
 
         wc.withBasicApiToken("charlotte");
         makeRequestAndAssertLogin(wc, "charlotte");
-    }
-
-    private void closureMethods() throws Exception {
-        JenkinsRule.WebClient wc = j.createWebClient();
-
-        User alice = User.getById("alice", true);
-        User.getById("bob", true);
-        User.getById("charlotte", true);
-        User.getById("dave", true);
-
-        wc.withBasicCredentials("alice", "alice", it ->
-            makeRequestAndAssertLogin(it, "alice")
-        );
-
-        makeRequestAndAssertLogin(wc, "anonymous");
-
-        wc.withBasicCredentials("alice", alice.getProperty(ApiTokenProperty.class).getApiToken(), it ->
-            makeRequestAndAssertLogin(it, "alice")
-        );
-
-        makeRequestAndAssertLogin(wc, "anonymous");
-
-        wc.withBasicApiToken("bob", it ->
-            makeRequestAndAssertLogin(it, "bob")
-        );
-
-        wc.withBasicApiToken("charlotte", it ->
-                makeRequestAndAssertLogin(it, "charlotte")
-        );
-
-        wc.withBasicCredentials("dave", it ->
-                makeRequestAndAssertLogin(it, "dave")
-        );
     }
 
     private void makeRequestAndAssertLogin(JenkinsRule.WebClient wc, String expectedLogin) throws IOException, SAXException {

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -157,27 +157,4 @@ public class JenkinsRuleTest {
             return setterParam;
         }
     }
-
-    @TestExtension("testTokenHelperMethods")
-    public static class AuthRetrieval implements UnprotectedRootAction {
-        @Override
-        public String getIconFileName() {
-            return null;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return null;
-        }
-
-        @Override
-        public String getUrlName() {
-            return "test";
-        }
-
-        public HttpResponse doIndex() {
-            User u = User.current();
-            return HttpResponses.plainText(u!=null ? u.getId() : "anonymous");
-        }
-    }
 }

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -194,10 +194,7 @@ public class JenkinsRuleTest {
         }
     }
 
-    /**
-     * Used only by {@link #testTokenHelperMethods()}
-     */
-    @TestExtension
+    @TestExtension("testTokenHelperMethods")
     public static class AuthRetrieval implements UnprotectedRootAction {
         @Override
         public String getIconFileName() {

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -183,8 +183,11 @@ public class JenkinsRuleTest {
         }
     }
 
+    /**
+     * Used only by {@link #testTokenHelperMethods()}
+     */
     @TestExtension
-    public static class WhoAmI implements UnprotectedRootAction {
+    public static class AuthRetrieval implements UnprotectedRootAction {
         @Override
         public String getIconFileName() {
             return null;

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -135,6 +135,7 @@ public class JenkinsRuleTest {
         User alice = User.getById("alice", true);
         User.getById("bob", true);
         User.getById("charlotte", true);
+        User.getById("dave", true);
 
         wc.withBasicCredentials("alice", "alice", it ->
             makeRequestAndAssertLogin(it, "alice")
@@ -153,7 +154,11 @@ public class JenkinsRuleTest {
         );
 
         wc.withBasicApiToken("charlotte", it ->
-            makeRequestAndAssertLogin(it, "charlotte")
+                makeRequestAndAssertLogin(it, "charlotte")
+        );
+
+        wc.withBasicCredentials("dave", it ->
+                makeRequestAndAssertLogin(it, "dave")
         );
     }
 


### PR DESCRIPTION
As requested in [#3129 jenkins-core](https://github.com/jenkinsci/jenkins/pull/3129), some helper methods to ease the use of token (Basic) with username ( password or API Token.

This will allow tests to be written with less code (better readability).

@reviewbybees @jglick 