### PR TITLE
Fix `DMI_RANDOM_USED_ONLY_ONCE` SpotBugs violation

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1143,7 +1143,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     // copy from ApiTokenStore#generateNewToken, version 2.138.4
     private String generateNewApiTokenValue() {
         byte[] random = new byte[16];
-        new SecureRandom().nextBytes(random);
+        RANDOM.nextBytes(random);
         String secretValue = Util.toHexString(random);
         // 11 is the version for the new API Token system
         return 11 + secretValue;
@@ -2900,6 +2900,8 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     private static final Logger LOGGER = Logger.getLogger(HudsonTestCase.class.getName());
 
     public static final List<ToolProperty<?>> NO_PROPERTIES = Collections.emptyList();
+
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     /**
      * Specify this to a TCP/IP port number to have slaves started with the debugger.


### PR DESCRIPTION
Fixes the following SpotBugs violation:

```
[ERROR] High: Random object created and used only once in org.jvnet.hudson.test.JenkinsRule.generateNewApiTokenValue() [org.jvnet.hudson.test.JenkinsRule] At JenkinsRule.java:[line 1146] DMI_RANDOM_USED_ONLY_ONCE
```