### PR TITLE
Remove unneeded injected test

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JellyTestSuiteBuilder.java
+++ b/src/main/java/org/jvnet/hudson/test/JellyTestSuiteBuilder.java
@@ -101,7 +101,6 @@ public class JellyTestSuiteBuilder {
         protected void runTest() throws Exception {
             jct.createContext().compileScript(jelly);
             Document dom = new SAXReader().read(jelly);
-            checkLabelFor(dom);
             if (requirePI) {
                 ProcessingInstruction pi = dom.processingInstruction("jelly");
                 if (pi==null || !pi.getText().contains("escape-by-default"))
@@ -109,18 +108,6 @@ public class JellyTestSuiteBuilder {
 
             }
             // TODO: what else can we check statically? use of taglibs?
-        }
-
-        /**
-         * Makes sure that &lt;label for=...> is not used inside config.jelly nor global.jelly
-         */
-        private void checkLabelFor(Document dom) {
-            if (isConfigJelly() || isGlobalJelly()) {
-                if (!dom.selectNodes("//label[@for]").isEmpty())
-                    throw new AssertionError("<label for=...> shouldn't be used because it doesn't work " +
-                            "when the configuration item is repeated. Use <label class=\"attach-previous\"> " +
-                            "to have your label attach to the previous DOM node instead.\nurl="+jelly);
-            }
         }
 
         private boolean isConfigJelly() {


### PR DESCRIPTION
As of https://github.com/jenkinsci/jenkins/pull/5923 `f:radio` uses `for=` to attach labels by generating a unique ID per input.

[Theme manager](https://github.com/jenkinsci/theme-manager-plugin/pull/75) is using a similar (completely safe) method.

Can we remove this test please given core is using this pattern?

One of the annoying parts of `InjectedTest` is you can't selectively disable it -.-