### PR TITLE
withBasicApiToken should create the user as needed

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2724,8 +2724,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
          * @since 2.32
          */
         public @Nonnull WebClient withBasicApiToken(@Nonnull String userId){
-            User user = User.getById(userId, false);
-            assertNotNull("The userId must correspond to an already created User", user);
+            User user = User.getById(userId, true);
             return withBasicApiToken(user);
         }
 


### PR DESCRIPTION
Otherwise if you are using e.g.

```java
r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
```

you have to add a superfluous

```java
User.getById("admin", true);
```

before calling

```java
r.createWebClient().withBasicApiToken("admin");
```
