### PR TITLE
Update `JenkinsRule#waitOnline()` to wait for all launchable agents, not just for `JNLPLauncher` implementations

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -220,7 +220,6 @@ import hudson.init.InitMilestone;
 import hudson.model.Job;
 import hudson.model.Slave;
 import hudson.model.queue.QueueTaskFuture;
-import hudson.slaves.JNLPLauncher;
 
 import java.net.HttpURLConnection;
 import java.nio.channels.ClosedByInterruptException;
@@ -231,7 +230,6 @@ import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.security.MasterToSlaveCallable;
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.Timeout;
 import org.junit.runners.model.TestTimedOutException;
@@ -1052,7 +1050,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      */
     public void waitOnline(Slave s) throws Exception {
         Computer computer = s.toComputer();
-        if (s.getLauncher() instanceof JNLPLauncher) {
+        if (!s.getLauncher().isLaunchSupported()) {
             while (!computer.isOnline()) {
                 Thread.sleep(100);
             }


### PR DESCRIPTION
Just noticed that #80 was overly specific: there is already an API method for inbound vs. outbound launchers.