### PR TITLE
Add new JenkinsSessionRule.getHome method

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsSessionRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsSessionRule.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
  * Simpler alternative to {@link RestartableJenkinsRule}.

--- a/src/main/java/org/jvnet/hudson/test/JenkinsSessionRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsSessionRule.java
@@ -60,7 +60,9 @@ public class JenkinsSessionRule implements TestRule {
      * Normally it will suffice to use {@link LocalData} to populate files.
      */
     public File getHome() {
-        assert home != null : "JENKINS_HOME has not been allocated yet";
+        if (home == null) {
+            throw new IllegalStateException("JENKINS_HOME has not been allocated yet");
+        }
         return home;
     }
 

--- a/src/main/java/org/jvnet/hudson/test/JenkinsSessionRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsSessionRule.java
@@ -55,6 +55,15 @@ public class JenkinsSessionRule implements TestRule {
      */
     private int port;
 
+    /**
+     * Get the Jenkins home directory, which is consistent across restarts.
+     * Normally it will suffice to use {@link LocalData} to populate files.
+     */
+    public File getHome() {
+        assert home != null : "JENKINS_HOME has not been allocated yet";
+        return home;
+    }
+
     @Override public Statement apply(final Statement base, Description description) {
         this.description = description;
         return new Statement() {

--- a/src/main/java/org/jvnet/hudson/test/JenkinsSessionRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsSessionRule.java
@@ -31,7 +31,6 @@ import org.junit.After;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
  * Simpler alternative to {@link RestartableJenkinsRule}.
@@ -58,7 +57,6 @@ public class JenkinsSessionRule implements TestRule {
 
     /**
      * Get the Jenkins home directory, which is consistent across restarts.
-     * Normally it will suffice to use {@link LocalData} to populate files.
      */
     public File getHome() {
         if (home == null) {


### PR DESCRIPTION
Analogous to `RealJenkinsRule.getHome`, which was added in #352. Useful in cases where you want to modify something in `JENKINS_HOME` between Jenkins restarts.

Once the CI build completes I will update https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/185 to consume the new method.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
