### PR TITLE
[JENKINS-50590] do not remove all request parameters when adding a crumb

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2300,8 +2300,13 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
          * Use {@link #createCrumbedUrl} instead if you intend to call {@link WebRequest#setRequestBody}, typical of a POST request.
          */
         public WebRequest addCrumb(WebRequest req) {
-            NameValuePair crumb = getCrumbHeaderNVP();
-            req.setRequestParameters(Arrays.asList(crumb));
+            ArrayList<NameValuePair> params = new ArrayList<>();
+            params.add(getCrumbHeaderNVP());
+            List<NameValuePair> oldParams = req.getRequestParameters();
+            if (oldParams != null && !oldParams.isEmpty()) {
+                params.addAll(oldParams);
+            }
+            req.setRequestParameters(params);
             return req;
         }
 


### PR DESCRIPTION
If you had a WebRequest with existing Parameters specified then adding a
crumb would remove all of those headers.  THis is somewhat suprising.

I thought about making getCrumbHeaderNVP() public but went with the
option that should anyway cause the least suprise.  The crumb is now
added to the list of parameters rather than replacing them.  It is added
first such that if there where existing crumb fields the newly added one
should be first.