### PR TITLE
[JENKINS-50590] do not remove all request parameters when adding a crumb

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2317,10 +2317,15 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             CrumbIssuer issuer = jenkins.getCrumbIssuer();
             String crumbName = issuer.getDescriptor().getCrumbRequestField();
             String crumb = issuer.getCrumb(null);
-            if (relativePath.indexOf('?') == -1) {
+            final int idx = relativePath.indexOf('?');
+            if (idx == -1) {
                 return new URL(getContextPath()+relativePath+"?"+crumbName+"="+crumb);
             }
-            return new URL(getContextPath()+relativePath+"&"+crumbName+"="+crumb);
+            // make sure the crumb comes first in case there are older crumbs in the parameters.
+            StringBuilder sb = new StringBuilder(relativePath);
+            sb.insert(idx + 1, crumbName + '=' + crumb + '&');
+            sb.insert(0, getContextPath());
+            return new URL(sb.toString());
         }
 
         /**


### PR DESCRIPTION
[JENKINS-50590](https://issues.jenkins-ci.org/browse/JENKINS-50590) When adding a crumb to a URL request the crumb should come first as well.