### PR TITLE
[JENKINS-55381] Add test for TestCrumbIssuer compatibility with JCasC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,12 @@ THE SOFTWARE.
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>1.21</version>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>1.34</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/test/java/org/jvnet/hudson/test/TestCrumbIssuerConfigurationAsCodeTest.java
+++ b/src/test/java/org/jvnet/hudson/test/TestCrumbIssuerConfigurationAsCodeTest.java
@@ -1,0 +1,38 @@
+package org.jvnet.hudson.test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.jvnet.hudson.test.LoggerRule.recorded;
+
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.snakeyaml.Yaml;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.logging.Level;
+
+public class TestCrumbIssuerConfigurationAsCodeTest {
+
+    private final JenkinsRule j = new JenkinsRule();
+    private final LoggerRule logRule = new LoggerRule().record("io.jenkins.plugins.casc", Level.INFO).capture(1000);
+
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(j).around(logRule);
+
+    @Test
+    public void testCrumpIssuerShouldBeSupportedWhenExportingConfiguration() throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ConfigurationAsCode.get().export(outputStream);
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+        String configuration = new Yaml().load(inputStream).toString();
+
+        assertThat(configuration, containsString("crumbIssuer"));
+        assertThat(configuration, not(containsString("FAILED TO EXPORT")));
+        assertThat(logRule, not(recorded(containsString("Configuration-as-Code can't handle type class org.jvnet.hudson.test.TestCrumbIssuer"))));
+    }
+}


### PR DESCRIPTION
Now that Jenkins 2.60.3 is used, this test can be added. It was originally provided already as #120 to test #119 but could not be merged at that time due to the dependency on a newer Jenkins version.