### PR TITLE
Java 17 support for `SimpleCommandLauncher`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/SimpleCommandLauncher.java
+++ b/src/main/java/org/jvnet/hudson/test/SimpleCommandLauncher.java
@@ -37,6 +37,8 @@ import hudson.slaves.SlaveComputer;
 import hudson.util.ProcessTree;
 import hudson.util.StreamCopyThread;
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -49,7 +51,7 @@ public class SimpleCommandLauncher extends ComputerLauncher {
     private static final Logger LOGGER = Logger.getLogger(SimpleCommandLauncher.class.getName());
 
     public final String cmd;
-    private final EnvVars env;
+    private final Map<String, String> env;
 
     @DataBoundConstructor // in case anyone needs to configRoundtrip such a node
     public SimpleCommandLauncher(String cmd) {
@@ -58,7 +60,7 @@ public class SimpleCommandLauncher extends ComputerLauncher {
 
     SimpleCommandLauncher(String cmd, EnvVars env) {
         this.cmd = cmd;
-        this.env = env;
+        this.env = env != null ? new LinkedHashMap<>(env) : null;
     }
 
     @Override

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -4,6 +4,7 @@ import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 
+import hudson.EnvVars;
 import hudson.model.RootAction;
 import hudson.model.User;
 import jenkins.model.Jenkins;
@@ -383,5 +384,11 @@ public class JenkinsRuleTest {
         public String getSetterParam() {
             return setterParam;
         }
+    }
+
+    @Test
+    public void serialization() throws Exception {
+        j.createSlave("agent", "agent", new EnvVars());
+        j.jenkins.save();
     }
 }


### PR DESCRIPTION
Noticed the following error when running `com.cloudbees.jenkins.support.configfiles.AgentsConfigFileTest#agentsConfigFile` on Java 17 in https://github.com/jenkinsci/bom/pull/935. I wrote up a quick test in this repository and could reproduce the same error in this repository by running `mvn clean verify -Dtest=org.jvnet.hudson.test.JenkinsRuleTest#serialization -Djenkins.version=2.339 '-DargLine=--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED'`. Looking into this further, it appears we are trying to serialize `EnvVars` from the test harness, but this is not a realistic production use case and XStream can't serialize this type with Java 17 modularity rules. Since the particular map used is an implementation detail, let us copy the contents to a `LinkedHashMap` (to preserve ordering) which is a simpler data structure that XStream can serialize without issue on Java 17. With this PR the new test in this repository passes, and I can also successfully run `com.cloudbees.jenkins.support.configfiles.AgentsConfigFileTest#agentsConfigFile` on Java 17.

```
java.io.IOException: java.lang.RuntimeException: Failed to serialize hudson.model.Slave#launcher for class hudson.slaves.DumbSlave
	at hudson.XmlFile.write(XmlFile.java:220)
	at jenkins.model.Nodes.persistNode(Nodes.java:183)
	at jenkins.model.Nodes.addNode(Nodes.java:148)
	at jenkins.model.Jenkins.addNode(Jenkins.java:2206)
	at org.jvnet.hudson.test.JenkinsRule.createSlave(JenkinsRule.java:1046)
	at com.cloudbees.jenkins.support.configfiles.AgentsConfigFileTest.agentsConfigFile(AgentsConfigFileTest.java:47)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:606)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.RuntimeException: Failed to serialize hudson.model.Slave#launcher for class hudson.slaves.DumbSlave
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:274)
	at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:241)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:174)
	at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:226)
	at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:163)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:59)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:44)
	at com.thoughtworks.xstream.core.TreeMarshaller.start(TreeMarshaller.java:83)
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.marshal(AbstractTreeMarshallingStrategy.java:37)
	at com.thoughtworks.xstream.XStream.marshal(XStream.java:1266)
	at com.thoughtworks.xstream.XStream.marshal(XStream.java:1255)
	at com.thoughtworks.xstream.XStream.toXML(XStream.java:1228)
	at hudson.XmlFile.write(XmlFile.java:213)
	... 18 more
Caused by: java.lang.RuntimeException: Failed to serialize org.jvnet.hudson.test.SimpleCommandLauncher#env for class org.jvnet.hudson.test.SimpleCommandLauncher
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:274)
	at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:241)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:174)
	at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:226)
	at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:163)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:59)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
	at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:283)
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:270)
	... 31 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field transient java.util.Set java.util.AbstractMap.keySet accessible: module java.base does not "opens java.util" to unnamed module @6c38726a
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at com.thoughtworks.xstream.converters.reflection.FieldDictionary.buildDictionaryEntryForClass(FieldDictionary.java:176)
	at com.thoughtworks.xstream.converters.reflection.FieldDictionary.buildMap(FieldDictionary.java:142)
	at com.thoughtworks.xstream.converters.reflection.FieldDictionary.fieldsFor(FieldDictionary.java:80)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:167)
	at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:206)
	at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:163)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:59)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
	at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:283)
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:270)
	... 40 more
```