### PR TITLE
Fixing showAgentLogs

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/DeltaSupportLogFormatter.java
+++ b/src/main/java/org/jvnet/hudson/test/DeltaSupportLogFormatter.java
@@ -29,13 +29,13 @@ import java.util.logging.LogRecord;
 
 class DeltaSupportLogFormatter extends SupportLogFormatter {
 
-    private static long start = System.nanoTime();
+    static long start = System.currentTimeMillis();
     static String elapsedTime() {
-        return String.format("%8.3f", (System.nanoTime() - start) / 1_000_000_000.0);
+        return String.format("%8.3f", (System.currentTimeMillis() - start) / 1_000.0);
     }
 
     DeltaSupportLogFormatter() {
-        start = System.nanoTime(); // reset for each test, if using LoggerRule
+        start = System.currentTimeMillis(); // reset for each test, if using LoggerRule
     }
 
     @Override protected String formatTime(LogRecord record) {

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1092,6 +1092,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         private final String name;
         private final Map<String, Level> loggers;
         private final TaskListener stderr = StreamTaskListener.fromStderr();
+        private final long start = DeltaSupportLogFormatter.start;
         @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
         private static final List<Logger> loggerReferences = new LinkedList<>();
         RemoteLogDumper(String name, Map<String, Level> loggers) {
@@ -1117,6 +1118,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                 logger.addHandler(handler);
                 loggerReferences.add(logger);
             });
+            DeltaSupportLogFormatter.start = start; // match clock time on master
             stderr.getLogger().println("Set up log dumper on " + name + ": " + loggers);
             stderr.getLogger().flush();
             return null;

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1104,7 +1104,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                 final Formatter formatter = new DeltaSupportLogFormatter();
                 @Override public void publish(LogRecord record) {
                     if (isLoggable(record)) {
-                        stderr.getLogger().print(formatter.format(record).replaceAll("(?m)^", "[" + name + "] "));
+                        stderr.getLogger().print(formatter.format(record).replaceAll("(?m)^([ 0-9.]*)", "$1[" + name + "] "));
                         stderr.getLogger().flush();
                     }
                 }


### PR DESCRIPTION
While trying to use my new utility from #127, I kept on missing remote log messages, even (randomly) in the original use case of `FileLogStorageTest`. At first I suspected that https://github.com/jenkinsci/jenkins/pull/3961 was to blame, and indeed a `flush` call might be necessary, but I was running on an older core prior to this patch! Finally I recalled that `Logger` can be garbage-collected and your customizations lost. With this patch, I am getting messages reliably at last.