### PR TITLE
RealJenkinsRule: wait for max 60 seconds for Jenkins to terminate

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -411,8 +411,14 @@ public final class RealJenkinsRule implements TestRule {
 
     public void stopJenkins() throws Throwable {
         endpoint("exit").openStream().close();
-        if (proc.waitFor() != 0) {
-            throw new AssertionError("nonzero exit code");
+        if (!proc.waitFor(60, TimeUnit.SECONDS) ) {
+            System.err.println("Jenkins failed to stop within 60 seconds, attempting to kill the Jenkins process");
+            proc.destroyForcibly();
+            throw new AssertionError("Jenkins failed to terminate within 60 seconds");
+        }
+        int exitValue = proc.exitValue();
+        if (exitValue != 0) {
+            throw new AssertionError("onzero exit code: " + exitValue);
         }
         proc = null;
     }

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -418,7 +418,7 @@ public final class RealJenkinsRule implements TestRule {
         }
         int exitValue = proc.exitValue();
         if (exitValue != 0) {
-            throw new AssertionError("onzero exit code: " + exitValue);
+            throw new AssertionError("nonzero exit code: " + exitValue);
         }
         proc = null;
     }


### PR DESCRIPTION
Observed a build in CI that was blocked with the following stack

```
"main" #1 prio=5 os_prio=0 cpu=6449.46ms elapsed=2937.07s tid=0x00007f869c011000 nid=0x236 in Object.wait()  [0x00007f86a3394000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.1/Native Method)
	- waiting on <no object reference available>
	at java.lang.Object.wait(java.base@11.0.1/Object.java:328)
	at java.lang.ProcessImpl.waitFor(java.base@11.0.1/ProcessImpl.java:495)
	- waiting to re-lock in wait() <0x00000000943c10b0> (a java.lang.ProcessImpl)
	at org.jvnet.hudson.test.RealJenkinsRule.then(RealJenkinsRule.java:243)
	at io.jenkins.plugins.artifact_manager_jclouds.s3.MinioIntegrationTest.artifactArchiveAndDelete(MinioIntegrationTest.java:175)
```

The Jenkins stack showed jetty just waiting for some data and the Jenkins crontab waiting.

We should not wait for infinity to shutdown - so pick an arbitrary number like 1 minute, and if we can not stop within that period fill Jenkins and throw an assertion error.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
