### PR TITLE
Print flags specified on command line or set by ergonomics

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -689,7 +689,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     public ComputerLauncher createComputerLauncher(EnvVars env) throws URISyntaxException, IOException {
         int sz = jenkins.getNodes().size();
         return new SimpleCommandLauncher(
-                String.format("\"%s/bin/java\" %s %s -Xmx512M -jar \"%s\"",
+                String.format("\"%s/bin/java\" %s %s -Xmx512m -XX:+PrintCommandLineFlags -jar \"%s\"",
                         System.getProperty("java.home"),
                         SLAVE_DEBUG_PORT>0 ? " -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address="+(SLAVE_DEBUG_PORT+sz): "",
                         "-Djava.awt.headless=true",

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1067,7 +1067,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     public ComputerLauncher createComputerLauncher(@CheckForNull EnvVars env) throws URISyntaxException, IOException {
         int sz = jenkins.getNodes().size();
         return new SimpleCommandLauncher(
-                String.format("\"%s/bin/java\" %s %s -Xmx512M -jar \"%s\"",
+                String.format("\"%s/bin/java\" %s %s -Xmx512m -XX:+PrintCommandLineFlags -jar \"%s\"",
                         System.getProperty("java.home"),
                         SLAVE_DEBUG_PORT>0 ? " -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address="+(SLAVE_DEBUG_PORT+sz): "",
                         "-Djava.awt.headless=true",


### PR DESCRIPTION
Sample output below. This information can be essential when reasoning about memory usage by multiple JVMs within a single VM or container.

Java 8:

```
$ "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"  -Djava.awt.headless=true -Xmx512m -XX:+PrintCommandLineFlags -jar "/home/basil/src/jenkinsci/text-finder-plugin/target/jenkins-for-test/WEB-INF/lib/remoting-4.5.jar"
-XX:InitialHeapSize=523530944 -XX:MaxHeapSize=536870912 -XX:+PrintCommandLineFlags -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseParallelGC 
<===[JENKINS REMOTING CAPACITY]===>channel started
Remoting version: 4.5
This is a Unix agent
Evacuated stdout
```

Java 11:

```
$ "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"  -Djava.awt.headless=true -Xmx512m -XX:+PrintCommandLineFlags -jar "/home/basil/src/jenkinsci/text-finder-plugin/target/jenkins-for-test/WEB-INF/lib/remoting-4.5.jar"
-XX:G1ConcRefinementThreads=8 -XX:GCDrainStackTargetSize=64 -XX:InitialHeapSize=523530944 -XX:MaxHeapSize=536870912 -XX:+PrintCommandLineFlags -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC 
<===[JENKINS REMOTING CAPACITY]===>channel started
Remoting version: 4.5
This is a Unix agent
```

Java 17:

```
$ "/usr/lib/jvm/java-17-openjdk-amd64/bin/java"  -Djava.awt.headless=true -Xmx512m -XX:+PrintCommandLineFlags -jar "/home/basil/src/jenkinsci/text-finder-plugin/target/jenkins-for-test/WEB-INF/lib/remoting-4.13.jar"
-XX:ConcGCThreads=2 -XX:G1ConcRefinementThreads=8 -XX:GCDrainStackTargetSize=64 -XX:InitialHeapSize=523530944 -XX:MarkStackSize=4194304 -XX:MaxHeapSize=536870912 -XX:MinHeapSize=6815736 -XX:+PrintCommandLineFlags -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC 
<===[JENKINS REMOTING CAPACITY]===>channel started
Remoting version: 4.13
This is a Unix agent
```