### PR TITLE
Moving SleepBuilderTest from core

### DIFF
--- a/src/test/java/org/jvnet/hudson/test/SleepBuilderTest.java
+++ b/src/test/java/org/jvnet/hudson/test/SleepBuilderTest.java
@@ -1,0 +1,21 @@
+package org.jvnet.hudson.test;
+
+import hudson.model.FreeStyleProject;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SleepBuilderTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testPerform() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        SleepBuilder builder = new SleepBuilder(30);
+        project.getBuildersList().add(builder);
+        j.configRoundtrip(project);
+        j.assertEqualDataBoundBeans(project.getBuildersList().get(SleepBuilder.class), builder);
+    }
+
+}


### PR DESCRIPTION
Apparently I forget this class during the split of `jenkins-test-harness`, probably due to it being in Groovy; noticed in the course of https://github.com/jenkinsci/jenkins/pull/3184.

@reviewbybees