### PR TITLE
Java 17 support for `RealJenkinsRule`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -437,6 +437,7 @@ public final class RealJenkinsRule implements TestRule {
         argv.addAll(javaOptions);
         argv.addAll(Arrays.asList(
                 "-jar", findJenkinsWar().getAbsolutePath(),
+                "--enable-future-java",
                 "--httpPort=" + port, "--httpListenAddress=127.0.0.1",
                 "--prefix=/jenkins"));
         ProcessBuilder pb = new ProcessBuilder(argv);


### PR DESCRIPTION
Extracted from #402. Without this, running `mvn clean verify -Dtest=org.jvnet.hudson.test.RealJenkinsRuleTest` on Java 17 hangs with

```
[INFO] Running org.jvnet.hudson.test.RealJenkinsRuleTest
=== Starting agentBuild(org.jvnet.hudson.test.RealJenkinsRuleTest)
Will load plugins: RealJenkinsRuleInit.jpi structs.jpi
Launching: [/usr/lib/jvm/java-17-openjdk-amd64/bin/java, -ea, -Dhudson.Main.development=true, -DRealJenkinsRule.location=file:jenkinsci/jenkins-test-harness/target/classes/, -DRealJenkinsRule.url=http://localhost:54116/jenkins/, -DRealJenkinsRule.description=agentBuild(org.jvnet.hudson.test.RealJenkinsRuleTest), -DRealJenkinsRule.token=b00b037d-9edc-4a9f-b55b-9898a826a625, -jar, jenkins-war-2.339-rc32171.7ef4d9496734.war, --httpPort=54116, --httpListenAddress=127.0.0.1, --prefix=/jenkins]
Mar 13, 2022 10:22:38 AM Main verifyJavaVersion
SEVERE: Running with Java class version 61 which is not in the list of supported versions: [52, 55]. Run with the --enable-future-java flag to enable such behavior. See https://jenkins.io/redirect/java-support/
java.lang.UnsupportedClassVersionError: 61.0
        at Main.verifyJavaVersion(Main.java:130)
        at Main.main(Main.java:99)

Jenkins requires Java versions [8, 11] but you are running with Java 17 from /usr/lib/jvm/java-17-openjdk-amd64
java.lang.UnsupportedClassVersionError: 61.0
        at Main.verifyJavaVersion(Main.java:130)
        at Main.main(Main.java:99)
```