### PR TITLE
Don't report temporary dir name to System.err

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
@@ -67,7 +67,6 @@ public class TemporaryDirectoryAllocator {
             f.delete();
             f.mkdirs();
             tmpDirectories.add(f);
-            System.err.println("Using temp dir: " + f);
             return f;
         } catch (IOException e) {
             throw new IOException("Failed to create a temporary directory in "+base,e);


### PR DESCRIPTION
Clutters command line output without benefit to the consumer