### PR TITLE
[JENKINS-58771] Warn if ChannelShutdownListener loaded outside of a test context

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/ChannelShutdownListener.java
+++ b/src/main/java/org/jvnet/hudson/test/ChannelShutdownListener.java
@@ -1,6 +1,7 @@
 package org.jvnet.hudson.test;
 
 import hudson.Extension;
+import hudson.Main;
 import hudson.model.Computer;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
@@ -10,6 +11,7 @@ import hudson.slaves.ComputerListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * Runs at the end of the test to cleanup any live channels.
@@ -22,6 +24,12 @@ public class ChannelShutdownListener extends ComputerListener implements EndOfTe
      * Remember channels that are created, to release them at the end.
      */
     private List<Channel> channels = new ArrayList<Channel>();
+
+    public ChannelShutdownListener() {
+        if (!Main.isUnitTest) {
+            Logger.getLogger(ChannelShutdownListener.class.getName()).severe(() -> "JENKINS-58771: Jenkins test harness code being loaded in what seems to be a production system, perhaps causing critical memory leaks: " + ChannelShutdownListener.class.getProtectionDomain().getCodeSource().getLocation());
+        }
+    }
 
     @Override
     public synchronized void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {


### PR DESCRIPTION
Has happened multiple times especially prior to https://github.com/jenkinsci/maven-hpi-plugin/pull/140 that `ChannelShutdownListener` is found in customer heap dumps, apparently due to mispackaged plugins. This can lead to memory leaks as every `Channel` ever created (and all of its `ExportTable`s etc.) gets held onto.

This should warn about it, and make it clear where the culprit is, such as `/var/lib/jenkins/plugins/xray-for-jira-connector/WEB-INF/lib/jenkins-test-harness-2.13.jar` from [XRAYJENKINS-55](https://jira.xpand-it.com/browse/XRAYJENKINS-55).