### PR TITLE
Enable Maven Enforcer checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,9 +53,6 @@ THE SOFTWARE.
     <jetty.version>9.4.5.v20170502</jetty.version>
     <java.level>8</java.level>
     <concurrency>1</concurrency> <!-- may use e.g. 2C for 2 × (number of cores) -->
-    <!--TODO: fix upper bounds -->
-    <!--Upper bounds: com.google.guava:guava:11.0.1, and com.google.code.findbugs:jsr305:1.3.9. Core update is needed-->
-    <enforcer.skip>true</enforcer.skip>
     <!--TODO: fix FindBugs-->
     <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
@@ -189,6 +186,25 @@ THE SOFTWARE.
         <artifactId>maven-stapler-plugin</artifactId>
         <!-- version specified in grandparent pom -->
         <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <rules>
+            <requireUpperBoundDeps>
+              <excludes combine.children="append">
+                <!--
+                  Stapler requests Guava 14.0 and Jenkins core requests Guice 4.0 which requests
+                  Guava 16.0.1. Core actually provides 11.0.1. Work around this mess by just
+                  excluding Guava from the RequireUpperBoundDeps check. The long-term fix is
+                  tracked in JENKINS-36779.
+                -->
+                <exclude>com.google.guava:guava</exclude>
+              </excludes>
+            </requireUpperBoundDeps>
+          </rules>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Problem

`pom.xml` currently has the `enforcer.skip` property set to `true`. This completely disables the Enforcer checks, which hides useful warnings. Unfortunately, re-enabling the Enforcer checks reveals this `RequireUpperBoundDeps` warning:

```
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (display-info) @ jenkins-test-harness ---
[WARNING] Rule 3: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.google.guava:guava:11.0.1 paths to dependency are:
+-org.jenkins-ci.main:jenkins-test-harness:2.54-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-war:2.60.3
    +-org.jenkins-ci.main:jenkins-core:2.60.3
      +-com.google.guava:guava:11.0.1
and
+-org.jenkins-ci.main:jenkins-test-harness:2.54-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-war:2.60.3
    +-org.jenkins-ci.main:jenkins-core:2.60.3
      +-com.google.inject:guice:4.0
        +-com.google.guava:guava:16.0.1
and
+-org.jenkins-ci.main:jenkins-test-harness:2.54-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-war:2.60.3
    +-org.jenkins-ci.main:jenkins-core:2.60.3
      +-org.kohsuke.stapler:stapler-jrebel:1.250
        +-org.kohsuke.stapler:stapler:1.250
          +-com.google.guava:guava:14.0
```

### Evaluation

Normally, the solution to such conflicts is to add a `dependencyManagement` section explicitly selecting the highest version of the dependency that is required. Unfortunately, that solution isn't quite feasible for Jenkins's Guava dependency, which has [a complicated history](https://issues.jenkins-ci.org/browse/JENKINS-36779) due to the way Jenkins does [class loading](https://jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/). Bumping Guava in the test harness to 16.0.1 would represent significant risk, since Jenkins core actually delivers Guava 11.0.1 today. The test harness currently delivers a version matching Jenkins core, as can be seen by this output:

```
$ mvn dependency:tree | grep guava
[INFO] |  |  +- com.google.guava:guava:jar:11.0.1:compile (optional)
```

To avoid the risk of any possible regressions, we want the version of Guava used in the test harness to match the version of Guava used in Jenkins core in production. However, selecting that version won't satisfy the `RequireUpperBoundDeps` check.

### Solution

The long-term fix is far beyond the realm of a single PR and is tracked in [JENKINS-36779](https://issues.jenkins-ci.org/browse/JENKINS-36779). This PR merely adds an exclusion for Guava to the `RequireUpperBoundDeps` check in the test harness. This allows the remaining Enforcer checks to run, which is a net improvement from the current code (where all Enforcer checks are disabled).