### PR TITLE
Add the GitHub repo URLs to the Maven metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,13 @@ THE SOFTWARE.
   <version>${revision}${changelist}</version>
 
   <name>Test harness for Jenkins and plugins</name>
+  <url>https://github.com/jenkinsci/jenkins-test-harness</url>
   <description>Harness used to run functional tests of Jenkins core and plugins.</description>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}.git</developerConnection>
-    <url>https://github.com/jenkinsci/${project.artifactId}</url>
+    <url>https://github.com/jenkinsci/jenkins-test-harness</url>
     <tag>${scmTag}</tag>
   </scm>
 


### PR DESCRIPTION
I doubt dependabot can resolve variables in the URL as it reading XML directly instead of parsing variables.