### PR TITLE
Remove `-Dfile.encoding=UTF-8` from Surefire JVM arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@ THE SOFTWARE.
         <!-- version specified in grandparent pom -->
         <configuration>
           <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
-          <argLine>-Dfile.encoding=UTF-8 -Xmx256m -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+          <argLine>-Xmx256m -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
           <systemPropertyVariables>
             <hudson.maven.debug>${mavenDebug}</hudson.maven.debug>
             <buildDirectory>${project.build.directory}</buildDirectory>


### PR DESCRIPTION
The original provenance of this code was jenkinsci/jenkins@e56c9d7802, where it was added for core's `DirectoryBrowserSupportTest`. This code was retained as the test harness was split into a new repository, but it is not needed for any of the tests in this repository. Let us dispense with it and run the Windows tests in a more realistic configuration.