### PR TITLE
Switch from GMaven to GMavenPlus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,17 +248,6 @@ THE SOFTWARE.
             <artifactId>ant</artifactId>
             <version>1.10.6</version>
           </dependency>
-          <!-- Usually a dependency of ant, but some people seem to have an incomplete ant POM. See JENKINS-11416 -->
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-launcher</artifactId>
-            <version>1.8.0</version>
-          </dependency>
-          <dependency>
-            <groupId>org.codehaus.gmaven.runtime</groupId>
-            <artifactId>gmaven-runtime-2.0</artifactId>
-            <version>1.5-jenkins-1</version>
-          </dependency>
         </dependencies>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -225,9 +225,9 @@ THE SOFTWARE.
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
-        <!-- version specified in grandparent pom -->
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.7.1</version>
         <executions>
           <execution>
             <id>preset-packager</id>
@@ -236,7 +236,9 @@ THE SOFTWARE.
               <goal>execute</goal>
             </goals>
             <configuration>
-              <source>${pom.basedir}/src/main/preset-data/package.groovy</source>
+              <scripts>
+                <script>file:///${pom.basedir}/src/main/preset-data/package.groovy</script>
+              </scripts>
             </configuration>
           </execution>
         </executions>
@@ -252,15 +254,7 @@ THE SOFTWARE.
             <artifactId>ant-launcher</artifactId>
             <version>1.8.0</version>
           </dependency>
-          <dependency>
-            <groupId>org.codehaus.gmaven.runtime</groupId>
-            <artifactId>gmaven-runtime-2.0</artifactId>
-            <version>1.5-jenkins-1</version>
-          </dependency>
         </dependencies>
-        <configuration>
-          <providerSelection>2.0</providerSelection>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Inspired by [jenkinsci/jenkins-test-harness#156 (comment)](https://github.com/jenkinsci/jenkins-test-harness/pull/156#pullrequestreview-267614033). Supersedes jenkinsci/jenkins-test-harness#156. This repository currently uses the GMavenPlugin to run a `package.groovy` to zip a few files during the build. The GMaven plugin is no longer maintained; active development is now taking place in the GMavenPlus project. Therefore, we switch to GMavenPlus.

After updating the group ID, artifact ID, and version, I got this error:

```
[ERROR] Failed to execute goal org.codehaus.gmavenplus:gmavenplus-plugin:1.7.1:execute (preset-packager) on project jenkins-test-harness: The parameters 'scripts' for goal org.codehaus.gmavenplus:gmavenplus-plugin:1.7.1:execute are missing or invalid -> [Help 1]
```

Looking into it further, I found that the calling conventions had changed. I updated them following the instructions in the [upstream wiki](https://github.com/groovy/GMavenPlus/wiki/Examples#execute-scripts).

With that, the goal passes, using the version of Groovy on the classpath from Jenkins core:

```
[INFO] --- gmavenplus-plugin:1.7.1:execute (preset-packager) @ jenkins-test-harness ---
[INFO] Using Groovy 2.4.8 to perform execute.
[INFO] Running Groovy script from file:////home/basil/work/third-party/jenkinsci/jenkins-test-harness/src/main/preset-data/package.groovy.
```