### PR TITLE
[JENKINS-58571] Fix default value for `isNameEditable()` on MockFolder.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
-      <version>2.110</version>
+      <version>2.60.3</version>
       <type>executable-war</type>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
-      <version>2.60.3</version>
+      <version>2.110</version>
       <type>executable-war</type>
       <exclusions>
         <exclusion>

--- a/src/main/java/org/jvnet/hudson/test/MockFolder.java
+++ b/src/main/java/org/jvnet/hudson/test/MockFolder.java
@@ -270,4 +270,9 @@ public class MockFolder extends AbstractItem implements DirectlyModifiableTopLev
             return new MockFolder(parent, name);
         }
     }
+
+    @Override
+    public boolean isNameEditable() {
+        return true;
+    }
 }

--- a/src/main/java/org/jvnet/hudson/test/MockFolder.java
+++ b/src/main/java/org/jvnet/hudson/test/MockFolder.java
@@ -271,7 +271,9 @@ public class MockFolder extends AbstractItem implements DirectlyModifiableTopLev
         }
     }
 
+    /* TODO uncomment when core dep ≥ 2.110:
     @Override
+    */
     public boolean isNameEditable() {
         return true;
     }


### PR DESCRIPTION
I need this modification to be able to merge this PR: https://github.com/jenkinsci/jenkins/pull/4122
Test are failing there because the default value for isNameEditable is false, and the PR add a protection when trying to rename a Item with isNameEditable false. MockFolder used in test does not override isNameEditable to true but it should.

The isNameEditable method is available only on jenkins-core > 2.110, so I upgrade jenkins-war to the first version including this method.