### PR TITLE
Add FunctionalInterface annotation to RestartableJenkinsRule.Step

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RestartableJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RestartableJenkinsRule.java
@@ -217,7 +217,7 @@ public class RestartableJenkinsRule implements MethodRule {
      * {@code Consumer} is the same, and is not present in Java 7.
      * Other candidates had similar issues.
      */
-    // TODO Java 8: @FunctionalInterface
+    @FunctionalInterface
     public interface Step {
         void run(JenkinsRule r) throws Throwable;
     }


### PR DESCRIPTION
#66 added a `Step` interface with a comment stating: "TODO Java 8: `@FunctionalInterface`". The Java level was set to 8 in #63, so this TODO can now be completed.