### PR TITLE
[JENKINS-67086] Ensure a free port is used by RealJenkinsRule

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/IOUtil.java
+++ b/src/main/java/org/jvnet/hudson/test/IOUtil.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jvnet.hudson.test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.logging.Logger;
+
+public class IOUtil {
+
+    private static final Logger LOGGER = Logger.getLogger(IOUtil.class.getName());
+
+    /**
+     * Gives random available TCP port in the given range.
+     *
+     * @param from if <=0 then default value 49152 is used
+     * @param to   if <=0 then default value 65535 is used
+     */
+    public static int randomTcpPort(int from, int to){
+        from = (from <=0) ? 49152 : from;
+        to = (to <= 0) ? 65535 : to;
+
+
+        while(true){
+            int candidate = (int) ((Math.random() * (to-from)) + from);
+            if(isTcpPortFree(candidate)){
+                return candidate;
+            }
+            LOGGER.info(String.format("Port %s is in use", candidate));
+        }
+    }
+
+    /**
+     * Gives random available TCP port.
+     */
+    public static int randomTcpPort(){
+        return randomTcpPort(-1,-1);
+    }
+
+    public static boolean isTcpPortFree(int port){
+        try {
+            ServerSocket ss = new ServerSocket(port);
+            ss.close();
+            return true;
+        } catch (IOException ex) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/jvnet/hudson/test/IOUtil.java
+++ b/src/main/java/org/jvnet/hudson/test/IOUtil.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.logging.Logger;
 
+/**
+ * Copied from https://github.com/jenkinsci/acceptance-test-harness/blob/f749d27b229ce5a4737d1614fa1f31d2e6402f4f/src/main/java/org/jenkinsci/test/acceptance/utils/IOUtil.java#L80-L115
+ */
 public class IOUtil {
 
     private static final Logger LOGGER = Logger.getLogger(IOUtil.class.getName());

--- a/src/main/java/org/jvnet/hudson/test/IOUtil.java
+++ b/src/main/java/org/jvnet/hudson/test/IOUtil.java
@@ -34,8 +34,8 @@ public class IOUtil {
     /**
      * Gives random available TCP port in the given range.
      *
-     * @param from if <=0 then default value 49152 is used
-     * @param to   if <=0 then default value 65535 is used
+     * @param from if &lt;=0 then default value 49152 is used
+     * @param to   if &lt;=0 then default value 65535 is used
      */
     public static int randomTcpPort(int from, int to){
         from = (from <=0) ? 49152 : from;

--- a/src/main/java/org/jvnet/hudson/test/IOUtil.java
+++ b/src/main/java/org/jvnet/hudson/test/IOUtil.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 /**
  * Copied from https://github.com/jenkinsci/acceptance-test-harness/blob/f749d27b229ce5a4737d1614fa1f31d2e6402f4f/src/main/java/org/jenkinsci/test/acceptance/utils/IOUtil.java#L80-L115
  */
-public class IOUtil {
+class IOUtil {
 
     private static final Logger LOGGER = Logger.getLogger(IOUtil.class.getName());
 

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -58,7 +58,6 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -246,7 +245,7 @@ public final class RealJenkinsRule implements TestRule {
                 System.out.println("=== Starting " + description);
                 try {
                     home = tmp.allocate();
-                    port = new Random().nextInt(16384) + 49152; // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
+                    port = IOUtil.randomTcpPort(); // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
                     File plugins = new File(home, "plugins");
                     plugins.mkdir();
                     FileUtils.copyURLToFile(RealJenkinsRule.class.getResource("RealJenkinsRuleInit.jpi"), new File(plugins, "RealJenkinsRuleInit.jpi"));
@@ -343,6 +342,7 @@ public final class RealJenkinsRule implements TestRule {
                     }
                 }
             }
+
         };
     }
 

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -245,7 +245,7 @@ public final class RealJenkinsRule implements TestRule {
                 System.out.println("=== Starting " + description);
                 try {
                     home = tmp.allocate();
-                    port = IOUtil.randomTcpPort(); // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
+                    port = IOUtil.randomTcpPort();
                     File plugins = new File(home, "plugins");
                     plugins.mkdir();
                     FileUtils.copyURLToFile(RealJenkinsRule.class.getResource("RealJenkinsRuleInit.jpi"), new File(plugins, "RealJenkinsRuleInit.jpi"));


### PR DESCRIPTION
[JENKINS-67086](https://issues.jenkins.io/browse/JENKINS-67086)

When running tests in parallel I sometimes see port conflicts

```
java.io.IOException: Failed to start Jetty
	at winstone.Launcher.<init>(Launcher.java:194)
	at winstone.Launcher.main(Launcher.java:369)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at Main._main(Main.java:375)
	at Main.main(Main.java:151)
Caused by: java.io.IOException: Failed to bind to /127.0.0.1:50786
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:349)
	at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:310)
	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:80)
	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:234)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.server.Server.doStart(Server.java:401)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at winstone.Launcher.<init>(Launcher.java:192)
	... 7 more
Caused by: java.net.BindException: Address already in use
	at sun.nio.ch.Net.bind0(Native Method)
	at sun.nio.ch.Net.bind(Net.java:461)
	at sun.nio.ch.Net.bind(Net.java:453)
	at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:222)
	at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:85)
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:344)
	... 14 more
```

The harness should ensure the port is free before trying to use it.

This includes a partial copy of IOUtil from acceptance-test-harness repo.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
