### PR TITLE
Drop dependency on JavaSpecificationVersion introduced in version-number 1.6, newer than our core baseline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.49</version>
+    <version>1.51</version>
+    <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.main</groupId>
@@ -110,7 +111,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -151,13 +151,7 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
-      <artifactId>version-number</artifactId>
-      <version>1.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
       <artifactId>test-annotations</artifactId>
-      <version>1.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -173,7 +167,6 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>2.0</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>

--- a/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
+++ b/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
@@ -25,6 +25,7 @@
 package org.jvnet.hudson.test;
 
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import hudson.util.VersionNumber;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
@@ -39,7 +40,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import javax.swing.BoundedRangeModel;
 
-import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import jenkins.model.Jenkins;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
@@ -159,7 +159,10 @@ public class MemoryAssert {
     @SuppressWarnings("DLS_DEAD_LOCAL_STORE_OF_NULL")
     public static void assertGC(WeakReference<?> reference, boolean allowSoft) {
         // Disabled on Java 9+, because below will call Netbeans Insane Engine, which in turns tries to call setAccessible
+        /* TODO version-number 1.6+:
         assumeTrue(JavaSpecificationVersion.forCurrentJVM().isOlderThanOrEqualTo(JavaSpecificationVersion.JAVA_8));
+        */
+        assumeTrue(new VersionNumber(System.getProperty("java.specification.version")).isOlderThan(new VersionNumber("9")));
         assertTrue(true); reference.get(); // preload any needed classes!
         System.err.println("Trying to collect " + reference.get() + "…");
         Set<Object[]> objects = new HashSet<Object[]>();


### PR DESCRIPTION
Amends #126 to avoid the need to pick up https://github.com/jenkinsci/lib-version-number/pull/11. See https://github.com/jenkinsci/plugin-pom/pull/175#issuecomment-478644544.