### PR TITLE
New `configRoundtrip` method for `Cloud` configuration

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -105,6 +105,7 @@ import hudson.security.ACL;
 import hudson.security.AbstractPasswordBasedSecurityRealm;
 import hudson.security.GroupDetails;
 import hudson.security.csrf.CrumbIssuer;
+import hudson.slaves.Cloud;
 import hudson.slaves.ComputerConnector;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.DumbSlave;
@@ -1424,6 +1425,13 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     public <V extends View> V configRoundtrip(V view) throws Exception {
         submit(createWebClient().getPage(view, "configure").getFormByName("viewConfig"));
         return view;
+    }
+
+    public <C extends Cloud> C configRoundtrip (C cloud) throws Exception {
+        jenkins.clouds.add(cloud);
+        jenkins.save();
+        submit(createWebClient().goTo("configureClouds/").getFormByName("config"));
+        return (C)jenkins.getCloud(cloud.name);
     }
 
 

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1427,7 +1427,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         return view;
     }
 
-    public <C extends Cloud> C configRoundtrip (C cloud) throws Exception {
+    public <C extends Cloud> C configRoundtrip(C cloud) throws Exception {
         jenkins.clouds.add(cloud);
         jenkins.save();
         submit(createWebClient().goTo("configureClouds/").getFormByName("config"));

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1431,7 +1431,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     /**
      * Performs a configuration round-trip testing for a cloud.
      * The given cloud is added to the cloud list of Jenkins.
-     *
+     * <p>
      * If a cloud with the same name already exists, then this old one will be replaced by the given one.
      */
     public <C extends Cloud> C configRoundtrip(C cloud) throws Exception {

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -181,6 +181,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletException;
@@ -1427,7 +1428,17 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         return view;
     }
 
+    /**
+     * Performs a configuration round-trip testing for a cloud.
+     * The given cloud is added to the cloud list of Jenkins.
+     *
+     * If a cloud with the same name already exists, then this old one will be replaced by the given one.
+     */
     public <C extends Cloud> C configRoundtrip(C cloud) throws Exception {
+        Cloud cloudConfig = jenkins.getCloud(cloud.name);
+        if (cloudConfig != null) {
+            jenkins.clouds.remove(cloudConfig);
+        }
         jenkins.clouds.add(cloud);
         jenkins.save();
         submit(createWebClient().goTo("configureClouds/").getFormByName("config"));


### PR DESCRIPTION
In Jenkins plugin [azure-container-plugin](https://github.com/jenkinsci/azure-container-agents-plugin/blob/1bf31f31ad77524b0699e4c6266cb709eef20855/src/test/java/com/microsoft/jenkins/containeragents/AciCloudConfigTest.java#L26), there is a use case to test the correctness of the cloud configuration. The JenkinsRule has no configRoundtrip method for the cloud configuration. 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
