### PR TITLE
Add WithTimeout support for JUnit4

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/recipes/WithTimeout.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/WithTimeout.java
@@ -24,6 +24,8 @@
 package org.jvnet.hudson.test.recipes;
 
 import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRecipe;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.lang.annotation.Documented;
 import static java.lang.annotation.ElementType.METHOD;
@@ -41,6 +43,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Recipe(WithTimeout.RunnerImpl.class)
+@JenkinsRecipe(WithTimeout.RunnerImpl4.class)
 @Target(METHOD)
 @Retention(RUNTIME)
 public @interface WithTimeout {
@@ -51,10 +54,25 @@ public @interface WithTimeout {
      */
     int value();
 
+    /**
+     * For JUnit 3 tests extending HudsonTestCase
+     * @deprecated New code should use {@link JenkinsRule}.
+     */
+    @Deprecated
     class RunnerImpl extends Recipe.Runner<WithTimeout> {
         @Override
         public void setup(HudsonTestCase testCase, WithTimeout recipe) throws Exception {
             testCase.timeout = recipe.value();
+        }
+    }
+
+    /**
+     * For JUnit 4 tests using JenkinsRule
+     */
+    class RunnerImpl4 extends JenkinsRecipe.Runner<WithTimeout> {
+        @Override 
+        public void setup(JenkinsRule jenkinsRule, WithTimeout recipe) throws Exception {
+            jenkinsRule.timeout = recipe.value();
         }
     }
 }


### PR DESCRIPTION
Useful during debugging to avoid writing:

```
{j.timeout = 0;}
```

Nothing depends on this improvement :)