### PR TITLE
Add Java 11 to build/test matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,10 @@
-properties([buildDiscarder(logRotator(numToKeepStr: '20'))])
-node('maven') {
-    timeout(time: 1, unit: 'HOURS') {
-        checkout scm
-        // TODO Azure mirror
-        sh 'mvn -B -ntp -e -Dset.changelist -Dmaven.test.failure.ignore clean install'
-        junit '**/target/surefire-reports/TEST-*.xml'
-        infra.prepareToPublishIncrementals()
-    }
-}
-infra.maybePublishIncrementals()
+/*
+ * While this is not a plugin, it is much simpler to reuse the pipeline code for CI. This allows for
+ * easy Linux/Windows testing and produces incrementals. The only feature that relates to plugins is
+ * allowing one to test against multiple Jenkins versions.
+ */
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '8' ],
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ]
+])


### PR DESCRIPTION
Update the build/test matrix to include recent versions of Java, as is being done in other core components.