### PR TITLE
Allow port reuse in RestartableJenkinsRule

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -693,8 +693,11 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
         config.setRequestHeaderSize(12 * 1024);
         connector.setHost("localhost");
-        if (System.getProperty("port")!=null)
+        if (System.getProperty("port") != null) {
             connector.setPort(Integer.parseInt(System.getProperty("port")));
+        } else if (localPort != 0) {
+            connector.setPort(localPort);
+        }
 
         server.addConnector(connector);
         server.start();

--- a/src/test/java/org/jvnet/hudson/test/RestartableJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RestartableJenkinsRuleTest.java
@@ -1,0 +1,55 @@
+package org.jvnet.hudson.test;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assume.assumeThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RestartableJenkinsRuleTest {
+
+    @Rule public RestartableJenkinsRule noPortReuse = new RestartableJenkinsRule();
+
+    @Rule
+    public RestartableJenkinsRule portReuse =
+            new RestartableJenkinsRule.Builder().withReusedPort().build();
+
+    @Test
+    public void testNoPortReuse() throws Exception {
+        assumeThat(
+                "This test requires a custom port to not be set.",
+                System.getProperty("port"),
+                nullValue());
+
+        AtomicInteger port = new AtomicInteger();
+        noPortReuse.then(
+                s -> {
+                    port.set(noPortReuse.j.getURL().getPort());
+                });
+        noPortReuse.then(
+                s -> {
+                    assertNotEquals(port.get(), noPortReuse.j.getURL().getPort());
+                });
+    }
+
+    @Test
+    public void testPortReuse() throws Exception {
+        assumeThat(
+                "This test requires a custom port to not be set.",
+                System.getProperty("port"),
+                nullValue());
+
+        AtomicInteger port = new AtomicInteger();
+        portReuse.then(
+                s -> {
+                    port.set(portReuse.j.getURL().getPort());
+                });
+        portReuse.then(
+                s -> {
+                    assertEquals(port.get(), portReuse.j.getURL().getPort());
+                });
+    }
+}


### PR DESCRIPTION
Inspired by [jenkinsci/swarm-plugin#81 (comment)](https://github.com/jenkinsci/swarm-plugin/pull/81#discussion_r279723719). Testing the Swarm client requires having Jenkins run on the same port before and after restart (c.f. jenkinsci/swarm-plugin#81). Here we add this functionality to `RestartableJenkinsRule`. The new functionality is opt-in to preserve existing behavior for tests which don't need it and which could be negatively impacted by races for open ports.