### PR TITLE
Reverting #138 as it broke display of FINE- messages

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -68,7 +68,7 @@ public class LoggerRule extends ExternalResource {
      */
     public LoggerRule() {
         consoleHandler.setFormatter(new DeltaSupportLogFormatter());
-        consoleHandler.setLevel(Level.WARNING); // do not duplicate messages from the console handler associated with the root logger
+        consoleHandler.setLevel(Level.ALL);
     }
 
     /**


### PR DESCRIPTION
#138 rendered `record` useless as it no longer displayed any messages at `FINE` or below. Not sure how I did not notice this before, but anyway observed in https://github.com/jenkinsci/kubernetes-plugin/pull/522. I do not have a fix for the original (duplication) problem handy, so I am just backing out the bad fix.