### PR TITLE
[JENKINS-61031] Fixed download of SVG images

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -174,6 +174,8 @@ import java.net.HttpURLConnection;
 
 import jenkins.model.JenkinsLocationConfiguration;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * Base class for all Jenkins test cases.
  *
@@ -950,17 +952,23 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         assertTrue("needle found in haystack", found); 
     }
 
+    public void assertImageLoadsSuccessfully(HtmlImage img) {
+        try {
+            assertEquals("Failed to load " + img.getSrcAttribute(),
+                    200,
+                    img.getWebResponse(true).getStatusCode());
+        } catch (IOException e) {
+            throw new Error("Failed to load " + img.getSrcAttribute());
+        }
+    }
+
     /**
      * Makes sure that all the images in the page loads successfully.
      * (By default, HtmlUnit doesn't load images.)
      */
     public void assertAllImageLoadSuccessfully(HtmlPage p) {
         for (HtmlImage img : DomNodeUtil.<HtmlImage>selectNodes(p, "//IMG")) {
-            try {
-                img.getHeight();
-            } catch (IOException e) {
-                throw new Error("Failed to load "+img.getSrcAttribute(),e);
-            }
+            assertImageLoadsSuccessfully(img);
         }
     }
 

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -952,15 +952,6 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         assertTrue("needle found in haystack", found); 
     }
 
-    public void assertImageLoadsSuccessfully(HtmlImage img) {
-        try {
-            assertEquals("Failed to load " + img.getSrcAttribute(),
-                    200,
-                    img.getWebResponse(true).getStatusCode());
-        } catch (IOException e) {
-            throw new AssertionError("Failed to load " + img.getSrcAttribute());
-        }
-    }
 
     /**
      * Makes sure that all the images in the page loads successfully.
@@ -968,7 +959,13 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      */
     public void assertAllImageLoadSuccessfully(HtmlPage p) {
         for (HtmlImage img : DomNodeUtil.<HtmlImage>selectNodes(p, "//IMG")) {
-            assertImageLoadsSuccessfully(img);
+            try {
+                assertEquals("Failed to load " + img.getSrcAttribute(),
+                        200,
+                        img.getWebResponse(true).getStatusCode());
+            } catch (IOException e) {
+                throw new AssertionError("Failed to load " + img.getSrcAttribute());
+            }
         }
     }
 

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -958,7 +958,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
                     200,
                     img.getWebResponse(true).getStatusCode());
         } catch (IOException e) {
-            throw new Error("Failed to load " + img.getSrcAttribute());
+            throw new AssertionError("Failed to load " + img.getSrcAttribute());
         }
     }
 

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1506,17 +1506,23 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         assertThat("needle found in haystack", found, is(true));
     }
 
+
+    public void assertImageLoadsSuccessfully(HtmlImage img) {
+        try {
+            assertEquals(img.getWebResponse(true).getStatusCode(), 200);
+        } catch (IOException e) {
+            throw new Error("Failed to load "+img.getSrcAttribute());
+        }
+    }
+
+
     /**
      * Makes sure that all the images in the page loads successfully.
      * (By default, HtmlUnit doesn't load images.)
      */
     public void assertAllImageLoadSuccessfully(HtmlPage p) {
         for (HtmlImage img : DomNodeUtil.<HtmlImage>selectNodes(p, "//IMG")) {
-            try {
-                img.getHeight();
-            } catch (IOException e) {
-                throw new Error("Failed to load "+img.getSrcAttribute(),e);
-            }
+            assertImageLoadsSuccessfully(img);
         }
     }
 

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1507,24 +1507,19 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
 
-    public void assertImageLoadsSuccessfully(HtmlImage img) {
-        try {
-            assertEquals("Failed to load " + img.getSrcAttribute(),
-                    200,
-                    img.getWebResponse(true).getStatusCode());
-        } catch (IOException e) {
-            throw new AssertionError("Failed to load " + img.getSrcAttribute());
-        }
-    }
-
-
     /**
      * Makes sure that all the images in the page loads successfully.
      * (By default, HtmlUnit doesn't load images.)
      */
     public void assertAllImageLoadSuccessfully(HtmlPage p) {
         for (HtmlImage img : DomNodeUtil.<HtmlImage>selectNodes(p, "//IMG")) {
-            assertImageLoadsSuccessfully(img);
+            try {
+                assertEquals("Failed to load " + img.getSrcAttribute(),
+                        200,
+                        img.getWebResponse(true).getStatusCode());
+            } catch (IOException e) {
+                throw new AssertionError("Failed to load " + img.getSrcAttribute());
+            }
         }
     }
 

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1513,7 +1513,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                     200,
                     img.getWebResponse(true).getStatusCode());
         } catch (IOException e) {
-            throw new Error("Failed to load " + img.getSrcAttribute());
+            throw new AssertionError("Failed to load " + img.getSrcAttribute());
         }
     }
 

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1509,7 +1509,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
     public void assertImageLoadsSuccessfully(HtmlImage img) {
         try {
-            assertEquals(img.getWebResponse(true).getStatusCode(), 200);
+            assertEquals("Failed to load " + img.getSrcAttribute(),
+                    200,
+                    img.getWebResponse(true).getStatusCode());
         } catch (IOException e) {
             throw new Error("Failed to load " + img.getSrcAttribute());
         }

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1511,7 +1511,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         try {
             assertEquals(img.getWebResponse(true).getStatusCode(), 200);
         } catch (IOException e) {
-            throw new Error("Failed to load "+img.getSrcAttribute());
+            throw new Error("Failed to load " + img.getSrcAttribute());
         }
     }
 


### PR DESCRIPTION
[JENKINS-61031](https://issues.jenkins-ci.org/browse/JENKINS-61031)

- JenkinsRule#assertAllImageLoadSuccessfully no longer breaks when download images on the format `<img src="/example.svg" />`
- Refactored and added a JenkinsRule#assertImageLoadsSuccessfully to implement the same test but for single images

#### Desired reviewers
@timja 
@fcojfernandez 

### Explanation

I have change the way of testing whether images were download to just check for the status code. That way it's format-agnostic.

I appreciate suggestions for how to add unit tests for this one.