### PR TITLE
Fix unexpected heading Javadoc error

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TestExtension.java
+++ b/src/main/java/org/jvnet/hudson/test/TestExtension.java
@@ -52,7 +52,7 @@ public @interface TestExtension {
      * To make this extension only active for one test case, specify the test method name.
      * Otherwise, leave it unspecified and it'll apply to all the test methods defined in the same class.
      *
-     * <h2>Example</h2>
+     * <h4>Example</h4>
      * <pre>
      * class FooTest extends HudsonTestCase {
      *     public void test1() { ... }


### PR DESCRIPTION
Fixes the following error generating Javadoc on Java 17:

```
src/main/java/org/jvnet/hudson/test/TestExtension.java:55: error: unexpected heading used: <H2>, compared to implicit preceding heading: <H3>
     * <h2>Example</h2>
       ^
```