### PR TITLE
Bump HTMLUnit version from 2.31 to 2.36.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@ THE SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.5.v20170502</jetty.version>
     <hamcrest.version>2.2</hamcrest.version>
+    <htmlunit.version>2.36.0-1</htmlunit.version>
     <java.level>8</java.level>
     <concurrency>1</concurrency> <!-- may use e.g. 2C for 2 × (number of cores) -->
     <!--TODO: fix FindBugs-->
@@ -129,7 +130,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness-htmlunit</artifactId>
-      <version>2.31-2</version>
+      <version>${htmlunit.version}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/src/main/java/com/gargoylesoftware/htmlunit/WebClientUtil.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/WebClientUtil.java
@@ -136,5 +136,9 @@ public class WebClientUtil {
         @Override
         public void loadScriptError(HtmlPage htmlPage, URL scriptUrl, Exception exception) {
         }
+
+        @Override
+        public void warn(String message, String sourceName, int line, String lineSource, int lineOffset) {
+        }
     }
 }

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/DomNodeUtil.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/DomNodeUtil.java
@@ -24,7 +24,7 @@
 package com.gargoylesoftware.htmlunit.html;
 
 import com.gargoylesoftware.htmlunit.WebClientUtil;
-import com.gargoylesoftware.htmlunit.html.xpath.XPathUtils;
+import com.gargoylesoftware.htmlunit.html.xpath.XPathHelper;
 
 import java.util.List;
 
@@ -47,7 +47,7 @@ public class DomNodeUtil {
      */
     public static <E> List<E> selectNodes(final DomNode domNode, final String xpathExpr) {
         WebClientUtil.waitForJSExec(domNode.getPage().getWebClient());
-        return (List) XPathUtils.getByXPath(domNode, xpathExpr, null);
+        return (List) XPathHelper.getByXPath(domNode, xpathExpr, null, false);
     }
 
     /**


### PR DESCRIPTION
Followup to https://github.com/jenkinsci/jenkins-test-harness-htmlunit/pull/5.

Required for https://github.com/jenkinsci/warnings-ng-plugin/pull/258.
