### PR TITLE
Remove obsolete workaround for SUREFIRE-1588

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,8 +268,7 @@ THE SOFTWARE.
         <artifactId>maven-surefire-plugin</artifactId>
         <!-- version specified in grandparent pom -->
         <configuration>
-          <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
-          <argLine>-Xmx256m -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+          <argLine>-Xmx256m -Djava.awt.headless=true</argLine>
           <systemPropertyVariables>
             <hudson.maven.debug>${mavenDebug}</hudson.maven.debug>
             <buildDirectory>${project.build.directory}</buildDirectory>


### PR DESCRIPTION
[SUREFIRE-1588](https://issues.apache.org/jira/browse/SUREFIRE-1588) has not seen any activity since 2018, so I think this workaround is no longer necessary.