### PR TITLE
[JEP-229] Enable CD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
   - dependency-name: org.jenkins-ci.main:jenkins-core
   - dependency-name: org.jenkins-ci.main:jenkins-war
   - dependency-name: org.jenkins-ci.plugins*
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,1 @@
 _extends: .github
-tag-template: jenkins-test-harness-$NEXT_MINOR_VERSION

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,36 @@
+name: cd
+on:
+  workflow_dispatch:
+  check_run:
+    types:
+    - completed
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify CI status
+      uses: jenkins-infra/verify-ci-status-action@v1.1.0
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Release Drafter
+      uses: release-drafter/release-drafter@v5.13.0
+      with:
+        name: next
+        tag: next
+        version: next
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check out
+      uses: actions/checkout@v2.3.4
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Release
+      uses: jenkins-infra/jenkins-maven-cd-action@v1.1.0
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+        MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-7</version>
+    <version>1.2</version>
   </extension>
 </extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ THE SOFTWARE.
 
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>jenkins-test-harness</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>${changelist}</version>
 
   <name>Test harness for Jenkins and plugins</name>
   <url>https://github.com/jenkinsci/jenkins-test-harness</url>
@@ -48,8 +48,7 @@ THE SOFTWARE.
   </scm>
 
   <properties>
-    <revision>2.73</revision>
-    <changelist>-SNAPSHOT</changelist>
+    <changelist>999999-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.38.v20210224</jetty.version>
     <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
As per https://github.com/jenkinsci/incrementals-tools/#superseding-maven-releases. Requires https://github.com/jenkins-infra/repository-permissions-updater/pull/1846.
