### PR TITLE
[JENKINS-65068] `RestartableJenkinsRule`: Handle `NoSuchFileException` thrown from `FileTreeWalker`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RestartableJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RestartableJenkinsRule.java
@@ -191,7 +191,10 @@ public class RestartableJenkinsRule implements MethodRule {
         @Override
         public FileVisitResult visitFileFailed(Path file, IOException exc) {
             if (exc instanceof FileNotFoundException) {
-                LOGGER.log(Level.FINE, "File not found while trying to copy to new home, continuing anyway: "+file.toString());
+                LOGGER.log(Level.FINE, "File not found while trying to copy to new home, continuing anyway: " + file.toString());
+                return FileVisitResult.CONTINUE;
+            } else if (exc instanceof NoSuchFileException) {
+                LOGGER.log(Level.FINE, "File disappeared while trying to copy to new home, continuing anyway: " + file.toString());
                 return FileVisitResult.CONTINUE;
             } else {
                 LOGGER.log(Level.WARNING, "Error copying file", exc);


### PR DESCRIPTION
The FileTreeWalker is quite a bit less hardened that one might hope.
The visitor must handle a NoSuchFileException throw during copy, but
the `visitFileFailed` method must handle NoSuchFileException if thrown
by the walker.

https://issues.jenkins.io/browse/JENKINS-65068

@jtnord @olamy 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
