### PR TITLE
[JENKINS-58038] Use Annotation-Indexer instead of Reflections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,11 +176,6 @@ THE SOFTWARE.
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>1.21</version>
     </dependency>
-    <dependency>
-      <groupId>io.github.classgraph</groupId>
-      <artifactId>classgraph</artifactId>
-      <version>4.8.41</version>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -177,9 +177,9 @@ THE SOFTWARE.
       <version>1.21</version>
     </dependency>
     <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-      <version>0.9.11</version>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+      <version>4.8.41</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/jenkins/benchmark/jmh/BenchmarkFinder.java
+++ b/src/main/java/jenkins/benchmark/jmh/BenchmarkFinder.java
@@ -1,8 +1,8 @@
 package jenkins.benchmark.jmh;
 
-import io.github.classgraph.ClassGraph;
-import io.github.classgraph.ClassInfo;
-import io.github.classgraph.ScanResult;
+
+import net.java.sezpoz.Index;
+import net.java.sezpoz.IndexItem;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 
 /**
@@ -11,34 +11,16 @@ import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
  */
 @SuppressWarnings("WeakerAccess")
 public final class BenchmarkFinder {
-    private final String[] packageNames;
-
-    /**
-     * Creates a {@link BenchmarkFinder}
-     *
-     * @param packageNames find benchmarks in these packages
-     */
-    public BenchmarkFinder(String... packageNames) {
-        this.packageNames = packageNames;
+    private BenchmarkFinder() {
     }
-
     /**
      * Includes classes annotated with {@link JmhBenchmark} as candidates for JMH benchmarks.
      *
      * @param optionsBuilder the optionsBuilder used to build the benchmarks
      */
-    public void findBenchmarks(ChainedOptionsBuilder optionsBuilder) {
-        try (ScanResult scanResult =
-                     new ClassGraph()
-                             .enableAnnotationInfo()
-                             .whitelistPackages(packageNames)
-                             .scan()) {
-            for (ClassInfo classInfo : scanResult.getClassesWithAnnotation(JmhBenchmark.class.getName())) {
-                Class<?> clazz = classInfo.loadClass();
-                JmhBenchmark annotation = clazz.getAnnotation(JmhBenchmark.class);
-                assert annotation != null;
-                optionsBuilder.include(clazz.getName() + annotation.value());
-            }
+    public static void findBenchmarks(ChainedOptionsBuilder optionsBuilder) {
+        for (IndexItem<JmhBenchmark, Object> item : Index.load(JmhBenchmark.class, Object.class)) {
+            optionsBuilder.include(item.className() + item.annotation().value());
         }
     }
 }

--- a/src/main/java/jenkins/benchmark/jmh/BenchmarkFinder.java
+++ b/src/main/java/jenkins/benchmark/jmh/BenchmarkFinder.java
@@ -21,7 +21,7 @@ public final class BenchmarkFinder {
      *
      * @param clazz the class whose {@link ClassLoader} will be used to search for benchmarks.
      */
-    BenchmarkFinder(Class<?> clazz) {
+    public BenchmarkFinder(Class<?> clazz) {
         this.classLoader = clazz.getClassLoader();
     }
 

--- a/src/main/java/jenkins/benchmark/jmh/BenchmarkFinder.java
+++ b/src/main/java/jenkins/benchmark/jmh/BenchmarkFinder.java
@@ -1,26 +1,40 @@
 package jenkins.benchmark.jmh;
 
 
-import net.java.sezpoz.Index;
-import net.java.sezpoz.IndexItem;
+import org.jvnet.hudson.annotation_indexer.Index;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+
+import java.io.IOException;
+import java.lang.reflect.AnnotatedElement;
 
 /**
  * Find classes annotated with {@link JmhBenchmark} to run their benchmark methods.
+ *
  * @since 2.50
  */
 @SuppressWarnings("WeakerAccess")
 public final class BenchmarkFinder {
-    private BenchmarkFinder() {
+    private final ClassLoader classLoader;
+
+    /**
+     * Class whose {@link ClassLoader} will be used to search for benchmarks.
+     *
+     * @param clazz the class whose {@link ClassLoader} will be used to search for benchmarks.
+     */
+    BenchmarkFinder(Class<?> clazz) {
+        this.classLoader = clazz.getClassLoader();
     }
+
     /**
      * Includes classes annotated with {@link JmhBenchmark} as candidates for JMH benchmarks.
      *
      * @param optionsBuilder the optionsBuilder used to build the benchmarks
      */
-    public static void findBenchmarks(ChainedOptionsBuilder optionsBuilder) {
-        for (IndexItem<JmhBenchmark, Object> item : Index.load(JmhBenchmark.class, Object.class)) {
-            optionsBuilder.include(item.className() + item.annotation().value());
+    public void findBenchmarks(ChainedOptionsBuilder optionsBuilder) throws IOException {
+        for (AnnotatedElement e : Index.list(JmhBenchmark.class, classLoader)) {
+            Class<?> clazz = (Class<?>) e;
+            JmhBenchmark annotation = clazz.getAnnotation(JmhBenchmark.class);
+            optionsBuilder.include(clazz.getName() + annotation.value());
         }
     }
 }

--- a/src/main/java/jenkins/benchmark/jmh/JmhBenchmark.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhBenchmark.java
@@ -1,6 +1,6 @@
 package jenkins.benchmark.jmh;
 
-import net.java.sezpoz.Indexable;
+import org.jvnet.hudson.annotation_indexer.Indexed;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,11 +9,12 @@ import java.lang.annotation.Target;
 
 /**
  * Annotate your benchmark classes with this annotation to allow them to be discovered by {@link BenchmarkFinder}
+ *
  * @since 2.50
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Indexable
+@Indexed
 public @interface JmhBenchmark {
     /**
      * Methods which annotated by {@link org.openjdk.jmh.annotations.Benchmark}

--- a/src/main/java/jenkins/benchmark/jmh/JmhBenchmark.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhBenchmark.java
@@ -1,5 +1,7 @@
 package jenkins.benchmark.jmh;
 
+import net.java.sezpoz.Indexable;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -11,6 +13,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Indexable
 public @interface JmhBenchmark {
     /**
      * Methods which annotated by {@link org.openjdk.jmh.annotations.Benchmark}

--- a/src/test/java/jenkins/benchmark/jmh/BenchmarkTest.java
+++ b/src/test/java/jenkins/benchmark/jmh/BenchmarkTest.java
@@ -33,7 +33,7 @@ public class BenchmarkTest {
                         .result("target/jmh-reports/jmh-benchmark-report.json")
                         .timeUnit(TimeUnit.MICROSECONDS)
                         .resultFormat(ResultFormatType.JSON);
-        BenchmarkFinder.findBenchmarks(optionsBuilder);
+        new BenchmarkFinder(getClass()).findBenchmarks(optionsBuilder);
         new Runner(optionsBuilder.build()).run();
     }
 }

--- a/src/test/java/jenkins/benchmark/jmh/BenchmarkTest.java
+++ b/src/test/java/jenkins/benchmark/jmh/BenchmarkTest.java
@@ -26,16 +26,14 @@ public class BenchmarkTest {
         ChainedOptionsBuilder optionsBuilder =
                 new OptionsBuilder()
                         .forks(1)
-                        .warmupIterations(1)
-                        .warmupBatchSize(1)
+                        .warmupIterations(0)
                         .measurementIterations(1)
                         .measurementBatchSize(1)
                         .shouldFailOnError(true)
                         .result("target/jmh-reports/jmh-benchmark-report.json")
                         .timeUnit(TimeUnit.MICROSECONDS)
                         .resultFormat(ResultFormatType.JSON);
-        BenchmarkFinder finder = new BenchmarkFinder(this.getClass().getPackage().getName());
-        finder.findBenchmarks(optionsBuilder);
+        BenchmarkFinder.findBenchmarks(optionsBuilder);
         new Runner(optionsBuilder.build()).run();
     }
 }


### PR DESCRIPTION
Reflections was causing a dependency conflict with the Guava from
Jenkins Core (see: https://travis-ci.org/jenkinsci/configuration-as-code-plugin/jobs/546110907#L878)

@jenkinsci/gsoc2019-role-strategy 