### PR TITLE
Make `BuildWatcher` behave better with `@LocalData`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/BuildWatcher.java
+++ b/src/main/java/org/jvnet/hudson/test/BuildWatcher.java
@@ -104,7 +104,8 @@ public final class BuildWatcher extends ExternalResource {
             if (build != null) {
                 build.copy();
             } else {
-                System.err.println(r + " was finalized but not started?!");
+                System.err.println(r + " was finalized but never started; assuming it was started earlier using @LocalData");
+                new RunningBuild(r).copy();
             }
         }
 


### PR DESCRIPTION
Known for a long time but reminded when working on https://github.com/jenkinsci/pipeline-input-step-plugin/pull/69#issuecomment-1004904008: if you use `@LocalData` to test resumption of a Pipeline build, and are using `BuildWatcher`, without this patch you will get a confusing warning and no log output.
