### PR TITLE
Prevent agent processes from stealing focus on OS X

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@ THE SOFTWARE.
         <artifactId>maven-surefire-plugin</artifactId>
         <!-- version specified in grandparent pom -->
         <configuration>
-          <argLine>-Dfile.encoding=UTF-8 -Xmx256m</argLine>
+          <argLine>-Dfile.encoding=UTF-8 -Xmx256m -Djava.awt.headless=true</argLine>
           <systemPropertyVariables>
               <!-- use AntClassLoader that supports predictable file handle release -->
               <hudson.ClassicPluginStrategy.useAntClassLoader>true</hudson.ClassicPluginStrategy.useAntClassLoader>

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -670,9 +670,10 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     public ComputerLauncher createComputerLauncher(EnvVars env) throws URISyntaxException, IOException {
         int sz = jenkins.getNodes().size();
         return new SimpleCommandLauncher(
-                String.format("\"%s/bin/java\" %s -jar \"%s\"",
+                String.format("\"%s/bin/java\" %s %s -jar \"%s\"",
                         System.getProperty("java.home"),
                         SLAVE_DEBUG_PORT>0 ? " -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address="+(SLAVE_DEBUG_PORT+sz): "",
+                        "-Djava.awt.headless=true",
                         new File(jenkins.getJnlpJars("slave.jar").getURL().toURI()).getAbsolutePath()),
                 env);
     }

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -918,9 +918,10 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     public ComputerLauncher createComputerLauncher(EnvVars env) throws URISyntaxException, IOException {
         int sz = jenkins.getNodes().size();
         return new SimpleCommandLauncher(
-                String.format("\"%s/bin/java\" %s -jar \"%s\"",
+                String.format("\"%s/bin/java\" %s %s -jar \"%s\"",
                         System.getProperty("java.home"),
                         SLAVE_DEBUG_PORT>0 ? " -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address="+(SLAVE_DEBUG_PORT+sz): "",
+                        "-Djava.awt.headless=true",
                         new File(jenkins.getJnlpJars("slave.jar").getURL().toURI()).getAbsolutePath()),
                 env);
     }


### PR DESCRIPTION
Any test that launches a new java process without passing `-Djava.awt.headless=true` causes focus to switch to the new process, which is mildly infuriating when I want to work on something while running tests in the background. A similar issue was fixed in jenkinsci/plugin-pom#22 to prevent `JenkinsRule` tests from stealing focus by default.

The focus-stealing feature on OS X can be disabled entirely, but it is normally useful and I do not have this issue with any other background processes on my machine, so I'd prefer to fix it here.

I am happy to create a Jira ticket or a screen recording to demonstrate the issue if desired.

@reviewbybees 