### PR TITLE
GC before trying to delete the Jenkins home directory

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -433,17 +433,17 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             ExtensionList.clearLegacyInstances();
             DescriptorExtensionList.clearLegacyInstances();
 
-            try {
-                env.dispose();
-            } catch (Exception x) {
-                x.printStackTrace();
-            }
-
             // Jenkins creates ClassLoaders for plugins that hold on to file descriptors of its jar files,
             // but because there's no explicit dispose method on ClassLoader, they won't get GC-ed until
             // at some later point, leading to possible file descriptor overflow. So encourage GC now.
             // see http://bugs.sun.com/view_bug.do?bug_id=4950148
             System.gc();
+
+            try {
+                env.dispose();
+            } catch (Exception x) {
+                x.printStackTrace();
+            }
             
             // restore defaultUseCache
             if(Functions.isWindows()) {

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -436,7 +436,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             // Jenkins creates ClassLoaders for plugins that hold on to file descriptors of its jar files,
             // but because there's no explicit dispose method on ClassLoader, they won't get GC-ed until
             // at some later point, leading to possible file descriptor overflow. So encourage GC now.
-            // see http://bugs.sun.com/view_bug.do?bug_id=4950148
+            // see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4950148
             System.gc();
 
             try {

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -509,10 +509,10 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         } finally {
             _stopJenkins(server, tearDowns, jenkins);
 
-            // Hudson creates ClassLoaders for plugins that hold on to file descriptors of its jar files,
+            // Jenkins creates ClassLoaders for plugins that hold on to file descriptors of its jar files,
             // but because there's no explicit dispose method on ClassLoader, they won't get GC-ed until
             // at some later point, leading to possible file descriptor overflow. So encourage GC now.
-            // see http://bugs.sun.com/view_bug.do?bug_id=4950148
+            // see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4950148
             // TODO use URLClassLoader.close() in Java 7
             System.gc();
 

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -509,16 +509,16 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         } finally {
             _stopJenkins(server, tearDowns, jenkins);
 
+            // Hudson creates ClassLoaders for plugins that hold on to file descriptors of its jar files,
+            // but because there's no explicit dispose method on ClassLoader, they won't get GC-ed until
+            // at some later point, leading to possible file descriptor overflow. So encourage GC now.
+            // see http://bugs.sun.com/view_bug.do?bug_id=4950148
+            // TODO use URLClassLoader.close() in Java 7
+            System.gc();
+
             try {
                 env.dispose();
             } finally {
-                // Hudson creates ClassLoaders for plugins that hold on to file descriptors of its jar files,
-                // but because there's no explicit dispose method on ClassLoader, they won't get GC-ed until
-                // at some later point, leading to possible file descriptor overflow. So encourage GC now.
-                // see http://bugs.sun.com/view_bug.do?bug_id=4950148
-                // TODO use URLClassLoader.close() in Java 7
-                System.gc();
-
                 // restore defaultUseCache
                 if(Functions.isWindows()) {
                     URLConnection aConnection = new File(".").toURI().toURL().openConnection();


### PR DESCRIPTION
We run `System.gc()` after shutting down Jenkins and deleting the Jenkins home directory, but by then it is too late on Windows: deleting the Jenkins home directory may have already failed due to open files held by class loaders. This PR solves the problem by moving the GC to before we delete the Jenkins home directory.