### PR TITLE
Update Java Microbenchmark Harness to 1.22, use a single property to manage dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@ THE SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.24.v20191120</jetty.version>
     <hamcrest.version>2.2</hamcrest.version>
+    <jmh.version>1.22</jmh.version>
     <java.level>8</java.level>
     <concurrency>1</concurrency> <!-- may use e.g. 2C for 2 × (number of cores) -->
     <!--TODO: fix FindBugs-->
@@ -177,12 +178,12 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>1.21</version>
+      <version>${jmh.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
-      <version>1.21</version>
+      <version>${jmh.version}</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Should integrate #178 and #176 