### PR TITLE
[JENKINS-60410] Disable stack trace suppression for tests.

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2682,6 +2682,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         {// enable debug assistance, since tests are often run from IDE
             Dispatcher.TRACE = true;
             MetaClass.NO_CACHE=true;
+            System.setProperty("jenkins.model.Jenkins.SHOW_STACK_TRACE", "true");
             // load resources from the source dir.
             File dir = new File("src/main/resources");
             if(dir.exists() && MetaClassLoader.debugLoader==null)


### PR DESCRIPTION
If this property is set and if the changes in jenkinscis/jenkins#4389 are active, then this changes the default behavior to show full stack traces. (It enables stack traces.) If the property isn't set with 4389 then stack traces are suppressed and some tests that check error results fail. If the property is set without 4389 then it's a no-op.

This matches other existing behavior. See the nearby line for allowing Dispatcher tracing, `Dispatcher.TRACE`.

It makes testing and troubleshooting a little easier.