### PR TITLE
Suppress more core CSS warnings

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2266,7 +2266,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                     String uri = exception.getURI();
                     return uri.contains("/yui/")
                         // TODO JENKINS-14749: these are a mess today, and we know that
-                        || uri.contains("/css/style.css") || uri.contains("/css/responsive-grid.css");
+                        || uri.contains("/css/style.css") || uri.contains("/css/responsive-grid.css") || uri.contains("/base-styles-v2.css");
                 }
             });
 


### PR DESCRIPTION
Looks like core reorganized CSS stuff without adapting the test harness accordingly, resulting in unnecessary log spam in plugin tests using `JenkinsRule.WebClient`.

FYI @timja @fqueiruga 

## Before (2.71)

```
   0.093 [id=16]	INFO	o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at /Users/danielbeck/Repositories/github.com/daniel-beck/matrix-auth-plugin/target/jenkins-for-test
   0.381 [id=16]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:57024/jenkins/
   0.663 [id=30]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.930 [id=41]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins13091184227555156879/plugins/command-launcher.jpi
   0.952 [id=41]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins13091184227555156879/plugins/jdk-tool.jpi
   0.975 [id=41]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins13091184227555156879/plugins/trilead-api.jpi
   1.013 [id=41]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins13091184227555156879/plugins/jaxb.jpi
   1.102 [id=41]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins13091184227555156879/plugins/bouncycastle-api.jpi
   2.109 [id=41]	WARNING	hudson.ClassicPluginStrategy#createClassJarFromWebInfClasses: Created /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins13091184227555156879/plugins/job-dsl/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness
   2.659 [id=35]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   2.713 [id=50]	INFO	j.b.a.SecurityProviderInitializer#addSecurityProvider: Initializing Bouncy Castle security provider.
   2.848 [id=50]	INFO	j.b.a.SecurityProviderInitializer#addSecurityProvider: Bouncy Castle security provider initialized.
   4.521 [id=35]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   4.526 [id=35]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   5.383 [id=42]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   5.395 [id=40]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   5.395 [id=28]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   5.457 [id=46]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   5.458 [id=45]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   5.516 [id=42]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
  10.689 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1381:17] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  10.690 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1381:17] Ignoring the whole rule.
  10.690 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1400:33] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  10.690 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1400:33] Ignoring the whole rule.
  10.691 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1419:49] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  10.691 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1419:49] Ignoring the whole rule.
  10.699 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1707:3] Error in declaration. '*' is not allowed as first char of a property.
  11.840 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1381:17] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  11.840 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1381:17] Ignoring the whole rule.
  11.840 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1400:33] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  11.840 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1400:33] Ignoring the whole rule.
  11.841 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1419:49] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  11.841 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1419:49] Ignoring the whole rule.
  11.844 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1707:3] Error in declaration. '*' is not allowed as first char of a property.
  13.643 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1381:17] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  13.644 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1381:17] Ignoring the whole rule.
  13.644 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1400:33] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  13.644 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1400:33] Ignoring the whole rule.
  13.645 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1419:49] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  13.645 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1419:49] Ignoring the whole rule.
  13.648 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1707:3] Error in declaration. '*' is not allowed as first char of a property.
  14.204 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1381:17] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  14.204 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1381:17] Ignoring the whole rule.
  14.205 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1400:33] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  14.205 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1400:33] Ignoring the whole rule.
  14.206 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1419:49] Error in class selector. (Invalid token "only". Was expecting: <IDENT>.)
  14.206 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#warning: CSS warning: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1419:49] Ignoring the whole rule.
  14.210 [id=16]	WARNING	c.g.h.DefaultCssErrorHandler#error: CSS error: 'http://localhost:57024/jenkins/static/ab0a3cde/jsbundles/base-styles-v2.css' [1707:3] Error in declaration. '*' is not allowed as first char of a property.
  14.756 [id=16]	INFO	jenkins.model.Jenkins#cleanUp: Stopping Jenkins
```

## After

```
   0.143 [id=16]	INFO	o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at /Users/danielbeck/Repositories/github.com/daniel-beck/matrix-auth-plugin/target/jenkins-for-test
   0.581 [id=16]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:56958/jenkins/
   1.004 [id=30]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   1.392 [id=29]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins12644558609344466337/plugins/command-launcher.jpi
   1.425 [id=29]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins12644558609344466337/plugins/jdk-tool.jpi
   1.462 [id=29]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins12644558609344466337/plugins/trilead-api.jpi
   1.520 [id=29]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins12644558609344466337/plugins/jaxb.jpi
   1.638 [id=38]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins12644558609344466337/plugins/bouncycastle-api.jpi
   3.380 [id=51]	WARNING	hudson.ClassicPluginStrategy#createClassJarFromWebInfClasses: Created /var/folders/sc/wj54hsn531l4lnbnqwthds_00000gn/T/jenkins12644558609344466337/plugins/job-dsl/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness
   4.263 [id=32]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   4.349 [id=31]	INFO	j.b.a.SecurityProviderInitializer#addSecurityProvider: Initializing Bouncy Castle security provider.
   4.554 [id=31]	INFO	j.b.a.SecurityProviderInitializer#addSecurityProvider: Bouncy Castle security provider initialized.
   6.742 [id=37]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   6.749 [id=42]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   8.186 [id=51]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   8.201 [id=51]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   8.202 [id=40]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   8.282 [id=31]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   8.283 [id=43]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   8.352 [id=42]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
  17.930 [id=16]	INFO	jenkins.model.Jenkins#cleanUp: Stopping Jenkins
