### PR TITLE
Remove unnecessary dependency on ant-launcher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,12 +246,6 @@ THE SOFTWARE.
             <artifactId>ant</artifactId>
             <version>1.10.6</version>
           </dependency>
-          <!-- Usually a dependency of ant, but some people seem to have an incomplete ant POM. See JENKINS-11416 -->
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-launcher</artifactId>
-            <version>1.8.0</version>
-          </dependency>
           <dependency>
             <groupId>org.codehaus.gmaven.runtime</groupId>
             <artifactId>gmaven-runtime-2.0</artifactId>


### PR DESCRIPTION
The dependency on `ant-launcher` was added in [JENKINS-11416](https://issues.jenkins-ci.org/browse/JENKINS-11416) in 2011 to work around a user-reported build issue. The user's Ant POM was missing the `ant-launcher` dependency. The [official Ant POM](https://search.maven.org/remotecontent?filepath=org/apache/ant/ant/1.10.6/ant-1.10.6.pom) declares this dependency, so it's unclear why the user was missing the dependency. In any case, it seems unlikely this workaround is still needed 8 years later (and even if it is, it would be easy to restore). Keeping this workaround in the source tree results in undesirable noise such as jenkinsci/jenkins-test-harness#152. It would be simpler to just remove the unnecessary dependency declaration.