### PR TITLE
Avoid serializing Permission.ID_COMPARATOR

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/MockAuthorizationStrategy.java
+++ b/src/main/java/org/jvnet/hudson/test/MockAuthorizationStrategy.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import org.acegisecurity.acls.sid.Sid;
 
@@ -86,10 +87,10 @@ public class MockAuthorizationStrategy extends AuthorizationStrategy {
      */
     public class Grant {
 
-        private final Set<Permission> permissions;
+        private final Set<String> permissions;
 
         Grant(Set<Permission> permissions) {
-            this.permissions = permissions;
+            this.permissions = permissions.stream().map(Permission::getId).collect(Collectors.toSet());
         }
 
         /**
@@ -202,7 +203,7 @@ public class MockAuthorizationStrategy extends AuthorizationStrategy {
                 boolean matches(String path, String name, Permission permission) {
                     return regexp.matcher(path).matches() &&
                         sids.contains(name) && // TODO consider IdStrategy
-                        permissions.contains(permission);
+                        permissions.contains(permission.getId());
                 }
 
             }


### PR DESCRIPTION
Follow-up to https://github.com/jenkinsci/remoting/pull/282 from running `com.cloudbees.plugins.credentials.SystemCredentialsProviderTest.given_globalScopeCredential_when_builtAsUserWithoutUseItem_then_credentialNotFound` against a new core. Saw

```
WARNING	o.j.r.u.AnonymousClassWarnings#warn: Attempt to (de-)serialize anonymous class hudson.security.Permission$1 in file:…/jenkins-core-2.138.jar; see: https://jenkins.io/redirect/serialization-of-anonymous-classes/
```

which referred to `Permission.ID_COMPARATOR`, that indeed was not designed to be serialized (in this case by XStream).