### PR TITLE
BuildWatcher should ignore any Throwable when Jenkins is not up

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/BuildWatcher.java
+++ b/src/main/java/org/jvnet/hudson/test/BuildWatcher.java
@@ -130,7 +130,7 @@ public final class BuildWatcher extends ExternalResource {
                 // Anyway we can just rely on onFinalized to let us know when to stop.
             } catch (FileNotFoundException x) {
                 // build deleted or not started
-            } catch (Exception x) {
+            } catch (Throwable x) {
                 if (Jenkins.getInstance() != null) {
                     x.printStackTrace();
                 } else {


### PR DESCRIPTION
Otherwise when using `RestartableJenkinsRule` you can get log spam such as

```
…
  13.076 [id=1]	INFO	jenkins.model.Jenkins#cleanUp: Jenkins stopped
Test timeout disabled.
=== Starting …
   0.012 [id=1]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:33923/jenkins/
   0.153 [id=15]	SEVERE	h.i.i.InstallUncaughtExceptionHandler$DefaultUncaughtExceptionHandler#uncaughtException: A thread (watching builds/15) died unexpectedly due to an uncaught exception, this may leave your Jenkins in a bad way and is usually indicative of a bug in the code.
java.lang.AssertionError: class org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject is missing its descriptor
	at jenkins.model.Jenkins.getDescriptorOrDie(Jenkins.java:1600)
	at com.cloudbees.hudson.plugins.folder.AbstractFolder.getDescriptor(AbstractFolder.java:597)
	at jenkins.branch.MultiBranchProject.getDescriptor(MultiBranchProject.java:873)
	at jenkins.branch.MultiBranchProject.getDescriptor(MultiBranchProject.java:125)
	at com.cloudbees.hudson.plugins.folder.AbstractFolder.childNameGenerator(AbstractFolder.java:589)
	at com.cloudbees.hudson.plugins.folder.AbstractFolder.getRootDirFor(AbstractFolder.java:632)
	at jenkins.branch.MultiBranchProject.getRootDirFor(MultiBranchProject.java:853)
	at jenkins.branch.MultiBranchProject.getRootDirFor(MultiBranchProject.java:125)
	at hudson.model.AbstractItem.getRootDir(AbstractItem.java:200)
	at jenkins.model.Jenkins.expandVariablesForDirectory(Jenkins.java:2505)
	at jenkins.model.Jenkins.getBuildDirFor(Jenkins.java:2486)
	at hudson.model.Job.getBuildDir(Job.java:882)
	at hudson.model.Run.getRootDir(Run.java:1078)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.getRootDir(WorkflowRun.java:973)
	at org.jenkinsci.plugins.workflow.log.LogStorage.of(LogStorage.java:171)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.getLogText(WorkflowRun.java:1046)
	at org.jvnet.hudson.test.BuildWatcher$RunningBuild.copy(BuildWatcher.java:126)
	at org.jvnet.hudson.test.BuildWatcher$1.run(BuildWatcher.java:64)
   0.163 [id=127]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
…
```
