### PR TITLE
Allow connector to listen in all interfaces

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -673,7 +673,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
         config.setRequestHeaderSize(12 * 1024);
-        connector.setHost("localhost");
+        connector.setHost(System.getProperty("host", "localhost"));
         if (System.getProperty("port")!=null)
             connector.setPort(Integer.parseInt(System.getProperty("port")));
 


### PR DESCRIPTION
In the kubernetes plugin we need the server to listen in all interfaces to connect external agents.

Currently working by copying the class https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/test/java/org/jvnet/hudson/test/JenkinsRuleNonLocalhost.java#L83

@reviewbybees
