### PR TITLE
Add Java 17 to build/test matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,6 @@
 buildPlugin(useContainerAgent: true, configurations: [
   [ platform: 'linux', jdk: '8' ],
   [ platform: 'linux', jdk: '11' ],
-  [ platform: 'windows', jdk: '11' ]
+  [ platform: 'windows', jdk: '11' ],
+  [ platform: 'linux', jdk: '17', jenkins: '2.339' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@ THE SOFTWARE.
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
+    <jenkins.version>2.204</jenkins.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.45.v20220203</jetty.version>
     <hamcrest.version>2.2</hamcrest.version>
@@ -87,7 +88,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
-      <version>2.204</version>
+      <version>${jenkins.version}</version>
       <type>executable-war</type>
       <!--
         To ensure consistent set of core artifacts are used, force the users to declare


### PR DESCRIPTION
Update the build/test matrix to include recent versions of Java, as is being done in other core components. Note that the first version of Jenkins core that fully support Java 17 without custom `--add-opens` directives (which is needed for tests like `RealJenkinsRuleTest`) is 2.339, so we run the Java 17 tests with a newer Jenkins core version than the Java 8 and 11 tests.