### PR TITLE
Add support for running benchmarks with WebClient

### DIFF
--- a/src/main/java/jenkins/benchmark/jmh/JmhJenkinsRule.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhJenkinsRule.java
@@ -1,0 +1,44 @@
+package jenkins.benchmark.jmh;
+
+import com.gargoylesoftware.htmlunit.Cache;
+import jenkins.model.Jenkins;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Objects;
+
+/**
+ * Extension of {@link JenkinsRule} to allow it to be used from JMH benchmarks.
+ * <p>
+ * This class should be instantiated only when the Jenkins instance is confirmed to exist.
+ *
+ * @since TODO
+ */
+public class JmhJenkinsRule extends JenkinsRule {
+    private final Jenkins jenkins;
+
+    public JmhJenkinsRule() {
+        super();
+        jenkins = Objects.requireNonNull(Jenkins.getInstanceOrNull());
+        super.jenkins = null; // the jenkins is not started from JenkinsRule
+    }
+
+    @Override
+    public URL getURL() throws MalformedURLException {
+        // the rootURL should not be null as it should've been set by JmhBenchmarkState
+        return new URL(Objects.requireNonNull(jenkins.getRootUrl()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WebClient createWebClient() {
+        WebClient webClient = super.createWebClient();
+        Cache cache = new Cache();
+        cache.setMaxSize(0);
+        webClient.setCache(cache); // benchmarks should not rely on cached content
+        return webClient;
+    }
+}

--- a/src/test/java/jenkins/benchmark/jmh/samples/WebClientBenchmark.java
+++ b/src/test/java/jenkins/benchmark/jmh/samples/WebClientBenchmark.java
@@ -1,0 +1,31 @@
+package jenkins.benchmark.jmh.samples;
+
+import jenkins.benchmark.jmh.JmhBenchmark;
+import jenkins.benchmark.jmh.JmhBenchmarkState;
+import jenkins.benchmark.jmh.JmhJenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.openjdk.jmh.annotations.Benchmark;
+
+@JmhBenchmark
+public class WebClientBenchmark {
+    public static class MyState extends JmhBenchmarkState {
+        JenkinsRule.WebClient webClient = null;
+
+        @Override
+        public void setup() {
+            JmhJenkinsRule jenkinsRule = new JmhJenkinsRule();
+            getJenkins().setSecurityRealm(jenkinsRule.createDummySecurityRealm());
+            webClient = jenkinsRule.createWebClient();
+        }
+
+        @Override
+        public void tearDown() {
+            webClient.close();
+        }
+    }
+
+    @Benchmark
+    public void benchmark(MyState state) throws Exception {
+        state.webClient.goTo("");
+    }
+}


### PR DESCRIPTION
Adds support for running benchmarks using `WebClient`.

@jenkinsci/gsoc2019-role-strategy 