### PR TITLE
[JENKINS-67974] `assertGC` works on Java 8 and 17 but not 11

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
+++ b/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
@@ -155,8 +155,12 @@ public class MemoryAssert {
      * @param allowSoft if true, pass even if {@link SoftReference}s apparently needed to be cleared by forcing an {@link OutOfMemoryError};
      *                  if false, fail in such a case (though the failure will be slow)
      */
-    @SuppressFBWarnings({"DLS_DEAD_LOCAL_STORE_OF_NULL", "DM_GC"})
+    @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE_OF_NULL")
     public static void assertGC(WeakReference<?> reference, boolean allowSoft) {
+        VersionNumber javaVersion = new VersionNumber(System.getProperty("java.specification.version"));
+        assumeTrue(
+                "TODO JENKINS-67974 works on Java 8 and 17 but not 11",
+                javaVersion.isOlderThan(new VersionNumber("9")) || javaVersion.isNewerThanOrEqualTo(new VersionNumber("17")));
         assertTrue(true); reference.get(); // preload any needed classes!
         System.err.println("Trying to collect " + reference.get() + "…");
         Set<Object[]> objects = new HashSet<>();
@@ -168,11 +172,6 @@ public class MemoryAssert {
                 size *= 1.3;
             } catch (OutOfMemoryError ignore) {
                 if (softErr != null) {
-                    VersionNumber javaVersion =
-                            new VersionNumber(System.getProperty("java.specification.version"));
-                    assumeTrue(
-                            "TODO JENKINS-67974 works on Java 8 and 17 but not 11",
-                            javaVersion.isOlderThan(new VersionNumber("9")) || javaVersion.isNewerThanOrEqualTo(new VersionNumber("17")));
                     fail(softErr);
                 } else {
                     break;

--- a/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
+++ b/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
@@ -25,6 +25,7 @@
 package org.jvnet.hudson.test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.util.VersionNumber;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
@@ -41,6 +42,7 @@ import javax.swing.BoundedRangeModel;
 
 import jenkins.model.Jenkins;
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
 
 import org.netbeans.insane.impl.LiveEngine;
 import org.netbeans.insane.live.LiveReferences;
@@ -166,6 +168,11 @@ public class MemoryAssert {
                 size *= 1.3;
             } catch (OutOfMemoryError ignore) {
                 if (softErr != null) {
+                    VersionNumber javaVersion =
+                            new VersionNumber(System.getProperty("java.specification.version"));
+                    assumeTrue(
+                            "TODO JENKINS-67974 works on Java 8 and 17 but not 11",
+                            javaVersion.isOlderThan(new VersionNumber("9")) || javaVersion.isNewerThanOrEqualTo(new VersionNumber("17")));
                     fail(softErr);
                 } else {
                     break;

--- a/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
+++ b/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
@@ -155,7 +155,7 @@ public class MemoryAssert {
      * @param allowSoft if true, pass even if {@link SoftReference}s apparently needed to be cleared by forcing an {@link OutOfMemoryError};
      *                  if false, fail in such a case (though the failure will be slow)
      */
-    @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE_OF_NULL")
+    @SuppressFBWarnings({"DLS_DEAD_LOCAL_STORE_OF_NULL", "DM_GC"})
     public static void assertGC(WeakReference<?> reference, boolean allowSoft) {
         assertTrue(true); reference.get(); // preload any needed classes!
         System.err.println("Trying to collect " + reference.get() + "…");

--- a/src/test/java/org/jvnet/hudson/test/MemoryAssertTest.java
+++ b/src/test/java/org/jvnet/hudson/test/MemoryAssertTest.java
@@ -25,12 +25,14 @@
 package org.jvnet.hudson.test;
 
 import java.lang.ref.WeakReference;
+import static org.junit.Assume.assumeTrue;
 import static org.jvnet.hudson.test.MemoryAssert.*;
 import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import hudson.util.VersionNumber;
 import org.junit.Test;
 
 public class MemoryAssertTest {
@@ -52,6 +54,10 @@ public class MemoryAssertTest {
 
     @Test
     public void gc() {
+        VersionNumber javaVersion = new VersionNumber(System.getProperty("java.specification.version"));
+        assumeTrue(
+                "TODO JENKINS-67974 works on Java 8 and 17 but not 11",
+                javaVersion.isOlderThan(new VersionNumber("9")) || javaVersion.isNewerThanOrEqualTo(new VersionNumber("17")));
         List<String> strings = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             strings.add(Integer.toString(i));


### PR DESCRIPTION
The following tests (when run against tip-of-trunk core, Maven HPI plugin, and test harness) fail when run with Java 11, but not when run with Java 8 or Java 17:

```
mvn clean verify -Dtest=org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovyMemoryLeakTest
mvn clean verify -Dtest=org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest
mvn clean verify -Dtest=org.jenkinsci.plugins.workflow.cps.CpsFlowExecutionMemoryTest
mvn clean verify -Dtest=org.jenkinsci.plugins.workflow.job.MemoryCleanupTest
```

I examined the test output from the Java 17 run and saw that it looked identical to the Java 8 run, so I think the Java 17 run really is doing the proper testing and not just passing accidentally. The Java 17 run is using the latest version of INSANE with the INSANE hooks.

I am not sure why the Java 11 run is failing, but I am not inclined to spend much time on it if things are working on Java 8 and Java 17. Rather I think we should just skip the test on Java 11.

Interestingly enough, the test coverage for `assertGC` in this repository does pass on Java 11, and the `MemoryAssert#assertGC`-based tests in core do pass on Java 11, so I think `assertGC` is actually somewhat working on Java 11, just not in all cases. Java 17 has worked in all cases that I tested.

So rather than skipping `assertGC` on Java 11 in all cases, let's just skip it on Java 11 in the cases where it fails. That is what this PR does.

To test this, I ran the 4 tests described above with Java 8, 11, and 17. Before, 8 and 17 passed and 11 failed. Now, 11 is skipped after printing "[WARNING] Corrupted STDOUT by directly writing to native stream in forked JVM 1"; 8 and 17 still pass.

The tests that call `assertGC` in this repository and in core passed in Java 8, 11, and 17 before this PR and continue to pass after this PR.

Unfortunately I am not sure how the test coverage in this repository could be improved.