### PR TITLE
NPE observed in RealJenkinsRule.startJenkins

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -362,7 +362,9 @@ public final class RealJenkinsRule implements TestRule {
                 } else {
                     String err = "?";
                     try (InputStream is = conn.getErrorStream()) {
-                        err = IOUtils.toString(is);
+                        if (is != null) {
+                            err = IOUtils.toString(is);
+                        }
                     } catch (Exception x) {
                         x.printStackTrace();
                     }


### PR DESCRIPTION
Seems to have been a flake somewhere, but the root cause was perhaps concealed by a secondary mistake in error handling:

```
java.lang.NullPointerException
	at java.io.Reader.<init>(Reader.java:78)
	at java.io.InputStreamReader.<init>(InputStreamReader.java:113)
	at org.apache.commons.io.IOUtils.copy(IOUtils.java:921)
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:2681)
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:2661)
	at org.jvnet.hudson.test.RealJenkinsRule.startJenkins(RealJenkinsRule.java:365)
	at …
```
