### PR TITLE
Allow `RealJenkinsRule` to use a specific WAR file

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -246,10 +246,7 @@ public final class RealJenkinsRule implements TestRule {
      * @param war The war file to be used.
      */
     public RealJenkinsRule withWar(File war) {
-        if (war != null && war.isFile()) {
-            this.war = war;
-        }
-
+        this.war = war;
         return this;
     }
 

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -430,12 +430,7 @@ public final class RealJenkinsRule implements TestRule {
         return home;
     }
 
-    private File findJenkinsWar() throws Exception {
-        // First take the war from rule
-        if (war != null) {
-            return war;
-        }
-
+    private static File findJenkinsWar() throws Exception {
         // Adapted from WarExploder.explode
 
         // Are we in Jenkins core? If so, pick up "war/target/jenkins.war".
@@ -471,8 +466,11 @@ public final class RealJenkinsRule implements TestRule {
             argv.add("-agentlib:jdwp=transport=dt_socket,server=y");
         }
         argv.addAll(javaOptions);
+
+        String warAbsolutePath = war == null ? findJenkinsWar().getAbsolutePath() : war.getAbsolutePath();
+
         argv.addAll(Arrays.asList(
-                "-jar", findJenkinsWar().getAbsolutePath(),
+                "-jar", warAbsolutePath,
                 "--enable-future-java",
                 "--httpPort=" + port, "--httpListenAddress=127.0.0.1",
                 "--prefix=/jenkins"));

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -242,8 +242,7 @@ public final class RealJenkinsRule implements TestRule {
     }
 
     /**
-     * Sets a custom war file to be used by the rule instead of the one in the path or war/target/jenkins.war in case of core.
-     * @param war The war file to be used.
+     * Sets a custom WAR file to be used by the rule instead of the one in the path or {@code war/target/jenkins.war} in case of core.
      */
     public RealJenkinsRule withWar(File war) {
         this.war = war;
@@ -254,8 +253,7 @@ public final class RealJenkinsRule implements TestRule {
      * The intended use case for this is to use the plugins bundled into the war {@link RealJenkinsRule#withWar(File)}
      * instead of the plugins in the pom. A typical scenario for this feature is a test which does not live inside a
      * plugin's src/test/java
-     * Default value: true
-     * @param includeTestClasspathPlugins false if plugins from pom should not be used
+     * @param includeTestClasspathPlugins false if plugins from pom should not be used (default true)
      */
     public RealJenkinsRule includeTestClasspathPlugins(boolean includeTestClasspathPlugins) {
         this.includeTestClasspathPlugins = includeTestClasspathPlugins;

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -144,15 +144,9 @@ public final class RealJenkinsRule implements TestRule {
      */
     private int port;
 
-    /**
-     * The war file to be used instead of the one in the path or war/target/jenkins.war if it is core build.
-     */
     private File war;
 
-    /**
-     * If true, all plugins from pom will be skipped. Extra plugins are not ignored.
-     */
-    private boolean skipAllPlugins = false;
+    private boolean includeTestClasspathPlugins = true;
 
     private final String token = UUID.randomUUID().toString();
 
@@ -259,8 +253,15 @@ public final class RealJenkinsRule implements TestRule {
         return this;
     }
 
-    public RealJenkinsRule skipAllPlugins(boolean skipAllPlugins) {
-        this.skipAllPlugins = skipAllPlugins;
+    /**
+     * The intended use case for this is to use the plugins bundled into the war {@link RealJenkinsRule#withWar(File)}
+     * instead of the plugins in the pom. A typical scenario for this feature is a test which does not live inside a
+     * plugin's src/test/java
+     * Default value: true
+     * @param includeTestClasspathPlugins false if plugins from pom should not be used
+     */
+    public RealJenkinsRule includeTestClasspathPlugins(boolean includeTestClasspathPlugins) {
+        this.includeTestClasspathPlugins = includeTestClasspathPlugins;
         return this;
     }
 
@@ -280,7 +281,7 @@ public final class RealJenkinsRule implements TestRule {
                     plugins.mkdir();
                     FileUtils.copyURLToFile(RealJenkinsRule.class.getResource("RealJenkinsRuleInit.jpi"), new File(plugins, "RealJenkinsRuleInit.jpi"));
 
-                    if (skipAllPlugins) {
+                    if (includeTestClasspathPlugins) {
                         // Adapted from UnitTestSupportingPluginManager & JenkinsRule.recipeLoadCurrentPlugin:
                         Set<String> snapshotPlugins = new TreeSet<>();
                         Enumeration<URL> indexJellies = RealJenkinsRule.class.getClassLoader().getResources("index.jelly");


### PR DESCRIPTION
Fixes #414

Instead of using the war on the path defined as part of the pom, or the one at war/target/jenkins.war, or using the system property affecting all tests, I can now create a RealJenkinsRule using a war (ie. a war built as part of the workflow). 

```java
@Rule
public RealJenkinsRule sc = new RealJenkinsRule()
                .javaOptions("-Xmx512M")
                .withHost("sc.127.0.0.1.nip.io")
                .withWar(new File("/path/to/my/own/jenkins.war"));
```