### PR TITLE
`WebClient.getPage(View, String)` needed to use `getViewUrl` not `getUrl`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2551,7 +2551,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         }
 
         public HtmlPage getPage(View view, String relative) throws IOException, SAXException {
-            return goTo(view.getUrl()+relative);
+            return goTo(view.getViewUrl() + relative);
         }
 
         /**


### PR DESCRIPTION
Otherwise `configRoundtrip` on a default view fails (cryptically) because it goes to `http://localhost:8080/jenkins/configure` and does not find a form `viewConfig`.