### PR TITLE
Use `{@code}` rather than `<tt>`

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/html/DomNodeUtil.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/DomNodeUtil.java
@@ -52,7 +52,7 @@ public class DomNodeUtil {
 
     /**
      * Evaluates the specified XPath expression from this node, returning the first matching element,
-     * or <tt>null</tt> if no node matches the specified XPath expression.
+     * or {@code null} if no node matches the specified XPath expression.
      * <p>
      * Calls {@link WebClientUtil#waitForJSExec(com.gargoylesoftware.htmlunit.WebClient)} before
      * executing the query.

--- a/src/main/java/org/jvnet/hudson/test/HudsonHomeLoader.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonHomeLoader.java
@@ -34,13 +34,13 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 
 /**
- * Controls how a {@link HudsonTestCase} initializes <tt>JENKINS_HOME</tt>.
+ * Controls how a {@link HudsonTestCase} initializes {@code JENKINS_HOME}.
  *
  * @author Kohsuke Kawaguchi
  */
 public interface HudsonHomeLoader {
     /** 
-     * Returns a directory to be used as <tt>JENKINS_HOME</tt>
+     * Returns a directory to be used as {@code JENKINS_HOME}
      *
      * @throws Exception
      *      to cause a test to fail.

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -1300,12 +1300,12 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     }
 
     /**
-     * If this test harness is launched for a Jenkins plugin, locate the <tt>target/test-classes/the.jpl</tt>
+     * If this test harness is launched for a Jenkins plugin, locate the {@code target/test-classes/the.jpl}
      * and add a recipe to install that to the new Jenkins.
      *
      * <p>
-     * This file is created by <tt>maven-hpi-plugin</tt> at the testCompile phase when the current
-     * packaging is <tt>hpi</tt>.
+     * This file is created by {@code maven-hpi-plugin} at the testCompile phase when the current
+     * packaging is {@code hpi}.
      */
     protected void recipeLoadCurrentPlugin() throws Exception {
     	final Enumeration<URL> jpls = getClass().getClassLoader().getResources("the.jpl");

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2021,12 +2021,12 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     /**
-     * If this test harness is launched for a Jenkins plugin, locate the <tt>target/test-classes/the.jpl</tt>
+     * If this test harness is launched for a Jenkins plugin, locate the {@code target/test-classes/the.jpl}
      * and add a recipe to install that to the new Jenkins.
      *
      * <p>
-     * This file is created by <tt>maven-hpi-plugin</tt> at the testCompile phase when the current
-     * packaging is <tt>jpi</tt>.
+     * This file is created by {@code maven-hpi-plugin} at the testCompile phase when the current
+     * packaging is {@code jpi}.
      */
     public void recipeLoadCurrentPlugin() throws Exception {
     	final Enumeration<URL> jpls = getClass().getClassLoader().getResources("the.jpl");

--- a/src/main/java/org/jvnet/hudson/test/WarExploder.java
+++ b/src/main/java/org/jvnet/hudson/test/WarExploder.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 
 /**
- * Ensures that <tt>jenkins.war</tt> is exploded.
+ * Ensures that {@code jenkins.war} is exploded.
  *
  * <p>
  * Depending on where the test is run (for example, inside Maven vs IDE), this code attempts to

--- a/src/main/java/org/jvnet/hudson/test/recipes/LocalData.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/LocalData.java
@@ -40,33 +40,33 @@ import static java.lang.annotation.ElementType.METHOD;
  * Runs a test case with a data set local to test method or the test class.
  *
  * <p>
- * This recipe allows your test case to start with the preset <tt>JENKINS_HOME</tt> data loaded
+ * This recipe allows your test case to start with the preset {@code JENKINS_HOME} data loaded
  * either from your test method or from the test class.
  *
  * <p>
- * For example, if the test method is <tt>org.acme.FooTest.testBar()</tt>, then
+ * For example, if the test method is {@code org.acme.FooTest.testBar()}, then
  * you can have your test data in one of the following places in resources folder
- * (typically <tt>src/test/resources</tt>):
+ * (typically {@code src/test/resources}):
  *
  * <ol>
  * <li>
- * Under <tt>org/acme/FooTest/testBar</tt> directory; that is, you could have files such as
- * <tt>org/acme/FooTest/testBar/config.xml</tt> or <tt>org/acme/FooTest/testBar/jobs/p/config.xml</tt>,
- * in the same layout as in the real <tt>JENKINS_HOME</tt> directory.
+ * Under {@code org/acme/FooTest/testBar} directory; that is, you could have files such as
+ * {@code org/acme/FooTest/testBar/config.xml} or {@code org/acme/FooTest/testBar/jobs/p/config.xml},
+ * in the same layout as in the real {@code JENKINS_HOME} directory.
  * <li>
- * In <tt>org/acme/FooTest/testBar.zip</tt> as a zip file.
+ * In {@code org/acme/FooTest/testBar.zip} as a zip file.
  * <li>
- * Under <tt>org/acme/FooTest</tt> directory; that is, you could have files such as
- * <tt>org/acme/FooTest/config.xml</tt> or <tt>org/acme/FooTest/jobs/p/config.xml</tt>,
- * in the same layout as in the real <tt>JENKINS_HOME</tt> directory.
+ * Under {@code org/acme/FooTest} directory; that is, you could have files such as
+ * {@code org/acme/FooTest/config.xml} or {@code org/acme/FooTest/jobs/p/config.xml},
+ * in the same layout as in the real {@code JENKINS_HOME} directory.
  * <li>
- * In <tt>org/acme/FooTest.zip</tt> as a zip file.
+ * In {@code org/acme/FooTest.zip} as a zip file.
  * </ol>
  *
  * You can specify a value to use instead of the method name
  * with the parameter of annotation. Should be a valid java identifier.
- * E.g. <tt>@LocalData("commonData")</tt> results using
- * <tt>org/acme/FooTest/commonData(.zip)</tt>.
+ * E.g. {@code @LocalData("commonData")} results using
+ * {@code org/acme/FooTest/commonData(.zip)}.
  *
  * <p>
  * Search is performed in this specific order. The fall back mechanism allows you to write


### PR DESCRIPTION
Javadoc generation on Java 11 and later throws errors without this PR.