### PR TITLE
Support `assertGC` on all Java versions

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
+++ b/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
@@ -25,7 +25,6 @@
 package org.jvnet.hudson.test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.util.VersionNumber;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
@@ -42,7 +41,6 @@ import javax.swing.BoundedRangeModel;
 
 import jenkins.model.Jenkins;
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
 
 import org.netbeans.insane.impl.LiveEngine;
 import org.netbeans.insane.live.LiveReferences;
@@ -150,7 +148,6 @@ public class MemoryAssert {
     }
 
     /**
-     * <strong>Assumes Java runtime is &le; Java 8. I.e. tests will be skipped if Java 9+</strong>
      * Forces GC by causing an OOM and then verifies the given {@link WeakReference} has been garbage collected.
      * @param reference object used to verify garbage collection.
      * @param allowSoft if true, pass even if {@link SoftReference}s apparently needed to be cleared by forcing an {@link OutOfMemoryError};
@@ -158,11 +155,6 @@ public class MemoryAssert {
      */
     @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE_OF_NULL")
     public static void assertGC(WeakReference<?> reference, boolean allowSoft) {
-        // Disabled on Java 9+, because below will call Netbeans Insane Engine, which in turns tries to call setAccessible
-        /* TODO version-number 1.6+:
-        assumeTrue(JavaSpecificationVersion.forCurrentJVM().isOlderThanOrEqualTo(JavaSpecificationVersion.JAVA_8));
-        */
-        assumeTrue(new VersionNumber(System.getProperty("java.specification.version")).isOlderThan(new VersionNumber("9")));
         assertTrue(true); reference.get(); // preload any needed classes!
         System.err.println("Trying to collect " + reference.get() + "…");
         Set<Object[]> objects = new HashSet<>();

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -80,6 +80,7 @@ import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.util.Timer;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.junit.Assume;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
@@ -118,6 +119,7 @@ import org.kohsuke.stapler.verb.POST;
  * <li>{@link LoggerRule} is not available.
  * <li>{@link BuildWatcher} is not available.
  * <li>There is not currently enough flexibility in how the controller is launched.
+ * <li>{@link Assume} is not available.
  * </ul>
  * <p>Systems not yet tested:
  * <ul>


### PR DESCRIPTION
Noticed in [jenkinsci/jenkins#6044](https://github.com/jenkinsci/jenkins/pull/6044#issuecomment-991124344) that `assertGC` was being skipped on recent Java versions. I can't see any good reason for this: it appears to work fine on Java 11 and Java 17 without logging any reflective access errors.