### PR TITLE
Fix `DM_DEFAULT_ENCODING` SpotBugs violations

### DIFF
--- a/src/main/java/hudson/cli/CLICommandInvoker.java
+++ b/src/main/java/hudson/cli/CLICommandInvoker.java
@@ -33,8 +33,12 @@ import hudson.security.Permission;
 import hudson.security.SecurityRealm;
 import hudson.security.SidACL;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -139,13 +143,32 @@ public class CLICommandInvoker {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final ByteArrayOutputStream err = new ByteArrayOutputStream();
 
-        final int returnCode = command.main(
-                args, locale, stdin, new PrintStream(out), new PrintStream(err)
-        );
+        final Charset outCharset;
+        final Charset errCharset;
+        try {
+            outCharset = errCharset = command.getClientCharset();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        final int returnCode;
+        try {
+            returnCode =
+                    command.main(
+                            args,
+                            locale,
+                            stdin,
+                            new PrintStream(out, false, outCharset.name()),
+                            new PrintStream(err, false, errCharset.name()));
+        } catch (UnsupportedEncodingException e) {
+            throw new AssertionError(e);
+        }
 
         restoreAuth();
 
-        return new Result(returnCode, out, err);
+        return new Result(returnCode, out, outCharset, err, errCharset);
     }
 
     private static class GrantPermissions extends AuthorizationStrategy {
@@ -232,17 +255,23 @@ public class CLICommandInvoker {
 
         private final int result;
         private final ByteArrayOutputStream out;
+        private final Charset outCharset;
         private final ByteArrayOutputStream err;
+        private final Charset errCharset;
 
         private Result(
                 final int result,
                 final ByteArrayOutputStream out,
-                final ByteArrayOutputStream err
+                final Charset outCharset,
+                final ByteArrayOutputStream err,
+                final Charset errCharset
         ) {
 
             this.result = result;
             this.out = out;
+            this.outCharset = outCharset;
             this.err = err;
+            this.errCharset = errCharset;
         }
 
         public int returnCode() {
@@ -252,7 +281,11 @@ public class CLICommandInvoker {
 
         public String stdout() {
 
-            return out.toString();
+            try {
+                return out.toString(outCharset.name());
+            } catch (UnsupportedEncodingException e) {
+                throw new AssertionError(e);
+            }
         }
 
         public byte[] stdoutBinary() {
@@ -261,7 +294,11 @@ public class CLICommandInvoker {
 
         public String stderr() {
 
-            return err.toString();
+            try {
+                return err.toString(errCharset.name());
+            } catch (UnsupportedEncodingException e) {
+                throw new AssertionError(e);
+            }
         }
 
         public byte[] stderrBinary() {

--- a/src/main/java/org/jvnet/hudson/test/ExtractChangeLogParser.java
+++ b/src/main/java/org/jvnet/hudson/test/ExtractChangeLogParser.java
@@ -62,7 +62,7 @@ public class ExtractChangeLogParser extends ChangeLogParser {
 
     @SuppressWarnings("rawtypes")
     public ExtractChangeLogSet parse(AbstractBuild build, InputStream changeLogStream) throws IOException, SAXException {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(changeLogStream))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(changeLogStream, build.getCharset()))) {
             ExtractChangeLogEntry entry = new ExtractChangeLogEntry(br.readLine());
             String fileName;
             while ((fileName = br.readLine()) != null) {

--- a/src/main/java/org/jvnet/hudson/test/ExtractResourceWithChangesSCM.java
+++ b/src/main/java/org/jvnet/hudson/test/ExtractResourceWithChangesSCM.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -94,7 +95,7 @@ public class ExtractResourceWithChangesSCM extends NullSCM {
                     changeLog.addFile(new ExtractChangeLogParser.FileInZip(e.getName()));
             }
         }
-        saveToChangeLog(changeLogFile, changeLog);
+        saveToChangeLog(changeLogFile, build.getCharset(), changeLog);
 
         return true;
     }
@@ -104,8 +105,16 @@ public class ExtractResourceWithChangesSCM extends NullSCM {
         return new ExtractChangeLogParser();
     }
 
+    /**
+     * @deprecated use {@link #saveToChangeLog(File, Charset, ExtractChangeLogParser.ExtractChangeLogEntry)}
+     */
+    @Deprecated
     public void saveToChangeLog(File changeLogFile, ExtractChangeLogParser.ExtractChangeLogEntry changeLog) throws IOException {
-        try (PrintStream ps = new PrintStream(changeLogFile)) {
+        saveToChangeLog(changeLogFile, Charset.defaultCharset(), changeLog);
+    }
+
+    public void saveToChangeLog(File changeLogFile, Charset charset, ExtractChangeLogParser.ExtractChangeLogEntry changeLog) throws IOException {
+        try (PrintStream ps = new PrintStream(changeLogFile, charset.name())) {
             ps.println(changeLog.getZipFile());
             for (String fileName : changeLog.getAffectedPaths()) {
                 ps.println(fileName);

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -126,6 +126,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -740,7 +741,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      */
     public void interactiveBreak() throws Exception {
         System.out.println("Jenkins is running at http://localhost:"+localPort+"/");
-        new BufferedReader(new InputStreamReader(System.in)).readLine();
+        new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset())).readLine();
     }
 
     /**
@@ -757,7 +758,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      * from an browser, while developing a test case.
      */
     protected void pause() throws IOException {
-        new BufferedReader(new InputStreamReader(System.in)).readLine();
+        new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset())).readLine();
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -146,6 +146,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.nio.channels.ClosedByInterruptException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.AbstractMap;
@@ -1244,7 +1245,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      */
     public void interactiveBreak() throws Exception {
         System.out.println("Jenkins is running at " + getURL());
-        new BufferedReader(new InputStreamReader(System.in)).readLine();
+        new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset())).readLine();
     }
 
     /**
@@ -1261,7 +1262,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * from an browser, while developing a test case.
      */
     public void pause() throws IOException {
-        new BufferedReader(new InputStreamReader(System.in)).readLine();
+        new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset())).readLine();
     }
 
     /**
@@ -2707,7 +2708,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
          * @since 2.32
          */
         public @NonNull WebClient withBasicCredentials(@NonNull String login, @NonNull String passwordOrToken) {
-            String authCode = new String(Base64.getEncoder().encode((login + ":" + passwordOrToken).getBytes(StandardCharsets.UTF_8)));
+            String authCode = Base64.getEncoder().encodeToString((login + ":" + passwordOrToken).getBytes(StandardCharsets.UTF_8));
 
             addRequestHeader(HttpHeaders.AUTHORIZATION, "Basic " + authCode);
             return this;


### PR DESCRIPTION
Fixes the following SpotBugs violations:

```
[ERROR] High: Found reliance on default encoding in hudson.cli.CLICommandInvoker.invoke(): new java.io.PrintStream(OutputStream) [hudson.cli.CLICommandInvoker] At CLICommandInvoker.java:[line 142] DM_DEFAULT_ENCODING
[ERROR] High: Found reliance on default encoding in hudson.cli.CLICommandInvoker$Result.stderr(): java.io.ByteArrayOutputStream.toString() [hudson.cli.CLICommandInvoker$Result] At CLICommandInvoker.java:[line 264] DM_DEFAULT_ENCODING
[ERROR] High: Found reliance on default encoding in hudson.cli.CLICommandInvoker$Result.stdout(): java.io.ByteArrayOutputStream.toString() [hudson.cli.CLICommandInvoker$Result] At CLICommandInvoker.java:[line 255] DM_DEFAULT_ENCODING
[ERROR] High: Found reliance on default encoding in org.jvnet.hudson.test.ExtractChangeLogParser.parse(AbstractBuild, InputStream): new java.io.InputStreamReader(InputStream) [org.jvnet.hudson.test.ExtractChangeLogParser] At ExtractChangeLogParser.java:[line 65] DM_DEFAULT_ENCODING
[ERROR] High: Found reliance on default encoding in org.jvnet.hudson.test.ExtractResourceWithChangesSCM.saveToChangeLog(File, ExtractChangeLogParser$ExtractChangeLogEntry): new java.io.PrintStream(File) [org.jvnet.hudson.test.ExtractResourceWithChangesSCM] At ExtractResourceWithChangesSCM.java:[line 108] DM_DEFAULT_ENCODING
[ERROR] High: Found reliance on default encoding in org.jvnet.hudson.test.HudsonTestCase.interactiveBreak(): new java.io.InputStreamReader(InputStream) [org.jvnet.hudson.test.HudsonTestCase] At HudsonTestCase.java:[line 740] DM_DEFAULT_ENCODING
[ERROR] High: Found reliance on default encoding in org.jvnet.hudson.test.HudsonTestCase.pause(): new java.io.InputStreamReader(InputStream) [org.jvnet.hudson.test.HudsonTestCase] At HudsonTestCase.java:[line 757] DM_DEFAULT_ENCODING
[ERROR] High: Found reliance on default encoding in org.jvnet.hudson.test.JenkinsRule.interactiveBreak(): new java.io.InputStreamReader(InputStream) [org.jvnet.hudson.test.JenkinsRule] At JenkinsRule.java:[line 1242] DM_DEFAULT_ENCODING
[ERROR] High: Found reliance on default encoding in org.jvnet.hudson.test.JenkinsRule.pause(): new java.io.InputStreamReader(InputStream) [org.jvnet.hudson.test.JenkinsRule] At JenkinsRule.java:[line 1259] DM_DEFAULT_ENCODING
[ERROR] High: Found reliance on default encoding in org.jvnet.hudson.test.JenkinsRule$WebClient.withBasicCredentials(String, String): new String(byte[]) [org.jvnet.hudson.test.JenkinsRule$WebClient] At JenkinsRule.java:[line 2698] DM_DEFAULT_ENCODING
```