### PR TITLE
Forward compatibility with Java 17 Javadoc generation

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TestExtension.java
+++ b/src/main/java/org/jvnet/hudson/test/TestExtension.java
@@ -51,8 +51,8 @@ public @interface TestExtension {
     /**
      * To make this extension only active for one test case, specify the test method name.
      * Otherwise, leave it unspecified and it'll apply to all the test methods defined in the same class.
+     * For example:
      *
-     * <h2>Example</h2>
      * <pre>
      * class FooTest extends HudsonTestCase {
      *     public void test1() { ... }


### PR DESCRIPTION
Extracted from #402. Without this, generating Javadoc on Java 17 fails with some obscure message about heading levels being wrong.