### PR TITLE
Add remote host binding for JenkinsRule

### DIFF
--- a/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
@@ -6,6 +6,7 @@ import hudson.security.ACL;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.eclipse.jetty.server.Server;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -43,6 +44,7 @@ public abstract class JmhBenchmarkState implements RootAction {
 
     private final TemporaryDirectoryAllocator temporaryDirectoryAllocator = new TemporaryDirectoryAllocator();
     private final MutableInt localPort = new MutableInt();
+    private final MutableObject<String> host = new MutableObject<String>("localhost");
 
     private Jenkins jenkins = null;
     private Server server = null;
@@ -87,8 +89,8 @@ public abstract class JmhBenchmarkState implements RootAction {
     }
 
     private void launchInstance() throws Exception {
-        ImmutablePair<Server, ServletContext> results = JenkinsRule._createWebServer(contextPath, localPort::setValue,
-                getClass().getClassLoader(), localPort.getValue(), JenkinsRule::_configureUserRealm);
+        ImmutablePair<Server, ServletContext> results = JenkinsRule._createWebServer(contextPath, host::setValue, localPort::setValue,
+                getClass().getClassLoader(), host.getValue(), localPort.getValue(),JenkinsRule::_configureUserRealm);
 
         server = results.left;
         ServletContext webServer = results.right;
@@ -104,7 +106,7 @@ public abstract class JmhBenchmarkState implements RootAction {
     }
 
     private URL getJenkinsURL() throws MalformedURLException {
-        return new URL("http://localhost:" + localPort.getValue() + contextPath + "/");
+        return new URL("http://"+host.getValue()+":" + localPort.getValue() + contextPath + "/");
     }
 
     /**

--- a/src/test/java/org/jvnet/hudson/main/BasicTestCase.java
+++ b/src/test/java/org/jvnet/hudson/main/BasicTestCase.java
@@ -23,25 +23,35 @@
  */
 package org.jvnet.hudson.main;
 
-import org.junit.Rule;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.tasks.Shell;
+import hudson.tasks.BatchFile;
+import org.apache.commons.io.FileUtils;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Experimenting with Hudson test suite.
  */
-public class AppTest extends BasicTestCase {
+public class BasicTestCase {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    protected void meat(JenkinsRule jenkinsRule) throws IOException, InterruptedException, ExecutionException {
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+        if(System.getProperty("os.name").contains("Windows")) {
+            project.getBuildersList().add(new BatchFile("echo hello"));
+        } else {
+            project.getBuildersList().add(new Shell("echo hello"));
+        }
 
-    @Test
-    public void test1() throws Exception {
-        meat(j);
-    }
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        System.out.println(build.getDisplayName()+" completed");
 
-    @Test
-    public void test2() throws Exception {
-        meat(j);
+        String s = FileUtils.readFileToString(build.getLogFile());
+        assertTrue(s,s.contains("echo hello"));
     }
 }

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleAllHostInterfaceTest.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleAllHostInterfaceTest.java
@@ -1,0 +1,32 @@
+package org.jvnet.hudson.main;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.net.URL;
+import java.util.List;
+
+public class JenkinsRuleAllHostInterfaceTest extends BasicTestCase {
+
+    @Rule public JenkinsRule j = new JenkinsRule() {
+        {
+            host = null;
+        }
+    };
+
+    @Test 
+    public void allInterfaceJenkins() throws Throwable {
+        System.out.println("running in: " + j.jenkins.getRootUrl());
+        URL jenkinsURL = new URL(j.jenkins.getRootUrl());
+
+        assertEquals("localhost", jenkinsURL.getHost());
+    }
+
+    @Test
+    public void allInterfaceJenkinsBuild() throws Throwable {
+        meat(j);
+    }
+}

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleHostIPTest.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleHostIPTest.java
@@ -1,0 +1,44 @@
+package org.jvnet.hudson.main;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.net.URL;
+import java.util.List;
+
+public class JenkinsRuleHostIPTest extends BasicTestCase {
+
+    private static String HOST_IP = getHostAddress();
+
+    private static String getHostAddress() {
+        try {
+            return InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Rule public JenkinsRule j = new JenkinsRule() {
+        {
+            host = HOST_IP;
+        }
+    };
+
+    @Test 
+    public void hostIpJenkins() throws Throwable {
+        System.out.println("running in: " + j.jenkins.getRootUrl());
+        URL jenkinsURL = new URL(j.jenkins.getRootUrl());
+
+        assertEquals(HOST_IP, jenkinsURL.getHost());
+    }
+
+    @Test
+    public void hostIpJenkinsBuild() throws Throwable {
+        meat(j);
+    }
+}


### PR DESCRIPTION
The reason for this change is that the JenkinRule based tests were all running
inside a docker container and i needed a way to bind it a non localhost address
in order to access it from outside the running container.

The host binding for the JenkinsRule is configurable with the `host`
property. The default value is `localhost` this keeps the backward
compatibility.

The following code snippet shows how to bind the JenkinsRule instance
```
@Rule public JenkinsRule j = new JenkinsRule() {{
    host = null;
  }
};
```
to all network interfaces. This is similar to set the `host` value to `0.0.0.0`.

The test case `JenkinsRuleHostIPTest` validates that the assignment to a specific
host ip address is working correctly.

The test case `JenkinsRuleAllHostInterfaceTest` validates that the assignment to all
network interfaces is working correctly.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
