### PR TITLE
Added FlagRule

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/FlagRule.java
+++ b/src/main/java/org/jvnet/hudson/test/FlagRule.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.test;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TestRule;
+
+/**
+ * Saves and restores sort of a flag, such as a {@code static} field or system property.
+ */
+public final class FlagRule<T> extends ExternalResource {
+
+    private final Supplier<T> getter;
+    private final Consumer<T> setter;
+    private final T replacement;
+    private T orig;
+
+    public FlagRule(Supplier<T> getter, Consumer<T> setter, T replacement) {
+        this.getter = getter;
+        this.setter = setter;
+        this.replacement = replacement;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        orig = getter.get();
+        setter.accept(replacement);
+    }
+
+    @Override
+    protected void after() {
+        setter.accept(orig);
+    }
+
+}

--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
@@ -49,7 +49,8 @@ public class TemporaryDirectoryAllocator {
      * Whether there should be a space character in the allocated temporary directories names.
      * It forces slaves created from a {@link JenkinsRule} to work inside a hazardous path,
      * which can help catching shell quoting bugs.<br>
-     * This option is controlled by the <code>jenkins.test.noSpaceInTmpDirs</code> system property.
+     * If a particular test cannot be readily fixed to tolerate spaces, as a workaround try:
+     * {@code @ClassRule public static TestRule noSpaceInTmpDirs = FlagRule.systemProperty("jenkins.test.noSpaceInTmpDirs", "true");}
      */
     private final boolean withoutSpace = Boolean.getBoolean("jenkins.test.noSpaceInTmpDirs");
 

--- a/src/test/java/org/jvnet/hudson/test/FlagRuleNoReplacementTest.java
+++ b/src/test/java/org/jvnet/hudson/test/FlagRuleNoReplacementTest.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.test;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+
+public class FlagRuleNoReplacementTest {
+
+    private static boolean FLAG;
+
+    @BeforeClass
+    public static void start() {
+        assertFalse(FLAG);
+    }
+
+    @AfterClass
+    public static void end() {
+        assertFalse(FLAG);
+    }
+
+    @Rule
+    public TestRule flagRule = new FlagRule<Boolean>(() -> FLAG, x -> FLAG = x);
+
+    @Test
+    public void smokes() {
+        assertFalse(FLAG);
+        FLAG = true;
+    }
+
+}

--- a/src/test/java/org/jvnet/hudson/test/FlagRuleReplacementTest.java
+++ b/src/test/java/org/jvnet/hudson/test/FlagRuleReplacementTest.java
@@ -31,7 +31,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 
-public class FlagRuleTest {
+public class FlagRuleReplacementTest {
 
     private static boolean FLAG;
 

--- a/src/test/java/org/jvnet/hudson/test/FlagRuleSystemPropertyTest.java
+++ b/src/test/java/org/jvnet/hudson/test/FlagRuleSystemPropertyTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.test;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+
+public class FlagRuleSystemPropertyTest {
+
+    @BeforeClass
+    public static void start() {
+        assertNull(System.getProperty("some.key"));
+    }
+
+    @AfterClass
+    public static void end() {
+        assertNull(System.getProperty("some.key"));
+    }
+
+    @Rule
+    public TestRule flagRule = FlagRule.systemProperty("some.key", "value");
+
+    @Test
+    public void smokes() {
+        assertEquals("value", System.getProperty("some.key"));
+    }
+
+}

--- a/src/test/java/org/jvnet/hudson/test/FlagRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/FlagRuleTest.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.test;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+
+public class FlagRuleTest {
+
+    private static boolean FLAG;
+
+    @BeforeClass
+    public static void start() {
+        assertFalse(FLAG);
+    }
+
+    @AfterClass
+    public static void end() {
+        assertFalse(FLAG);
+    }
+
+    @Rule
+    public TestRule flagRule = new FlagRule<Boolean>(() -> FLAG, x -> FLAG = x, true);
+
+    @Test
+    public void smokes() {
+        assertTrue(FLAG);
+    }
+
+}


### PR DESCRIPTION
A lot of Jenkins tests turn on some hidden flag defined by static variable, so it would be convenient to not need `@Before` & `@After` methods for this common idiom.
