### PR TITLE
Use `PropertyResourceBundle` in test suite and validate `.properties` files are not both valid UTF-8 and valid ISO-8859-1

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
+++ b/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
@@ -79,7 +79,7 @@ public class PropertiesTestSuite extends TestSuite {
                 }
             };
 
-            byte[] contents = IOUtils.toByteArray(resource.openStream());
+            byte[] contents = IOUtils.toByteArray(resource);
             if (!isEncoded(contents, StandardCharsets.US_ASCII)) {
                 boolean isUtf8 = isEncoded(contents, StandardCharsets.UTF_8);
                 boolean isIso88591 = isEncoded(contents, StandardCharsets.ISO_8859_1);

--- a/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
+++ b/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
@@ -28,10 +28,22 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.PropertyResourceBundle;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
+import org.apache.commons.io.IOUtils;
+
 import static org.jvnet.hudson.test.JellyTestSuiteBuilder.scan;
 
 /**
@@ -66,11 +78,43 @@ public class PropertiesTestSuite extends TestSuite {
                     return null;
                 }
             };
+
+            byte[] contents = IOUtils.toByteArray(resource.openStream());
+            if (!isEncoded(contents, StandardCharsets.US_ASCII)) {
+                boolean isUtf8 = isEncoded(contents, StandardCharsets.UTF_8);
+                boolean isIso88591 = isEncoded(contents, StandardCharsets.ISO_8859_1);
+                if (isUtf8 && isIso88591) {
+                    throw new AssertionError(resource + " is encoded with both valid utf-8 and ISO-8859-1 characters, the utf-8 characters need to be encoded with something like `native2ascii`");
+                }
+            }
+
             try (InputStream is = resource.openStream()) {
-                props.load(is);
+                PropertyResourceBundle propertyResourceBundle = new PropertyResourceBundle(is);
+                Enumeration<String> keys = propertyResourceBundle.getKeys();
+                // TODO Java 9+ can use 'asIterator' and get rid of below collections conversion
+                List<String> keysAsSaneType = Collections.list(keys);
+
+                for (String localKey : keysAsSaneType) {
+                    String value = propertyResourceBundle.getString(localKey);
+                    props.setProperty(localKey, value);
+                }
             }
         }
 
+    }
+
+    private static boolean isEncoded(byte[] bytes, Charset charset) {
+        CharsetDecoder decoder = charset.newDecoder();
+        decoder.onMalformedInput(CodingErrorAction.REPORT);
+        decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+
+        try {
+            decoder.decode(buffer);
+            return true;
+        } catch (CharacterCodingException e) {
+            return false;
+        }
     }
 
 }

--- a/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
+++ b/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
@@ -84,7 +84,7 @@ public class PropertiesTestSuite extends TestSuite {
                 boolean isUtf8 = isEncoded(contents, StandardCharsets.UTF_8);
                 boolean isIso88591 = isEncoded(contents, StandardCharsets.ISO_8859_1);
                 if (isUtf8 && isIso88591) {
-                    throw new AssertionError(resource + " is encoded with both valid utf-8 and ISO-8859-1 characters, the utf-8 characters need to be encoded with something like `native2ascii`");
+                    throw new AssertionError(resource + " is valid UTF-8 and valid ISO-8859-1. To avoid problems when auto-detecting the encoding, use the lowest common denominator of ASCII encoding and express non-ASCII characters with escape sequences using a tool like `native2ascii`.");
                 }
             }
 


### PR DESCRIPTION
see https://github.com/jenkinsci/jenkins/pull/6550#issuecomment-1121055141 https://github.com/jenkinsci/stapler/pull/357

You can't actually use a file that is valid utf-8 and not valid ISO-8859-1 in at least core right now due to https://github.com/jenkinsci/jenkins/blob/ff39fbb3cdf58d7dda17c37b8d0606dc8e9282f4/core/pom.xml#L604

But we can adjust that later when we switch to Java 11

Validated with core:
```
[ERROR] Tests run: 7139, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.743 s <<< FAILURE! - in jenkins.CorePropertiesTest
[ERROR] hudson/Messages_es.properties(org.jvnet.hudson.test.PropertiesTestSuite$PropertiesTest)  Time elapsed: 0.004 s  <<< FAILURE!
java.lang.AssertionError: jar:file:/Users/timja/.m2/repository/org/jenkins-ci/main/jenkins-core/2.347-SNAPSHOT/jenkins-core-2.347-SNAPSHOT.jar!/hudson/Messages_es.properties is encoded with both valid utf-8 and ISO-8859-1 characters, the utf-8 characters need to be encoded with something like `native2ascii`
	at org.jvnet.hudson.test.PropertiesTestSuite$PropertiesTest.runTest(PropertiesTestSuite.java:87)
```