### PR TITLE
[JENKINS-48466] Provide JUnit 5 support for JenkinsRule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@ THE SOFTWARE.
     <jetty.version>9.4.44.v20210927</jetty.version>
     <hamcrest.version>2.2</hamcrest.version>
     <jmh.version>1.34</jmh.version>
+    <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <java.level>8</java.level>
 
     <!-- may use e.g. 2C for 2 × (number of cores) -->
@@ -162,6 +163,22 @@ THE SOFTWARE.
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>${hamcrest.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson</groupId>

--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRule.java
@@ -1,0 +1,57 @@
+package org.jvnet.hudson.test.junit.jupiter;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * JUnit 5 meta annotation providing {@link org.jvnet.hudson.test.JenkinsRule JenkinsRule} integration.
+ *
+ * <p>
+ * Test methods using the rule extension need to accept it by {@link JenkinsRuleExtension} parameter; each test case
+ * gets a new rule object.
+ * <p>
+ * Annotating a <i>class</i> provides access for all of it's tests. Unrelated test cases can omit the parameter.
+ *
+ * <blockquote><pre>
+ * &#64;JenkinsRule
+ * class ExampleJUnit5Test {
+ *
+ *     &#64;Test
+ *     public void example(JenkinsRuleExtension r) {
+ *         // use 'r' ...
+ *     }
+ *
+ *     &#64;Test
+ *     public void exampleNotUsingRule() {
+ *         // ...
+ *     }
+ * }
+ * </pre></blockquote>
+ * <p>
+ * Annotating a <i>method</i> limits access to the method.
+ *
+ * <blockquote><pre>
+ * class ExampleJUnit5Test {
+ *
+ *     &#64;JenkinsRule
+ *     &#64;Test
+ *     public void example(JenkinsRuleExtension r) {
+ *         // use 'r' ...
+ *     }
+ * }
+ * </pre></blockquote>
+ *
+ * @see org.jvnet.hudson.test.junit.jupiter.JenkinsRuleResolver
+ * @see org.junit.jupiter.api.extension.ExtendWith
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(JenkinsRuleResolver.class)
+public @interface JenkinsRule {
+}

--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRuleExtension.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRuleExtension.java
@@ -1,0 +1,36 @@
+package org.jvnet.hudson.test.junit.jupiter;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.runner.Description;
+import org.jvnet.hudson.test.JenkinsRecipe;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import javax.annotation.Nonnull;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+/**
+ * Provides JUnit 5 compatibility for {@link JenkinsRule}.
+ */
+public class JenkinsRuleExtension extends JenkinsRule {
+	private final ParameterContext context;
+
+	JenkinsRuleExtension(@Nonnull ParameterContext context, @Nonnull ExtensionContext extensionContext) {
+		this.context = context;
+		this.testDescription = Description.createTestDescription(extensionContext.getTestClass().map(Class::getName).orElse(null),
+				extensionContext.getTestMethod().map(Method::getName).orElse(null));
+	}
+
+	@Override
+	public void recipe() throws Exception {
+		final Optional<JenkinsRecipe> jenkinsRecipe = context.findAnnotation(JenkinsRecipe.class);
+
+		if (jenkinsRecipe.isPresent()) {
+			@SuppressWarnings("unchecked") final JenkinsRecipe.Runner<JenkinsRecipe> runner = (JenkinsRecipe.Runner<JenkinsRecipe>) jenkinsRecipe.get()
+					.value().getDeclaredConstructor().newInstance();
+			recipes.add(runner);
+			tearDowns.add(() -> runner.tearDown(this, jenkinsRecipe.get()));
+		}
+	}
+}

--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRuleResolver.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRuleResolver.java
@@ -1,0 +1,46 @@
+package org.jvnet.hudson.test.junit.jupiter;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * JUnit 5 extension providing {@link JenkinsRule} integration.
+ *
+ * @see org.jvnet.hudson.test.junit.jupiter.JenkinsRule
+ */
+public class JenkinsRuleResolver implements ParameterResolver, AfterEachCallback {
+
+	private static final String key = "jenkins-instance";
+	private static final ExtensionContext.Namespace namespace = ExtensionContext.Namespace.create(JenkinsRuleResolver.class);
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		final JenkinsRule rule = context.getStore(namespace).remove(key, JenkinsRule.class);
+
+		if (rule != null) {
+			rule.after();
+		}
+	}
+
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+		return parameterContext.getParameter().getType().equals(JenkinsRuleExtension.class);
+	}
+
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+		final JenkinsRule rule = extensionContext.getStore(namespace).getOrComputeIfAbsent(key, key
+				-> new JenkinsRuleExtension(parameterContext, extensionContext), JenkinsRule.class);
+
+		try {
+			rule.before();
+			return rule;
+		} catch (Throwable t) {
+			throw new ParameterResolutionException(t.getMessage(), t);
+		}
+	}
+}

--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRuleResolverTest.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRuleResolverTest.java
@@ -1,0 +1,19 @@
+package org.jvnet.hudson.test.junit.jupiter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+@JenkinsRule
+class JenkinsRuleResolverTest {
+
+	@Test
+	void jenkinsRuleIsAccessible(JenkinsRuleExtension r) throws IOException {
+		assertThat(r.jenkins.getJobNames(), empty());
+		r.createFreeStyleProject("job-0");
+		assertThat(r.jenkins.getJobNames(), hasSize(1));
+	}
+}

--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRuleResolverWithMethodScopeTest.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRuleResolverWithMethodScopeTest.java
@@ -1,0 +1,19 @@
+package org.jvnet.hudson.test.junit.jupiter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class JenkinsRuleResolverWithMethodScopeTest {
+
+	@JenkinsRule
+	@Test
+	void jenkinsRuleIsAccessible(JenkinsRuleExtension r) throws IOException {
+		assertThat(r.jenkins.getJobNames(), empty());
+		r.createFreeStyleProject("job-0");
+		assertThat(r.jenkins.getJobNames(), hasSize(1));
+	}
+}


### PR DESCRIPTION
This PR reapplies https://github.com/jenkinsci/jenkins-test-harness/pull/303 (reverted by https://github.com/jenkinsci/jenkins-test-harness/pull/317).

According to what we learned in https://github.com/jenkins-infra/pipeline-library/pull/272 , this PR fixes the original one by moving `junit-vintage-engine` from scope `test` to scope `compile` to make it available to all dependent projects.

----------------------------------------------------------------------------------------------------------------------------

Provides JUnit 5 support for JenkinsRule as discussed in JENKINS-48466.

Tests written with JUnit 5 don't support rules, thus require code like this to work with the test harness.

Usage example:

```java
// JUnit 5
@ExtendWith(JenkinsRuleResolver.class)
class ExampleJUnit5Test {

    @Test
    public void example(JenkinsRuleExtension r) {
        // use 'r' as usual
        // ...
    }

}
```

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
