### PR TITLE
Restore working version of `MemoryAssert#assertGC`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.netbeans.modules</groupId>
       <artifactId>org-netbeans-insane</artifactId>
-      <version>RELEASE130</version>
+      <version>RELEASE126</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/src/test/java/org/jvnet/hudson/test/MemoryAssertTest.java
+++ b/src/test/java/org/jvnet/hudson/test/MemoryAssertTest.java
@@ -54,8 +54,7 @@ public class MemoryAssertTest {
 
     @Test
     public void gc() {
-        // TODO JENKINS-67974 does not work on Java 9+
-        assumeTrue(new VersionNumber(System.getProperty("java.specification.version")).isOlderThan(new VersionNumber("9")));
+        assumeTrue("TODO JENKINS-67974 does not work on Java 9+", new VersionNumber(System.getProperty("java.specification.version")).isOlderThan(new VersionNumber("9")));
         List<String> strings = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             strings.add(Integer.toString(i));


### PR DESCRIPTION
Reverts #397 and adds test coverage for `MemoryAssert#assertGC`. The new test fails without the revert of #397 and passes with the revert of #397.

Fixes #360