### PR TITLE
Avoid printing duplicated messages when LoggerRule is used

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -68,7 +68,7 @@ public class LoggerRule extends ExternalResource {
      */
     public LoggerRule() {
         consoleHandler.setFormatter(new DeltaSupportLogFormatter());
-        consoleHandler.setLevel(Level.ALL);
+        consoleHandler.setLevel(Level.WARNING); // do not duplicate messages from the console handler associated with the root logger
     }
 
     /**


### PR DESCRIPTION
`LoggerRule` has two basic functions:

* Let you see `FINE` or lower messages from particular loggers in test output. (`record`)
* Keep track of messages so you can assert things about them. (`capture`)

For the `record` aspect, there was an unfortunate side effect that messages to those loggers at `INFO` or above got printed once for the general system logger (formatted nicely by `JenkinsRule`), _plus_ once per matching `LoggerRule`. So the test output would get multiple copies of lots of messages, which was harmless but irritating.

Not trivially testable, but tried it interactively in https://github.com/jenkinsci/kubernetes-plugin/pull/503 and it seemed to do the job.