### PR TITLE
Fix concurrent access to LoggerRule#getMessages

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -26,6 +26,7 @@ package org.jvnet.hudson.test;
 
 import hudson.util.RingBufferLogHandler;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +79,7 @@ public class LoggerRule extends ExternalResource {
      * @return this rule, for convenience
      */
     public LoggerRule capture(int maximum) {
-        messages = new ArrayList<String>();
+        messages = Collections.synchronizedList(new ArrayList<>());
         ringHandler = new RingBufferLogHandler(maximum) {
             final Formatter f = new SimpleFormatter(); // placeholder instance for what should have been a static method perhaps
             @Override
@@ -153,12 +154,16 @@ public class LoggerRule extends ExternalResource {
     }
 
     /**
+     * Returns a read-only view of current messages.
+     *
      * {@link Formatter#formatMessage} applied to {@link #getRecords} at the time of logging.
      * However, if the message is null, but there is an exception, {@link Throwable#toString} will be used.
      * Does not include logger names, stack traces, times, etc. (these will appear in the test console anyway).
      */
     public List<String> getMessages() {
-        return messages;
+        synchronized (messages) {
+            return Collections.unmodifiableList(new ArrayList<>(messages));
+        }
     }
 
     @Override

--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -79,7 +79,7 @@ public class LoggerRule extends ExternalResource {
      * @return this rule, for convenience
      */
     public LoggerRule capture(int maximum) {
-        messages = Collections.synchronizedList(new ArrayList<>());
+        messages = new ArrayList<>();
         ringHandler = new RingBufferLogHandler(maximum) {
             final Formatter f = new SimpleFormatter(); // placeholder instance for what should have been a static method perhaps
             @Override
@@ -87,7 +87,9 @@ public class LoggerRule extends ExternalResource {
                 super.publish(record);
                 String message = f.formatMessage(record);
                 Throwable x = record.getThrown();
-                messages.add(message == null && x != null ? x.toString() : message);
+                synchronized (messages) {
+                    messages.add(message == null && x != null ? x.toString() : message);
+                }
             }
         };
         ringHandler.setLevel(Level.ALL);

--- a/src/test/java/org/jvnet/hudson/test/LoggerRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/LoggerRuleTest.java
@@ -24,6 +24,7 @@
 package org.jvnet.hudson.test;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.Test;
@@ -85,18 +86,16 @@ public class LoggerRuleTest {
         assertThat(logRule, recorded(Level.INFO, equalTo("Foo Entry"), instanceOf(IOException.class)));
     }
 
-    private boolean active;
-
     @Test
     public void multipleThreads() throws InterruptedException {
-        active = true;
+        AtomicBoolean active = new AtomicBoolean(true);
         logRule.record("Foo", Level.INFO).capture(1000);
         Thread thread = new Thread("logging stuff") {
             @Override
             public void run() {
                 try {
                     int i = 1;
-                    while (active) {
+                    while (active.get()) {
                         FOO_LOGGER.log(Level.INFO, "Foo Entry " + i++);
                         Thread.sleep(50);
                     }
@@ -114,7 +113,7 @@ public class LoggerRuleTest {
                 Thread.sleep(50);
             }
         } finally {
-            active = false;
+            active.set(false);
             thread.interrupt();
         }
     }


### PR DESCRIPTION
Causing flakes in https://github.com/jenkinsci/kubernetes-plugin/pull/525

> java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909)
	at java.util.ArrayList$Itr.next(ArrayList.java:859)
	at org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesPipelineTest.runInPod(KubernetesPipelineTest.java:106)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:599)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)