### PR TITLE
[JENKINS-60821] let Jetty configure its own defaults

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -506,7 +506,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      */
     protected ServletContext createWebServer() throws Exception {
         QueuedThreadPool qtp = new QueuedThreadPool();
-        qtp.setName("Jetty Thread Pool (HudsonTestCase)");
+        qtp.setName("Jetty (HudsonTestCase)");
         server = new Server(qtp);
 
         explodedWarDir = WarExploder.getExplodedDir();

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -133,6 +133,7 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.security.Password;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
@@ -504,7 +505,9 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      * that we need for testing.
      */
     protected ServletContext createWebServer() throws Exception {
-        server = new Server();
+        QueuedThreadPool qtp = new QueuedThreadPool();
+        qtp.setName("Jetty Thread Pool (HudsonTestCase)");
+        server = new Server(qtp);
 
         explodedWarDir = WarExploder.getExplodedDir();
         WebAppContext context = new WebAppContext(explodedWarDir.getPath(), contextPath);

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -504,13 +504,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      * that we need for testing.
      */
     protected ServletContext createWebServer() throws Exception {
-        server = new Server(new ThreadPoolImpl(new ThreadPoolExecutor(10, 10, 10L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(),new ThreadFactory() {
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setName("Jetty Thread Pool");
-                return t;
-            }
-        })));
+        server = new Server();
 
         explodedWarDir = WarExploder.getExplodedDir();
         WebAppContext context = new WebAppContext(explodedWarDir.getPath(), contextPath);
@@ -522,7 +516,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         context.setMimeTypes(MIME_TYPES);
         context.getSecurityHandler().setLoginService(configureUserRealm());
 
-        ServerConnector connector = new ServerConnector(server, 1, 1);
+        ServerConnector connector = new ServerConnector(server);
 
         HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL

--- a/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
+++ b/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
@@ -43,7 +43,7 @@ public class JavaNetReverseProxy extends HttpServlet {
         ServletContextHandler root = new ServletContextHandler(contexts, "/", ServletContextHandler.SESSIONS);
         root.addServlet(new ServletHolder(this), "/");
 
-        ServerConnector connector = new ServerConnector(server, 1, 1);
+        ServerConnector connector = new ServerConnector(server);
         server.addConnector(connector);
         server.start();
 

--- a/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
+++ b/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
@@ -8,7 +8,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -34,8 +34,9 @@ public class JavaNetReverseProxy extends HttpServlet {
     public JavaNetReverseProxy(File cacheFolder) throws Exception {
         this.cacheFolder = cacheFolder;
         cacheFolder.mkdirs();
-
-        server = new Server();
+        QueuedThreadPool qtp = new QueuedThreadPool();
+        qtp.setName("Jetty Thread Pool (JavaNetReverseProxy)");
+        server = new Server(qtp);
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         server.setHandler(contexts);

--- a/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
+++ b/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
@@ -35,7 +35,7 @@ public class JavaNetReverseProxy extends HttpServlet {
         this.cacheFolder = cacheFolder;
         cacheFolder.mkdirs();
         QueuedThreadPool qtp = new QueuedThreadPool();
-        qtp.setName("Jetty Thread Pool (JavaNetReverseProxy)");
+        qtp.setName("Jetty (JavaNetReverseProxy)");
         server = new Server(qtp);
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -733,13 +733,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                                                                          ClassLoader classLoader, int localPort,
                                                                          Supplier<LoginService> loginServiceSupplier)
             throws Exception {
-        Server server = new Server(new ThreadPoolImpl(new ThreadPoolExecutor(10, 10, 10L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(), new ThreadFactory() {
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setName("Jetty Thread Pool");
-                return t;
-            }
-        })));
+        Server server = new Server();
 
         WebAppContext context = new WebAppContext(WarExploder.getExplodedDir().getPath(), contextPath);
         context.setClassLoader(classLoader);
@@ -750,7 +744,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         context.getSecurityHandler().setLoginService(loginServiceSupplier.get());
         context.setResourceBase(WarExploder.getExplodedDir().getPath());
 
-        ServerConnector connector = new ServerConnector(server, 1, 1);
+        ServerConnector connector = new ServerConnector(server);
         HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
         config.setRequestHeaderSize(12 * 1024);

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -197,6 +197,7 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.security.Password;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
@@ -733,7 +734,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                                                                          ClassLoader classLoader, int localPort,
                                                                          Supplier<LoginService> loginServiceSupplier)
             throws Exception {
-        Server server = new Server();
+        QueuedThreadPool qtp = new QueuedThreadPool();
+        qtp.setName("Jetty Thread Pool (JenkinsRule)");
+        Server server = new Server(qtp);
 
         WebAppContext context = new WebAppContext(WarExploder.getExplodedDir().getPath(), contextPath);
         context.setClassLoader(classLoader);

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -735,7 +735,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                                                                          Supplier<LoginService> loginServiceSupplier)
             throws Exception {
         QueuedThreadPool qtp = new QueuedThreadPool();
-        qtp.setName("Jetty Thread Pool (JenkinsRule)");
+        qtp.setName("Jetty (JenkinsRule)");
         Server server = new Server(qtp);
 
         WebAppContext context = new WebAppContext(WarExploder.getExplodedDir().getPath(), contextPath);


### PR DESCRIPTION
[JENKINS-60821](https://issues.jenkins-ci.org/browse/JENKINS-60821)
Jetty knows better than us, so let Jetty configure its own defaults for the ThreadPool (min 8 max 200) and #acceptor/selector threads.

This applies feedback from eclipse/jetty.project#4492

Whilst we are here - give all of the Jetty Thread pools different names so it is obvious which pool is which