### PR TITLE
[RFC] space char in tmp dirs to catch quoting issues

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
@@ -45,6 +45,14 @@ public class TemporaryDirectoryAllocator {
      */
     private final File base;
 
+    /**
+     * Whether there should be a space character in the allocated temporary directories names.
+     * It forces slaves created from a {@link JenkinsRule} to work inside a hazardous path,
+     * which can help catching shell quoting bugs.<br>
+     * This option is controlled by the <code>jenkins.test.noSpaceInTmpDirs</code> system property.
+     */
+    private final boolean withoutSpace = Boolean.getBoolean("jenkins.test.noSpaceInTmpDirs");
+
     public TemporaryDirectoryAllocator(File base) {
         this.base = base;
     }
@@ -62,7 +70,7 @@ public class TemporaryDirectoryAllocator {
      */
     public synchronized File allocate() throws IOException {
         try {
-            File f = File.createTempFile("jenkins", " test", base);
+            File f = File.createTempFile("jenkins", (withoutSpace ? "test" : " test"), base);
             f.delete();
             f.mkdirs();
             tmpDirectories.add(f);

--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
@@ -62,7 +62,7 @@ public class TemporaryDirectoryAllocator {
      */
     public synchronized File allocate() throws IOException {
         try {
-            File f = File.createTempFile("jenkins", "test", base);
+            File f = File.createTempFile("jenkins", " test", base);
             f.delete();
             f.mkdirs();
             tmpDirectories.add(f);


### PR DESCRIPTION
This is an idea I got after reporting [JENKINS-48264](https://issues.jenkins-ci.org/browse/JENKINS-48264), which is a recent regression in pipeline-maven-plugin with job names (hence workspace paths) containing space characters.  

It's not the first time I come across a quoting issue like that in a plugin, so... why not try to detect them (at least some) sooner, by tweaking JenkinsRule to always put some space characters in workspaces paths?
My initial thought was to make a WorkspaceLocator or something like that, but the patch in this PR is even simpler.

I've verified that it somehow works: it breaks 6 out of 27 tests in the WithMavenStepOnMasterTest class in pipeline-maven-plugin 3.0.3.

I'm not sure how good or stupid this idea is, just wanted to share and get your feedback.