### PR TITLE
waitForCompletion should wait for !Run.logUpdated even after !Run.building

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1461,7 +1461,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      */
     public <R extends Run<?,?>> R waitForCompletion(R r) throws InterruptedException {
         // Could be using com.jayway.awaitility:awaitility but it seems like overkill here.
-        while (r.isBuilding()) {
+        while (r.isLogUpdated()) {
             Thread.sleep(100);
         }
         return r;


### PR DESCRIPTION
I think this is the root of many of the flakes surrounding `WorkflowRun.finish`, like https://github.com/jenkinsci/workflow-job-plugin/pull/158. For both traditional job types (https://github.com/jenkinsci/jenkins/blob/449c5aced523a6e66fe3d6a804e5dbfd5c5c67c6/core/src/main/java/hudson/model/Run.java#L520-L537) and Pipeline (https://github.com/jenkinsci/workflow-job-plugin/blob/5323c277aaa1194f899e8e320bb7246f2bbcc24f/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java#L778-L779), `!Run.logUpdated` is stronger than `!Run.building`, so we ought to wait for the build to _really_ be completed.