### PR TITLE
Update Javadoc for LoggerRule#recorded

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -177,10 +177,12 @@ public class LoggerRule extends ExternalResource {
      * Creates a {@link Matcher} that matches if the {@link LoggerRule} has a {@link LogRecord} at
      * the specified {@link Level}, with a message matching the specified matcher, and with a
      * {@link Throwable} matching the specified matcher.
+     * You must have first called {@link #capture}.
      *
      * @param level The {@link Level} of the {@link LoggerRule} to match. Pass {@code null} to match any {@link Level}.
      * @param message the matcher to match against {@link LogRecord#getMessage}
-     * @param thrown the matcher to match against {@link LogRecord#getThrown()}
+     * @param thrown the matcher to match against {@link LogRecord#getThrown()}. Passing {@code null} is equivalent to
+     * passing {@link org.hamcrest.CoreMatchers#anything}
      */
     public static Matcher<LoggerRule> recorded(@CheckForNull Level level, @Nonnull Matcher<String> message, @CheckForNull Matcher<Throwable> thrown) {
         return new RecordedMatcher(level, message, thrown);
@@ -189,6 +191,7 @@ public class LoggerRule extends ExternalResource {
     /**
      * Creates a {@link Matcher} that matches if the {@link LoggerRule} has a {@link LogRecord} at
      * the specified {@link Level} and with a message matching the specified matcher.
+     * You must have first called {@link #capture}.
      *
      * @param level The {@link Level} of the {@link LoggerRule} to match. Pass {@code null} to match any {@link Level}.
      * @param message The matcher to match against {@link LogRecord#getMessage}.
@@ -201,9 +204,11 @@ public class LoggerRule extends ExternalResource {
      * Creates a {@link Matcher} that matches if the {@link LoggerRule} has a {@link LogRecord}
      * with a message matching the specified matcher and with a {@link Throwable} matching the specified
      * matcher.
+     * You must have first called {@link #capture}.
      *
      * @param message the matcher to match against {@link LogRecord#getMessage}
-     * @param thrown the matcher to match against {@link LogRecord#getThrown()}
+     * @param thrown the matcher to match against {@link LogRecord#getThrown()}. Passing {@code null} is equivalent to
+     * passing {@link org.hamcrest.CoreMatchers#anything}
      */
     public static Matcher<LoggerRule> recorded(@Nonnull Matcher<String> message, @CheckForNull Matcher<Throwable> thrown) {
         return recorded(null, message, thrown);
@@ -212,6 +217,7 @@ public class LoggerRule extends ExternalResource {
     /**
      * Creates a {@link Matcher} that matches if the {@link LoggerRule} has a {@link LogRecord}
      * with a message matching the specified matcher.
+     * You must have first called {@link #capture}.
      *
      * @param message the matcher to match against {@link LogRecord#getMessage}
      */


### PR DESCRIPTION
Updates the Javadoc of the `Loggerrule#recorded` methods as requested in #86.

@reviewbybees