### PR TITLE
Run RealJenkinsRule steps on a separate thread to avoid unintended interaction with the request for doStep

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -553,11 +553,13 @@ public final class RealJenkinsRule implements TestRule {
         try {
             error = (Throwable) Init2.readSer(conn.getInputStream(), null);
         } catch (IOException e) {
-            try {
-                String errorMessage = IOUtils.toString(conn.getErrorStream(), StandardCharsets.UTF_8);
-                e.addSuppressed(new IOException("Response body: " + errorMessage));
-            } catch (IOException e2) {
-                e.addSuppressed(e2);
+            if (conn.getErrorStream() != null) {
+                try {
+                    String errorMessage = IOUtils.toString(conn.getErrorStream(), StandardCharsets.UTF_8);
+                    e.addSuppressed(new IOException("Response body: " + errorMessage));
+                } catch (IOException e2) {
+                    e.addSuppressed(e2);
+                }
             }
             error = e;
         }

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -544,7 +544,18 @@ public final class RealJenkinsRule implements TestRule {
         conn.setRequestProperty("Content-Type", "application/octet-stream");
         conn.setDoOutput(true);
         Init2.writeSer(conn.getOutputStream(), Arrays.asList(token, s));
-        Throwable error = (Throwable) Init2.readSer(conn.getInputStream(), null);
+        Throwable error;
+        try {
+            error = (Throwable) Init2.readSer(conn.getInputStream(), null);
+        } catch (IOException e) {
+            try {
+                String errorMessage = IOUtils.toString(conn.getErrorStream(), StandardCharsets.UTF_8);
+                e.addSuppressed(new IOException("Response body: " + errorMessage));
+            } catch (IOException e2) {
+                e.addSuppressed(e2);
+            }
+            error = e;
+        }
         if (error != null) {
             throw error;
         }

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -47,10 +47,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.recipes.LocalData;
+import org.kohsuke.stapler.Stapler;
 
 public class RealJenkinsRuleTest {
 
@@ -160,6 +162,13 @@ public class RealJenkinsRuleTest {
     private static void _restart2(JenkinsRule r) throws Throwable {
         assertEquals(r.jenkins.getRootUrl(), r.getURL().toString());
         assertEquals(r.jenkins.getRootUrl(), FileUtils.readFileToString(new File(r.jenkins.getRootDir(), "url.txt"), StandardCharsets.UTF_8));
+    }
+
+    @Test public void stepsDoNotRunOnHttpWorkerThread() throws Throwable {
+        rr.then(RealJenkinsRuleTest::_stepsDoNotRunOnHttpWorkerThread);
+    }
+    private static void _stepsDoNotRunOnHttpWorkerThread(JenkinsRule r) throws Throwable {
+        assertNull(Stapler.getCurrentRequest());
     }
 
     // TODO interesting scenarios to test:


### PR DESCRIPTION
I recently ran into a `RealJenkinsRule` test that called code that used `Stapler.getCurrentRequest`, which ended up failing with a confusing error message because `Stapler.getCurrentRequest` returned the request for `RealJenkinsRule.doStep` instead of `null` as would typically be the case in a test. This PR does two things to improve this case:

1. It includes the response body of `RealJenkinsRule.doStep` in the error thrown by `RealJenkinsRule.runRemotely` if `doStep` returns a non-200 response to make it easier to diagnose errors.
2. It runs the steps passed to `RealJenkinsRule.runRemotely` on a separate thread so that they cannot accidentally interact with the HTTP request for `RealJenkinsRule.doStep` if they use `Stapler.getCurrentRequest`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
