### PR TITLE
Show log records when `RecordedMatcher` doesn't match

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -81,6 +81,14 @@ public class LoggerRule extends ExternalResource {
         return this;
     }
 
+    @Override
+    public String toString() {
+        return getRecords()
+                .stream()
+                .map(logRecord -> logRecord.getLevel().toString() + "->" + logRecord.getMessage())
+                .collect(Collectors.joining(","));
+    }
+
     /**
      * Initializes log record capture, in addition to merely printing it.
      * This allows you to call {@link #getRecords} and/or {@link #getMessages} later.


### PR DESCRIPTION
Previously the matcher showed the LoggerRule toString:

```
Expected: has LogRecord with level \"INFO\" with a message matching \"Entry 2\" 
    but: was <org.jvnet.hudson.test.LoggerRule@60dcc9fe>
```