### PR TITLE
Remove usages of deprecated `@SuppressWarnings ` references

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
+++ b/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
@@ -24,7 +24,7 @@
 
 package org.jvnet.hudson.test;
 
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.VersionNumber;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
@@ -156,7 +156,7 @@ public class MemoryAssert {
      * @param allowSoft if true, pass even if {@link SoftReference}s apparently needed to be cleared by forcing an {@link OutOfMemoryError};
      *                  if false, fail in such a case (though the failure will be slow)
      */
-    @SuppressWarnings("DLS_DEAD_LOCAL_STORE_OF_NULL")
+    @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE_OF_NULL")
     public static void assertGC(WeakReference<?> reference, boolean allowSoft) {
         // Disabled on Java 9+, because below will call Netbeans Insane Engine, which in turns tries to call setAccessible
         /* TODO version-number 1.6+:


### PR DESCRIPTION
While perusing the source tree, I noticed some deprecated methods:

- The documentation for [`edu.umd.cs.findbugs.annotations.SuppressWarnings`](http://findbugs.sourceforge.net/api/edu/umd/cs/findbugs/annotations/SuppressWarnings.html) states: "Was used to suppress FindBugs warnings but generates name conflicts with `SuppressWarnings`".

Accordingly, I replace any usages of `edu.umd.cs.findbugs.annotations.SuppressWarnings` with usages of `edu.umd.cs.findbugs.annotations.SuppressFBWarnings`.