### PR TITLE
[JENKINS-47975] Add utility methods to LoggerRule for matching log entries

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -169,7 +169,7 @@ public class LoggerRule extends ExternalResource {
     /**
      * Creates a {@link Matcher} that matches if the {@link LoggerRule} has a {@link LogRecord} at
      * the specified {@link Level}, with a message matching the specified matcher, and with a
-     * throwable matching the specified matcher.
+     * {@link Throwable} matching the specified matcher.
      *
      * @param level The {@link Level} of the {@link LoggerRule} to match. Pass {@code null} to match any {@link Level}.
      * @param message the matcher to match against {@link LogRecord#getMessage}
@@ -192,7 +192,7 @@ public class LoggerRule extends ExternalResource {
 
     /**
      * Creates a {@link Matcher} that matches if the {@link LoggerRule} has a {@link LogRecord}
-     * with a message matching the specified matcher, and with a throwable matching the specified
+     * with a message matching the specified matcher and with a {@link Throwable} matching the specified
      * matcher.
      *
      * @param message the matcher to match against {@link LogRecord#getMessage}

--- a/src/test/java/org/jvnet/hudson/test/LoggerRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/LoggerRuleTest.java
@@ -72,6 +72,15 @@ public class LoggerRuleTest {
         FOO_LOGGER.log(Level.INFO, "Foo Entry 1", new IllegalStateException());
         assertThat(logRule, recorded(equalTo("Foo Entry 1"), instanceOf(IllegalStateException.class)));
         assertThat(logRule, recorded(Level.INFO, equalTo("Foo Entry 1"), instanceOf(IllegalStateException.class)));
-        assertThat(logRule, not(recorded(Level.INFO, instanceOf(IOException.class))));
+        assertThat(logRule, not(recorded(Level.INFO, equalTo("Foo Entry 1"), instanceOf(IOException.class))));
+    }
+
+    @Test
+    public void testRecordedNoShortCircuit() {
+        logRule.record("Foo", Level.INFO).capture(2);
+        FOO_LOGGER.log(Level.INFO, "Foo Entry", new IllegalStateException());
+        FOO_LOGGER.log(Level.INFO, "Foo Entry", new IOException());
+        assertThat(logRule, recorded(Level.INFO, equalTo("Foo Entry"), instanceOf(IllegalStateException.class)));
+        assertThat(logRule, recorded(Level.INFO, equalTo("Foo Entry"), instanceOf(IOException.class)));
     }
 }

--- a/src/test/java/org/jvnet/hudson/test/LoggerRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/LoggerRuleTest.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jvnet.hudson.test;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Test;
+import org.junit.Rule;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.jvnet.hudson.test.LoggerRule.recorded;
+
+public class LoggerRuleTest {
+
+    @Rule
+    public LoggerRule logRule = new LoggerRule();
+
+    private static final Logger FOO_LOGGER = Logger.getLogger("Foo");
+    private static final Logger BAR_LOGGER = Logger.getLogger("Bar");
+
+    @Test
+    public void testRecordedSingleLogger() {
+        logRule.record("Foo", Level.INFO).capture(1);
+        FOO_LOGGER.log(Level.INFO, "Entry 1");
+        assertThat(logRule, recorded(equalTo("Entry 1")));
+        assertThat(logRule, recorded(Level.INFO, equalTo("Entry 1")));
+        assertThat(logRule, not(recorded(Level.WARNING, equalTo("Entry 1"))));
+        FOO_LOGGER.log(Level.INFO, "Entry 2");
+        assertThat(logRule, not(recorded(equalTo("Entry 1"))));
+        assertThat(logRule, recorded(equalTo("Entry 2")));
+    }
+
+    @Test
+    public void testRecordedMultipleLoggers() {
+        logRule.record("Foo", Level.INFO).record("Bar", Level.SEVERE).capture(2);
+        FOO_LOGGER.log(Level.INFO, "Foo Entry 1");
+        BAR_LOGGER.log(Level.SEVERE, "Bar Entry 1");
+        assertThat(logRule, recorded(equalTo("Foo Entry 1")));
+        assertThat(logRule, recorded(equalTo("Bar Entry 1")));
+        // All criteria must match a single LogRecord.
+        assertThat(logRule, not(recorded(Level.INFO, equalTo("Bar Entry 1"))));
+    }
+
+    @Test
+    public void testRecordedThrowable() {
+        logRule.record("Foo", Level.INFO).capture(1);
+        FOO_LOGGER.log(Level.INFO, "Foo Entry 1", new IllegalStateException());
+        assertThat(logRule, recorded(equalTo("Foo Entry 1"), instanceOf(IllegalStateException.class)));
+        assertThat(logRule, recorded(Level.INFO, equalTo("Foo Entry 1"), instanceOf(IllegalStateException.class)));
+        assertThat(logRule, not(recorded(Level.INFO, instanceOf(IOException.class))));
+    }
+}


### PR DESCRIPTION
See [JENKINS-47975](https://issues.jenkins-ci.org/browse/JENKINS-47975).

Adds utility methods to `LoggerRule` so that it can be used naturally with `assertThat`. Code taken from @rsandell and `CaptureLogRule` in jenkinsci/ldap-plugin/pull/27.

@reviewbybees