### PR TITLE
Update org-netbeans-insane from RELEASE802 to RELEASE111

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.netbeans.modules</groupId>
       <artifactId>org-netbeans-insane</artifactId>
-      <version>RELEASE802</version>
+      <version>RELEASE111</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
#155  continuation

https://mvnrepository.com/artifact/org.netbeans.modules/org-netbeans-insane/RELEASE802 is Date | (Nov 26, 2014) and it's placed in weird rpeo

Note `New Version | RELEASE111`
is (Aug 07, 2019) and it's in central repo!

@jglick what does netbeans do with all this versions and repos?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jenkins-test-harness/169)
<!-- Reviewable:end -->
