### PR TITLE
[FIX JENKINS-49046] Fix WithTimeout handling for JenkinsRule

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -222,6 +222,7 @@ import org.hamcrest.core.IsInstanceOf;
 import org.junit.rules.Timeout;
 import org.junit.runners.model.TestTimedOutException;
 import org.jvnet.hudson.test.recipes.Recipe;
+import org.jvnet.hudson.test.recipes.WithTimeout;
 import org.jvnet.hudson.test.rhino.JavaScriptDebugger;
 import org.kohsuke.stapler.ClassDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -567,6 +568,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                 }
             }
         };
+        applyTestTimeoutOverride(description);
         if (timeout <= 0) {
             System.out.println("Test timeout disabled.");
             return wrapped;
@@ -585,6 +587,14 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                     }
                 }
             };
+        }
+    }
+
+    private void applyTestTimeoutOverride(Description description) {
+        WithTimeout withTiemout = description.getAnnotation(WithTimeout.class);
+        if (withTiemout != null) {
+            timeout = withTiemout.value();
+            System.out.println("Using test timeout: " + timeout + " seconds");
         }
     }
 

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -568,7 +568,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                 }
             }
         };
-        final int testTimeout = getTestTimeoutOverride(description, this.timeout);
+        final int testTimeout = getTestTimeoutOverride(description);
         if (testTimeout <= 0) {
             System.out.println("Test timeout disabled.");
             return wrapped;
@@ -590,9 +590,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         }
     }
 
-    private int getTestTimeoutOverride(Description description, int def) {
+    private int getTestTimeoutOverride(Description description) {
         WithTimeout withTimeout = description.getAnnotation(WithTimeout.class);
-        return withTimeout != null ? withTimeout.value(): def;
+        return withTimeout != null ? withTimeout.value(): this.timeout;
     }
 
     @SuppressWarnings("serial")

--- a/src/main/java/org/jvnet/hudson/test/recipes/WithTimeout.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/WithTimeout.java
@@ -24,9 +24,6 @@
 package org.jvnet.hudson.test.recipes;
 
 import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.JenkinsRecipe;
-import org.jvnet.hudson.test.JenkinsRule;
-
 
 import java.lang.annotation.Documented;
 import static java.lang.annotation.ElementType.METHOD;
@@ -44,7 +41,6 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Recipe(WithTimeout.RunnerImpl.class)
-@JenkinsRecipe(WithTimeout.RuleRunnerImpl.class)
 @Target(METHOD)
 @Retention(RUNTIME)
 public @interface WithTimeout {
@@ -59,13 +55,6 @@ public @interface WithTimeout {
         @Override
         public void setup(HudsonTestCase testCase, WithTimeout recipe) throws Exception {
             testCase.timeout = recipe.value();
-        }
-    }
-
-    class RuleRunnerImpl extends JenkinsRecipe.Runner<WithTimeout> {
-        @Override
-        public void setup(JenkinsRule jenkinsRule, WithTimeout recipe) throws Exception {
-            jenkinsRule.timeout = recipe.value();
         }
     }
 }

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTest.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTest.java
@@ -32,6 +32,10 @@ import org.junit.rules.RuleChain;
 import org.junit.runners.model.TestTimedOutException;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.recipes.WithTimeout;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class JenkinsRuleTimeoutTest {
 
@@ -153,4 +157,10 @@ public class JenkinsRuleTimeoutTest {
         }
     }
 
+    @Test @WithTimeout(20)
+    public void withTimeoutPropagation() throws Exception {
+        assertEquals(20, r.timeout);
+        Thread.sleep(1000 * 30);
+        fail("Should have been interrupted");
+    }
 }

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTest.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTest.java
@@ -34,7 +34,6 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.recipes.WithTimeout;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class JenkinsRuleTimeoutTest {
@@ -159,7 +158,6 @@ public class JenkinsRuleTimeoutTest {
 
     @Test @WithTimeout(20)
     public void withTimeoutPropagation() throws Exception {
-        assertEquals(20, r.timeout);
         Thread.sleep(1000 * 30);
         fail("Should have been interrupted");
     }


### PR DESCRIPTION
[JENKINS-49046](https://issues.jenkins-ci.org/browse/JENKINS-49046)

Fixing `JenkinsRule` while keeping the deprecated `HudsonTestCase` as it is.