### PR TITLE
[JENKINS-53823] - Changelog: Noting 2.41.1 release with JDK11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ See [wiki page](//wiki.jenkins-ci.org/display/JENKINS/Unit+Test)
 
 * Updated HTMLUnit.
 * New convenience methods in `WebClient`.
-* Java 11 compatibility.
+* [JENKINS-53823](https://issues.jenkins-ci.org/browse/JENKINS-53823) - 
+JDK 11 compatibility.
+
+### 2.41.1 (2018 Nov 13)
+
+This is a custom release without HTMLUnit upgrade
+
+* [JENKINS-53823](https://issues.jenkins-ci.org/browse/JENKINS-53823) - 
+JDK 11 compatibility.
 
 ### 2.41 (2018 Sep 21)
 


### PR DESCRIPTION
This release happened from the branch. This is a version without HTML Unit bump. I have some issues with JS-based tests and I am pretty much stuck there: jenkinsci/jenkins#3661. Want to workaround it, because I am not a JS expert.

2.41.1 would unblock testing of Java 11 within the Jenkins Core CI pipeline. I do not consider it as a long-term branch, but in short-term I do not plan to work on fixing the rest of the tests in the core.

@jenkinsci/java11-support 