### PR TITLE
[JENKINS-60694] Do not use defaults for acceptors & selectors

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -522,7 +522,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         context.setMimeTypes(MIME_TYPES);
         context.getSecurityHandler().setLoginService(configureUserRealm());
 
-        ServerConnector connector = new ServerConnector(server);
+        ServerConnector connector = new ServerConnector(server, 1, 1);
 
         HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL

--- a/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
+++ b/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
@@ -43,7 +43,7 @@ public class JavaNetReverseProxy extends HttpServlet {
         ServletContextHandler root = new ServletContextHandler(contexts, "/", ServletContextHandler.SESSIONS);
         root.addServlet(new ServletHolder(this), "/");
 
-        ServerConnector connector = new ServerConnector(server);
+        ServerConnector connector = new ServerConnector(server, 1, 1);
         server.addConnector(connector);
         server.start();
 


### PR DESCRIPTION
I think this fixes [JENKINS-60694](https://issues.jenkins-ci.org/browse/JENKINS-60694). Just copies the fix from #69 to `HudsonTestCase` which I should have done to begin with.