### PR TITLE
Use DisableOnDebug’s logic rather than rolling our own

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -225,6 +225,7 @@ import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import jenkins.model.ParameterizedJobMixIn;
 import org.hamcrest.core.IsInstanceOf;
+import org.junit.rules.DisableOnDebug;
 import org.junit.rules.Timeout;
 import org.junit.runners.model.TestTimedOutException;
 import org.jvnet.hudson.test.recipes.Recipe;
@@ -319,7 +320,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     /**
      * Number of seconds until the test times out.
      */
-    public int timeout = Integer.getInteger("jenkins.test.timeout", System.getProperty("maven.surefire.debug") == null ? 180 : 0);
+    public int timeout = Integer.getInteger("jenkins.test.timeout", new DisableOnDebug(null).isDebugging() ? 0 : 180);
 
     /**
      * Set the plugin manager to be passed to {@link Jenkins} constructor.


### PR DESCRIPTION
@kshultzCB ran into issues with a `JenkinsRule`-based test timing out while inside the debugger. Normally this is not supposed to happen, since it tries to disable the test timeout automatically, but evidently that trick does not work for IDEs (such as IDEA) which do not simply run `mvn` with appropriate arguments but instead launch the test JVM idiosyncratically. Anyway the previous logic would not have worked from Gradle-based plugins etc. @MarkEWaite alerted me to a standard utility he had used in https://github.com/jenkinsci/git-client-plugin/commit/cb6e220ff6359120974a41cb1f8e43ea3226883f which does the job better.