### PR TITLE
Added explanatory text for test failures that contain plugin dependencies

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TestPluginManager.java
+++ b/src/main/java/org/jvnet/hudson/test/TestPluginManager.java
@@ -122,7 +122,16 @@ public class TestPluginManager extends PluginManager {
                     try {
                         f = new File(url.toURI());
                     } catch (IllegalArgumentException x) {
-                        throw new IOException(index + " contains bogus line " + line, x);
+                        if (x.getMessage().equals("URI is not hierarchical")) {
+                            throw new IOException(
+                                    "You are probably trying to load plugins from within a jarfile (not possible). If"
+                                            + " you are running this in your IDE and see this message, it is likely"
+                                            + " that you have a clean target directory. Try running 'mvn test-compile' "
+                                            + "from the command line (once only), which will copy the required plugins "
+                                            + "into target/test-classes/test-dependencies - then retry your test", x);
+                        } else {
+                            throw new IOException(index + " contains bogus line " + line, x);
+                        }
                     }
                 	if(f.exists()){
                 		copyBundledPlugin(url, line + ".jpi");


### PR DESCRIPTION
If your plugin has test dependencies, you have a clean checkout (ie,
no `target` directory) and you run the test from JUnit directly (in your IDE),
then you get an obtuse "URI is not hierarchical" message.
Running via the command line using `mvn test` works fine.

This adds an explanatory note to help the user, rather than actually fixing
the issue (as I don't know how to fix it)

Eg, just starting an empty `JenkinsRule` test that depends on `blueocean-rest-impl` tests, I got the following:
```
=== Starting updateWithNonExistentPluginCatalog(com.cloudbees.opscenter.server.bluesteel.cli.TeamCreationRecipesCommandTest)
   0.117 [id=14]	INFO	o.jvnet.hudson.test.WarExploder#explode: Exploding C:\Users\Steve\.m2\repository\org\jenkins-ci\main\jenkins-war\2.121.1-cb-1\jenkins-war-2.121.1-cb-1.war into C:\Users\Steve\code\cloudbees\operations-center-all\bluesteel\bluesteel-cjoc\target\jenkins-for-test
   6.001 [id=14]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:62179/jenkins/
   8.232 [id=22]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   8.259 [id=21]	SEVERE	jenkins.InitReactorRunner$1#onTaskFailed: Failed Loading bundled plugins
java.lang.IllegalArgumentException: URI is not hierarchical
	at java.io.File.<init>(File.java:418)
	at org.jvnet.hudson.test.TestPluginManager.loadBundledPlugins(TestPluginManager.java:123)
Caused: java.io.IOException: jar:file:/C:/Users/Steve/.m2/repository/io/jenkins/blueocean/blueocean-rest-impl/1.8.2/blueocean-rest-impl-1.8.2-tests.jar!/test-dependencies/index contains bogus line blueocean-commons
	at org.jvnet.hudson.test.TestPluginManager.loadBundledPlugins(TestPluginManager.java:125)
	at org.jvnet.hudson.test.TestPluginManager.loadBundledPlugins(TestPluginManager.java:71)
	at hudson.PluginManager$1$1.run(PluginManager.java:380)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1068)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

org.jvnet.hudson.reactor.ReactorException: java.io.IOException: jar:file:/C:/Users/Steve/.m2/repository/io/jenkins/blueocean/blueocean-rest-impl/1.8.2/blueocean-rest-impl-1.8.2-tests.jar!/test-dependencies/index contains bogus line blueocean-commons

	at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:282)
	at jenkins.InitReactorRunner.run(InitReactorRunner.java:48)
	at jenkins.model.Jenkins.executeReactor(Jenkins.java:1102)
	at jenkins.model.Jenkins.<init>(Jenkins.java:904)
	at hudson.model.Hudson.<init>(Hudson.java:85)
	at org.jvnet.hudson.test.JenkinsRule.newHudson(JenkinsRule.java:611)
	at org.jvnet.hudson.test.JenkinsRule.before(JenkinsRule.java:384)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:537)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: jar:file:/C:/Users/Steve/.m2/repository/io/jenkins/blueocean/blueocean-rest-impl/1.8.2/blueocean-rest-impl-1.8.2-tests.jar!/test-dependencies/index contains bogus line blueocean-commons
	at org.jvnet.hudson.test.TestPluginManager.loadBundledPlugins(TestPluginManager.java:125)
	at org.jvnet.hudson.test.TestPluginManager.loadBundledPlugins(TestPluginManager.java:71)
	at hudson.PluginManager$1$1.run(PluginManager.java:380)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1068)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	... 1 more
Caused by: java.lang.IllegalArgumentException: URI is not hierarchical
	at java.io.File.<init>(File.java:418)
	at org.jvnet.hudson.test.TestPluginManager.loadBundledPlugins(TestPluginManager.java:123)
	... 10 more


Process finished with exit code -1
```


@reviewbybees 
