### PR TITLE
Make this compile again with a Jenkins 2.61+ dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
-      <version>2.60.3</version>
+      <version>2.73.3</version>
       <type>executable-war</type>
       <exclusions>
         <exclusion>

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1364,7 +1364,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     @Nonnull
-    public <J extends Job<J,R> & ParameterizedJobMixIn.ParameterizedJob,R extends Run<J,R> & Queue.Executable> R buildAndAssertSuccess(@Nonnull J job) throws Exception {
+    public <J extends Job<J,R> & ParameterizedJobMixIn.ParameterizedJob<J,R>,R extends Run<J,R> & Queue.Executable> R buildAndAssertSuccess(@Nonnull J job) throws Exception {
         return buildAndAssertStatus(Result.SUCCESS, job);
     }
 
@@ -1373,7 +1373,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * @since TODO
      */
     @Nonnull
-    public <J extends Job<J,R> & ParameterizedJobMixIn.ParameterizedJob,R extends Run<J,R> & Queue.Executable> R buildAndAssertStatus(@Nonnull Result status, @Nonnull J job) throws Exception {
+    public <J extends Job<J,R> & ParameterizedJobMixIn.ParameterizedJob<J,R>,R extends Run<J,R> & Queue.Executable> R buildAndAssertStatus(@Nonnull Result status, @Nonnull J job) throws Exception {
         final QueueTaskFuture<R> f = new ParameterizedJobMixIn<J, R>() {
             @Override protected J asJob() {
                 return job;


### PR DESCRIPTION
Looks like https://github.com/jenkinsci/jenkins/pull/2864 and https://github.com/jenkinsci/jenkins-test-harness/pull/167 don't work well together.

Untested.