### PR TITLE
[JENKINS-41729] Allow UTF-8 property files

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
+++ b/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
@@ -81,7 +81,8 @@ public class PropertiesTestSuite extends TestSuite {
                 }
             };
 
-            if (Jenkins.getVersion().isOlderThan(new VersionNumber("2.357"))) {
+            VersionNumber jv = Jenkins.getVersion();
+            if (jv != null && jv.isOlderThan(new VersionNumber("2.357"))) {
                 byte[] contents = IOUtils.toByteArray(resource);
                 if (!isEncoded(contents, StandardCharsets.US_ASCII)) {
                     boolean isUtf8 = isEncoded(contents, StandardCharsets.UTF_8);

--- a/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
+++ b/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
@@ -24,6 +24,7 @@
 
 package org.jvnet.hudson.test;
 
+import hudson.util.VersionNumber;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.PropertyResourceBundle;
+import jenkins.model.Jenkins;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.apache.commons.io.IOUtils;
@@ -79,12 +81,14 @@ public class PropertiesTestSuite extends TestSuite {
                 }
             };
 
-            byte[] contents = IOUtils.toByteArray(resource);
-            if (!isEncoded(contents, StandardCharsets.US_ASCII)) {
-                boolean isUtf8 = isEncoded(contents, StandardCharsets.UTF_8);
-                boolean isIso88591 = isEncoded(contents, StandardCharsets.ISO_8859_1);
-                if (isUtf8 && isIso88591) {
-                    throw new AssertionError(resource + " is valid UTF-8 and valid ISO-8859-1. To avoid problems when auto-detecting the encoding, use the lowest common denominator of ASCII encoding and express non-ASCII characters with escape sequences using a tool like `native2ascii`.");
+            if (Jenkins.getVersion().isOlderThan(new VersionNumber("2.357"))) {
+                byte[] contents = IOUtils.toByteArray(resource);
+                if (!isEncoded(contents, StandardCharsets.US_ASCII)) {
+                    boolean isUtf8 = isEncoded(contents, StandardCharsets.UTF_8);
+                    boolean isIso88591 = isEncoded(contents, StandardCharsets.ISO_8859_1);
+                    if (isUtf8 && isIso88591) {
+                        throw new AssertionError(resource + " is valid UTF-8 and valid ISO-8859-1. To avoid problems when auto-detecting the encoding, use the lowest common denominator of ASCII encoding and express non-ASCII characters with escape sequences using a tool like `native2ascii`.");
+                    }
                 }
             }
 


### PR DESCRIPTION
Amends #433. Allows the use of UTF-8 property files when running on Java 11 (i.e., when running on Jenkins 2.357 or greater). Note that this relies on `Jenkins#getVersion` having been initialized, which is only the case in plugin tests because the Jelly tests (which actually start Jenkins) have previously executed in the same VM and is only the case in core tests after some adjustments in https://github.com/jenkinsci/jenkins/pull/6719. Tested in a plugin (after converting a `.properties` file from ASCII to UTF-8) and in core (in the context of https://github.com/jenkinsci/jenkins/pull/6719). It is recommended to review this diff with the "Hide whitespace" feature enabled.