### PR TITLE
RealJenkinsRule improvements

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -445,7 +445,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         jenkins.getJDKs().add(new JDK("default", System.getProperty("java.home")));
     }
     
-    private static void dumpThreads() {
+    static void dumpThreads() {
         ThreadInfo[] threadInfos = Functions.getThreadInfos();
         Functions.ThreadGroupMap m = Functions.sortThreadsAndGetGroupMap(threadInfos);
         for (ThreadInfo ti : threadInfos) {

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -228,6 +228,9 @@ public final class RealJenkinsRule implements TestRule {
                     }
                     base.evaluate();
                 } finally {
+                    if (proc != null) {
+                        stopJenkins();
+                    }
                     try {
                         tmp.dispose();
                     } catch (Exception x) {

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -364,8 +364,6 @@ public final class RealJenkinsRule implements TestRule {
                     throw new AssertionError("Jenkins did not start after 3m");
                 } else if (tries % /* 1m */ 600 == 0) {
                     x.printStackTrace();
-                } else if (tries % /* 5s */ 50 == 0) {
-                    System.err.println("Jenkins is not yet ready: " + x);
                 }
             }
             Thread.sleep(100);

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -356,7 +356,7 @@ public final class RealJenkinsRule implements TestRule {
                     } catch (Exception x) {
                         x.printStackTrace();
                     }
-                    throw new IOException("Response code " + code + " for " + status + ": " + err);
+                    throw new IOException("Response code " + code + " for " + status + ": " + err + " " + conn.getHeaderFields());
                 }
             } catch (Exception x) {
                 tries++;

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -62,6 +62,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -74,6 +75,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
+import jenkins.util.Timer;
 import org.apache.commons.io.FileUtils;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
@@ -113,7 +115,6 @@ import org.kohsuke.stapler.verb.POST;
  * <li>{@link LocalData} is not available.
  * <li>{@link LoggerRule} is not available.
  * <li>{@link BuildWatcher} is not available.
- * <li>There is no automatic test timeout.
  * <li>There is not currently enough flexibility in how the controller is launched (such as custom environment variables).
  * </ul>
  * <p>Systems not yet tested:
@@ -449,6 +450,12 @@ public final class RealJenkinsRule implements TestRule {
             Jenkins.get().setNoUsageStatistics(true);
             DownloadService.neverUpdate = true;
             UpdateSite.neverUpdate = true;
+            System.err.println("RealJenkinsRule ready");
+            Timer.get().schedule(JenkinsRule::dumpThreads, 2, TimeUnit.MINUTES);
+            Timer.get().schedule(() -> {
+                JenkinsRule.dumpThreads();
+                System.exit(1);
+            }, 5, TimeUnit.MINUTES);
         }
         @Override public String getUrlName() {
             return "RealJenkinsRule";

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -83,13 +83,9 @@ public class RealJenkinsRuleTest {
 
     @Test public void htmlUnit() throws Throwable {
         rr.startJenkins();
-        try {
-            rr.runRemotely(RealJenkinsRuleTest::_htmlUnit1);
-            System.err.println("running against " + rr.getUrl());
-            rr.runRemotely(RealJenkinsRuleTest::_htmlUnit2);
-        } finally {
-            rr.stopJenkins();
-        }
+        rr.runRemotely(RealJenkinsRuleTest::_htmlUnit1);
+        System.err.println("running against " + rr.getUrl());
+        rr.runRemotely(RealJenkinsRuleTest::_htmlUnit2);
     }
     private static void _htmlUnit1(JenkinsRule r) throws Throwable {
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());


### PR DESCRIPTION
- Call `stopJenkins` automatically
- Ability to disable plugins
- Ability to add Java options
- Apply an overall timeout, and print diagnostics if Jenkins cannot be contacted or the test hangs