### PR TITLE
`JenkinsRuleTimeoutTest` was flaky

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@ THE SOFTWARE.
               <hudson.maven.debug>${mavenDebug}</hudson.maven.debug>
               <buildDirectory>${project.build.directory}</buildDirectory>
           </systemPropertyVariables>
-          <reuseForks>true</reuseForks>
+          <reuseForks>false</reuseForks>
           <forkCount>${concurrency}</forkCount>
           <trimStackTrace>false</trimStackTrace>
         </configuration>

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout1Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout1Test.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.main;
+
+import org.junit.Test;
+
+public class JenkinsRuleTimeout1Test extends JenkinsRuleTimeoutTestBase {
+
+    @Test
+    public void hangInterruptiblyInTest() {
+        try {
+            hangInterruptibly();
+        } catch (InterruptedException x) {
+            System.err.println("Interrupted, good.");
+        }
+    }
+
+}

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout2Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout2Test.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.main;
+
+import org.junit.Test;
+import static org.jvnet.hudson.main.JenkinsRuleTimeoutTestBase.hangUninterruptibly;
+
+public class JenkinsRuleTimeout2Test extends JenkinsRuleTimeoutTestBase {
+
+    @Test
+    public void hangUninterruptiblyInTest() {
+        hangUninterruptibly();
+    }
+
+}

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout3Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout3Test.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.main;
+
+import hudson.model.listeners.ItemListener;
+import org.junit.Test;
+import static org.jvnet.hudson.main.JenkinsRuleTimeoutTestBase.hangInterruptibly;
+import org.jvnet.hudson.test.TestExtension;
+
+public class JenkinsRuleTimeout3Test extends JenkinsRuleTimeoutTestBase {
+
+    @Test
+    public void hangInterruptiblyInShutdown() {
+        System.err.println("Test itself passed…");
+    }
+
+    @TestExtension
+    public static class HangsInterruptibly extends ItemListener {
+        @Override
+        public void onBeforeShutdown() {
+            try {
+                hangInterruptibly();
+            } catch (InterruptedException x) {
+                System.err.println("Interrupted, good.");
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout4Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout4Test.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.main;
+
+import hudson.model.listeners.ItemListener;
+import org.junit.Test;
+import static org.jvnet.hudson.main.JenkinsRuleTimeoutTestBase.hangUninterruptibly;
+import org.jvnet.hudson.test.TestExtension;
+
+public class JenkinsRuleTimeout4Test extends JenkinsRuleTimeoutTestBase {
+
+    @Test
+    public void hangUninterruptiblyInShutdown() {
+        System.err.println("Test itself passed…");
+    }
+
+    @TestExtension
+    public static class HangsUninterruptibly extends ItemListener {
+        @Override
+        public void onBeforeShutdown() {
+            hangUninterruptibly();
+        }
+    }
+
+}

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout5Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout5Test.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.main;
+
+import hudson.model.listeners.ItemListener;
+import org.junit.Test;
+import static org.jvnet.hudson.main.JenkinsRuleTimeoutTestBase.hangInterruptibly;
+import org.jvnet.hudson.test.TestExtension;
+
+public class JenkinsRuleTimeout5Test extends JenkinsRuleTimeoutTestBase {
+
+    @Test
+    public void hangInterruptiblyInStartup() {
+        assert false : "should not get here";
+    }
+
+    @TestExtension
+    public static class HangsInterruptibly extends ItemListener {
+        @Override
+        public void onLoaded() {
+            try {
+                hangInterruptibly();
+            } catch (InterruptedException x) {
+                System.err.println("Interrupted, good.");
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout6Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout6Test.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.main;
+
+import hudson.model.listeners.ItemListener;
+import org.junit.Test;
+import static org.jvnet.hudson.main.JenkinsRuleTimeoutTestBase.hangUninterruptibly;
+import org.jvnet.hudson.test.TestExtension;
+
+public class JenkinsRuleTimeout6Test extends JenkinsRuleTimeoutTestBase {
+
+    @Test
+    public void hangUninterruptiblyInStartup() {
+        assert false : "should not get here";
+    }
+
+    @TestExtension
+    public static class HangsUninterruptibly extends ItemListener {
+        @Override
+        public void onLoaded() {
+            hangUninterruptibly();
+        }
+    }
+
+}

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout7Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout7Test.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.main;
+
+import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.jvnet.hudson.test.recipes.WithTimeout;
+
+public class JenkinsRuleTimeout7Test extends JenkinsRuleTimeoutTestBase {
+
+    @Test
+    @WithTimeout(15)
+    public void withTimeoutPropagation() throws Exception {
+        Thread.sleep(1000 * 20);
+        fail("Should have been interrupted");
+    }
+
+}

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTestBase.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeoutTestBase.java
@@ -24,19 +24,13 @@
 
 package org.jvnet.hudson.main;
 
-import hudson.model.listeners.ItemListener;
-import org.junit.Test;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 import org.junit.runners.model.TestTimedOutException;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.TestExtension;
-import org.jvnet.hudson.test.recipes.WithTimeout;
 
-import static org.junit.Assert.fail;
-
-public class JenkinsRuleTimeoutTest {
+public class JenkinsRuleTimeoutTestBase {
 
     private final ExpectedException thrown = ExpectedException.none();
 
@@ -49,83 +43,13 @@ public class JenkinsRuleTimeoutTest {
     @Rule
     public RuleChain chain = RuleChain.outerRule(thrown).around(r);
 
-    @Test
-    public void hangInterruptiblyInTest() {
-        try {
-            hangInterruptibly();
-        } catch (InterruptedException x) {
-            System.err.println("Interrupted, good.");
-        }
-    }
-
-    @Test
-    public void hangUninterruptiblyInTest() {
-        hangUninterruptibly();
-    }
-
-    @Test
-    public void hangInterruptiblyInShutdown() {
-        System.err.println("Test itself passed…");
-    }
-    @TestExtension("hangInterruptiblyInShutdown")
-    public static class HangsInterruptibly extends ItemListener {
-        @Override
-        public void onBeforeShutdown() {
-            try {
-                hangInterruptibly();
-            } catch (InterruptedException x) {
-                System.err.println("Interrupted, good.");
-            }
-        }
-    }
-
-    @Test
-    public void hangUninterruptiblyInShutdown() {
-        System.err.println("Test itself passed…");
-    }
-    @TestExtension("hangUninterruptiblyInShutdown")
-    public static class HangsUninterruptibly extends ItemListener {
-        @Override
-        public void onBeforeShutdown() {
-            hangUninterruptibly();
-        }
-    }
-
-    @Test
-    public void hangInterruptiblyInStartup() {
-        assert false : "should not get here";
-    }
-    @TestExtension("hangInterruptiblyInStartup")
-    public static class HangsInterruptibly2 extends ItemListener {
-        @Override
-        public void onLoaded() {
-            try {
-                hangInterruptibly();
-            } catch (InterruptedException x) {
-                System.err.println("Interrupted, good.");
-            }
-        }
-    }
-
-    @Test
-    public void hangUninterruptiblyInStartup() {
-        assert false : "should not get here";
-    }
-    @TestExtension("hangUninterruptiblyInStartup")
-    public static class HangsUninterruptibly2 extends ItemListener {
-        @Override
-        public void onLoaded() {
-            hangUninterruptibly();
-        }
-    }
-
-    private static void hangInterruptibly() throws InterruptedException {
+    protected static void hangInterruptibly() throws InterruptedException {
         Thread.sleep(Long.MAX_VALUE);
         assert false : "should not get here";
     }
 
     @SuppressWarnings("SleepWhileHoldingLock")
-    private static void hangUninterruptibly() {
+    protected static void hangUninterruptibly() {
         // Adapted from http://stackoverflow.com/a/22489064/12916
         final Object a = new Object();
         final Object b = new Object();
@@ -156,10 +80,4 @@ public class JenkinsRuleTimeoutTest {
         }
     }
 
-    @Test 
-    @WithTimeout(15)
-    public void withTimeoutPropagation() throws Exception {
-        Thread.sleep(1000 * 20);
-        fail("Should have been interrupted");
-    }
 }


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins-test-harness/pull/303#issuecomment-831811098. By running against an instrumented version of core, the root problem seems to be that `FailOnTimeout` does its interruption in a separate thread, so it is unpredictable when `Jenkins.cleanUp` will be called—sometimes _after_ another test has started `Jenkins.<init>`. `cleanUp` does supposedly verify that it is cleaning up `this`, and `JenkinsRule` has an additional defense, but it seems there are lots of race conditions here. Safest to run each of these tests in its own JVM. We do not really care about a test that failed due to timeout also “poisoning” other tests in the same JVM since we expect the test suite to fail at that point anyway, so this probably only affects `JenkinsRuleTimeoutTest` itself.