### PR TITLE
Follow-up #46

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/NoListenerConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/test/NoListenerConfiguration.java
@@ -41,7 +41,7 @@ import javax.servlet.ServletContextListener;
 public final class NoListenerConfiguration extends AbstractLifeCycle {
     private final WebAppContext context;
 
-    NoListenerConfiguration(WebAppContext context) {
+    public NoListenerConfiguration(WebAppContext context) {
         this.context = context;
     }
 


### PR DESCRIPTION
Custom `XXXRule extends JenkinsRule` that overrides `createWebServer` needs public `NoListenerConfiguration` constructor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jenkins-test-harness/104)
<!-- Reviewable:end -->
