### PR TITLE
Revert the change with WithTimeout

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -322,6 +322,10 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
     /**
      * Number of seconds until the test times out.
+     * 
+     * The {@link WithTimeout} rule can be used to specify this value per test.
+     * 
+     * In case of debugging session, the default timeout behavior is removed. Otherwise it's set to 3 minutes. 
      */
     public int timeout = Integer.getInteger("jenkins.test.timeout", new DisableOnDebug(null).isDebugging() ? 0 : 180);
 

--- a/src/main/java/org/jvnet/hudson/test/recipes/WithTimeout.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/WithTimeout.java
@@ -37,14 +37,13 @@ import java.lang.annotation.Target;
  *
  * All the tests time out after some number of seconds by default, but this recipe
  * allows you to override that value.
- * 
- * No need for @JenkinsRecipe in JUnit 4 as it's implemented directly in {@link JenkinsRule} 
- * by the private method: getTestTimeoutOverride.
  *
  * @author Kohsuke Kawaguchi
  */
 @Documented
 @Recipe(WithTimeout.RunnerImpl.class)
+// No need for @JenkinsRecipe in JUnit 4 as it's implemented directly in JenkinsRule 
+// by the private method: getTestTimeoutOverride.
 @Target(METHOD)
 @Retention(RUNTIME)
 public @interface WithTimeout {

--- a/src/main/java/org/jvnet/hudson/test/recipes/WithTimeout.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/WithTimeout.java
@@ -24,7 +24,6 @@
 package org.jvnet.hudson.test.recipes;
 
 import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.JenkinsRecipe;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.lang.annotation.Documented;
@@ -38,12 +37,14 @@ import java.lang.annotation.Target;
  *
  * All the tests time out after some number of seconds by default, but this recipe
  * allows you to override that value.
+ * 
+ * No need for @JenkinsRecipe in JUnit 4 as it's implemented directly in {@link JenkinsRule} 
+ * by the private method: getTestTimeoutOverride.
  *
  * @author Kohsuke Kawaguchi
  */
 @Documented
 @Recipe(WithTimeout.RunnerImpl.class)
-@JenkinsRecipe(WithTimeout.RunnerImpl4.class)
 @Target(METHOD)
 @Retention(RUNTIME)
 public @interface WithTimeout {
@@ -62,17 +63,8 @@ public @interface WithTimeout {
     class RunnerImpl extends Recipe.Runner<WithTimeout> {
         @Override
         public void setup(HudsonTestCase testCase, WithTimeout recipe) throws Exception {
+            System.out.println("RunnerImpl call");
             testCase.timeout = recipe.value();
-        }
-    }
-
-    /**
-     * For JUnit 4 tests using JenkinsRule
-     */
-    class RunnerImpl4 extends JenkinsRecipe.Runner<WithTimeout> {
-        @Override 
-        public void setup(JenkinsRule jenkinsRule, WithTimeout recipe) throws Exception {
-            jenkinsRule.timeout = recipe.value();
         }
     }
 }

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTest.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTest.java
@@ -159,7 +159,7 @@ public class JenkinsRuleTimeoutTest {
     @Test 
     @WithTimeout(15)
     public void withTimeoutPropagation() throws Exception {
-        Thread.sleep(1000 * 15);
+        Thread.sleep(1000 * 20);
         fail("Should have been interrupted");
     }
 }

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTest.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTest.java
@@ -156,9 +156,10 @@ public class JenkinsRuleTimeoutTest {
         }
     }
 
-    @Test @WithTimeout(20)
+    @Test 
+    @WithTimeout(15)
     public void withTimeoutPropagation() throws Exception {
-        Thread.sleep(1000 * 30);
+        Thread.sleep(1000 * 15);
         fail("Should have been interrupted");
     }
 }


### PR DESCRIPTION
It was already implemented directly in JenkinsRule, private method: getTestTimeoutOverride
I updated a test case that was not asserting something useful.

Revert #209 + update test.

@jglick @MarkEWaite as reviewers of the first one