### PR TITLE
Always print softErr from MemoryAssert even if test ultimately passes

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
+++ b/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
@@ -197,6 +197,7 @@ public class MemoryAssert {
                             return !referent.equals(reference) || !(referredFrom instanceof WeakReference);
                         }
                     }) + "; apparent weak references: " + fromRoots(Collections.singleton(obj), null, null, ScannerUtils.skipObjectsFilter(Collections.singleton(reference), true));
+                    System.err.println(softErr);
                 }
             }
         }


### PR DESCRIPTION
Useful working on the likes of https://github.com/jenkinsci/workflow-cps-plugin/pull/289.