### PR TITLE
Add utilities to RestartableJenkinsRule to simulate dirty shutdowns

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RestartableJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RestartableJenkinsRule.java
@@ -1,6 +1,7 @@
 package org.jvnet.hudson.test;
 
 import groovy.lang.Closure;
+import hudson.FilePath;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.Description;
@@ -9,14 +10,8 @@ import org.junit.runners.model.Statement;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -84,46 +79,6 @@ public class RestartableJenkinsRule implements MethodRule {
         });
     }
 
-    /** Approach adapted from https://stackoverflow.com/questions/6214703/copy-entire-directory-contents-to-another-directory */
-    static class CopyFileVisitor extends SimpleFileVisitor<Path> {
-        private final Path targetPath;
-        private Path sourcePath = null;
-        public CopyFileVisitor(Path targetPath) {
-            this.targetPath = targetPath;
-        }
-
-        @Override
-        public FileVisitResult preVisitDirectory(final Path dir,
-                                                 final BasicFileAttributes attrs) throws IOException {
-            if (sourcePath == null) {
-                sourcePath = dir;
-            } else {
-                Files.createDirectories(targetPath.resolve(sourcePath
-                        .relativize(dir)));
-            }
-            return FileVisitResult.CONTINUE;
-        }
-
-        @Override
-        public FileVisitResult visitFile(final Path file,
-                                         final BasicFileAttributes attrs) throws IOException {
-            try {
-                if (!Files.isSymbolicLink(file)) {
-                    // Needed because Jenkins includes invalid lastSuccessful symlinks and otherwise we get a NoSuchFileException
-                    Files.copy(file,
-                            targetPath.resolve(sourcePath.relativize(file)));
-                } else if (Files.isSymbolicLink(file) && Files.exists(Files.readSymbolicLink(file))) {
-                    Files.copy(file,
-                            targetPath.resolve(sourcePath.relativize(file)));
-                }
-            } catch (NoSuchFileException nsfe) {
-                // File removed in between scan beginning and when we try to copy it, ignore it
-            }
-
-            return FileVisitResult.CONTINUE;
-        }
-    }
-
     /**
      * Simulate an abrupt failure of Jenkins to see if it appropriately handles inconsistent states when
      *  shutdown cleanup is not performed or data is not written fully to disk.
@@ -142,7 +97,18 @@ public class RestartableJenkinsRule implements MethodRule {
         File newHome = temp.newFolder();
 
         // Copy efficiently
-        Files.walkFileTree(homeDir.toPath(), Collections.EMPTY_SET, 99, new CopyFileVisitor(newHome.toPath()));
+         try {
+             try {
+                new FilePath(homeDir).copyRecursiveTo(new FilePath(newHome));
+             } catch (NoSuchFileException nsfe) {
+                // Retry in case of tempfile deletion while copying.
+                newHome.delete();
+                newHome = temp.newFolder();
+                new FilePath(homeDir).copyRecursiveTo(new FilePath(newHome));
+             }
+         } catch (InterruptedException ie) {
+             throw new IOException(ie);
+         }
         home = newHome;
     }
 


### PR DESCRIPTION
This can be used to verify that data is appropriately persisted and masters can start cleanly even when normal shutdown-time processes don't get a chance to run. 

Note that it isn't perfect -- slightly-delayed periodic or async processes may still get a chance to run, since the JENKINS_HOME isn't atomically/instantly snapshotted (instead it is copied over a piece at a time).  However, it has been useful to identify persistence issues. 

Deployed as:
* 2.33-20171220.165503-3

@reviewbybees