### PR TITLE
Use Hamcrest matchers where possible

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -24,6 +24,10 @@
  */
 package org.jvnet.hudson.test;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
 import com.gargoylesoftware.css.parser.CSSErrorHandler;
 import com.gargoylesoftware.css.parser.CSSException;
 import com.gargoylesoftware.css.parser.CSSParseException;
@@ -896,16 +900,14 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      * Asserts that the console output of the build contains the given substring.
      */
     public void assertLogContains(String substring, Run run) throws Exception {
-        String log = getLog(run);
-        assertTrue("Console output of "+run+" didn't contain "+substring+":\n"+log,log.contains(substring));
+        assertThat(getLog(run), containsString(substring));
     }
 
     /**
      * Asserts that the console output of the build does not contain the given substring.
      */
     public void assertLogNotContains(String substring, Run run) throws Exception {
-        String log = getLog(run);
-        assertFalse("Console output of "+run+" contains "+substring+":\n"+log,log.contains(substring));
+        assertThat(getLog(run), not(containsString(substring)));
     }
 
     /**
@@ -950,7 +952,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
         org.w3c.dom.Node n = (org.w3c.dom.Node) node;
         String textString = n.getTextContent();
-        assertTrue("needle found in haystack", textString.contains(needle)); 
+        assertThat(textString, containsString(needle));
     }
 
     public void assertXPathResultsContainText(DomNode page, String xpath, String needle) {
@@ -989,11 +991,11 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
 
     public void assertStringContains(String message, String haystack, String needle) {
-        assertTrue(message + " (seeking '" + needle + "')",haystack.contains(needle));
+        assertThat(message, haystack, containsString(needle));
     }
 
     public void assertStringContains(String haystack, String needle) {
-        assertTrue("Could not find '" + needle + "'.",haystack.contains(needle));
+        assertThat(haystack, containsString(needle));
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -24,9 +24,9 @@
  */
 package org.jvnet.hudson.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 import com.gargoylesoftware.css.parser.CSSErrorHandler;
 import com.gargoylesoftware.css.parser.CSSException;

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -219,13 +219,13 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.internal.AssumptionViolatedException;
@@ -1766,7 +1766,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      *
      * <p>
      * This method takes two objects that have properties (getXyz, isXyz, or just the public xyz field),
-     * and makes sure that the property values for each given property are equals (by using {@link org.junit.Assert#assertThat(Object, org.hamcrest.Matcher)})
+     * and makes sure that the property values for each given property are equals (by using {@link org.hamcrest.MatcherAssert.assertThat(Object, org.hamcrest.Matcher)})
      *
      * <p>
      * Property values can be null on both objects, and that is OK, but passing in a property that doesn't

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -219,8 +219,7 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
-import static org.hamcrest.CoreMatchers.containsString;
-import org.hamcrest.Matchers;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -1476,7 +1475,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     public <R extends Run> R assertBuildStatus(Result status, Future<? extends R> r) throws Exception {
-        assertThat("build was actually scheduled", r, Matchers.notNullValue());
+        assertThat("build was actually scheduled", r, notNullValue());
         return assertBuildStatus(status, r.get());
     }
 
@@ -1629,7 +1628,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
         org.w3c.dom.Node n = (org.w3c.dom.Node) node;
         String textString = n.getTextContent();
-        assertTrue("needle found in haystack", textString.contains(needle));
+        assertThat(textString, containsString(needle));
     }
 
     public void assertXPathResultsContainText(DomNode page, String xpath, String needle) {
@@ -1668,11 +1667,11 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
 
     public void assertStringContains(String message, String haystack, String needle) {
-        assertThat(message, haystack, Matchers.containsString(needle));
+        assertThat(message, haystack, containsString(needle));
     }
 
     public void assertStringContains(String haystack, String needle) {
-        assertThat(haystack, Matchers.containsString(needle));
+        assertThat(haystack, containsString(needle));
     }
 
     /**
@@ -1692,7 +1691,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                 for (String property : listProperties(properties)) {
                     String url = d.getHelpFile(property);
                     assertThat("Help file for the property " + property + " is missing on " + type, url,
-                            Matchers.notNullValue());
+                            notNullValue());
                     wc.goTo(url); // make sure it successfully loads
                 }
                 return null;

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1766,7 +1766,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      *
      * <p>
      * This method takes two objects that have properties (getXyz, isXyz, or just the public xyz field),
-     * and makes sure that the property values for each given property are equals (by using {@link org.hamcrest.MatcherAssert.assertThat(Object, org.hamcrest.Matcher)})
+     * and makes sure that the property values for each given property are equals (by using {@link org.hamcrest.MatcherAssert#assertThat(Object, org.hamcrest.Matcher)})
      *
      * <p>
      * Property values can be null on both objects, and that is OK, but passing in a property that doesn't

--- a/src/test/java/org/jvnet/hudson/main/UseRecipesWithJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/main/UseRecipesWithJenkinsRuleTest.java
@@ -1,8 +1,10 @@
 package org.jvnet.hudson.main;
 
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import hudson.LocalPluginManager;
 
@@ -70,7 +72,7 @@ public class UseRecipesWithJenkinsRuleTest {
         HtmlPage p = wc.goTo("loginError");
         URL url = p.getUrl();
         System.out.println(url);
-        assertFalse(url.toExternalForm().contains("login"));
+        assertThat(url.toExternalForm(), not(containsString("login")));
     }
 
     public static class MyPluginManager extends LocalPluginManager {

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -29,9 +29,10 @@ import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class JenkinsRuleTest {
@@ -147,12 +148,12 @@ public class JenkinsRuleTest {
 
         // Testing a simple GET that should answer 200 OK and a json
         JenkinsRule.JSONWebResponse response = j.getJSON("testing-cli/getMyJsonObject");
-        assertTrue(response.getContentAsString().contains("I am JenkinsRule"));
+        assertThat(response.getContentAsString(), containsString("I am JenkinsRule"));
         assertEquals(response.getStatusCode(), 200);
 
         // Testing a simple GET with parameter that should answer 200 OK and a json
         response = j.getJSON("testing-cli/getWithParameters?paramValue=whatelse");
-        assertTrue(response.getContentAsString().contains("I am JenkinsRule whatelse"));
+        assertThat(response.getContentAsString(), containsString("I am JenkinsRule whatelse"));
         assertEquals(response.getStatusCode(), 200);
 
         //Testing with a GET that the test expect to raise an server error: we want to be able to assert the status
@@ -197,13 +198,13 @@ public class JenkinsRuleTest {
         response = webClient
                         .withBasicApiToken(admin)
                         .postJSON( "testing-cli/create", JSONObject.fromObject(objectToSend));
-        assertTrue(response.getContentAsString().contains("Creating a new Object with Json. - CREATED"));
+        assertThat(response.getContentAsString(), containsString("Creating a new Object with Json. - CREATED"));
         assertEquals(response.getStatusCode(), 200);
 
         // Testing an authenticated POST that return error 500
         webClient.setThrowExceptionOnFailingStatusCode(false);
         response = webClient.postJSON( "testing-cli/createFailure", JSONObject.fromObject(objectToSend));
-        assertTrue(response.getContentAsString().contains("Creating a new Object with Json. - NOT CREATED"));
+        assertThat(response.getContentAsString(), containsString("Creating a new Object with Json. - NOT CREATED"));
         assertEquals(response.getStatusCode(), 500);
 
     }
@@ -217,13 +218,13 @@ public class JenkinsRuleTest {
         // Testing a simple PUT that should answer 200 OK and return same json
         MyJsonObject objectToSend = new MyJsonObject("Jenkins is the way !");
         response = webClient.putJSON( "testing-cli/update", JSONObject.fromObject(objectToSend));
-        assertTrue(response.getContentAsString().contains("Jenkins is the way ! - UPDATED"));
+        assertThat(response.getContentAsString(), containsString("Jenkins is the way ! - UPDATED"));
 
         //Testing with a PUT that the test expect to raise an server error: we want to be able to assert the status
         webClient.setThrowExceptionOnFailingStatusCode(false);
         response = webClient.putJSON( "testing-cli/updateFailure", JSONObject.fromObject(objectToSend));
         assertEquals(response.getStatusCode(), 500);
-        assertTrue(response.getContentAsString().contains("Jenkins is the way ! - NOT UPDATED"));
+        assertThat(response.getContentAsString(), containsString("Jenkins is the way ! - NOT UPDATED"));
 
         //Testing a PUT that requires the user to be authenticated
         User admin = User.getById("admin", true);
@@ -241,7 +242,7 @@ public class JenkinsRuleTest {
         response = webClient.withBasicApiToken(admin)
                             .putJSON("testing-cli/update", JSONObject.fromObject(objectToSend));
         assertEquals(response.getStatusCode(), 200);
-        assertTrue(response.getContentAsString().contains("Jenkins is the way ! - UPDATED"));
+        assertThat(response.getContentAsString(), containsString("Jenkins is the way ! - UPDATED"));
 
     }
 

--- a/src/test/java/org/jvnet/hudson/test/MemoryAssertTest.java
+++ b/src/test/java/org/jvnet/hudson/test/MemoryAssertTest.java
@@ -25,9 +25,13 @@
 package org.jvnet.hudson.test;
 
 import java.lang.ref.WeakReference;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
 import static org.jvnet.hudson.test.MemoryAssert.*;
-import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,7 +53,7 @@ public class MemoryAssertTest {
             e = _e;
         }
         assertNotNull(e);
-        assertTrue(e.toString(), e.getMessage().contains("3000"));
+        assertThat(e.getMessage(), containsString("3000"));
     }
 
     @Test


### PR DESCRIPTION
While debugging some test failures recently, I found some of the error messages less than helpful. Using Hamcrest matchers consistently results in better error messages and a smoother debugging experience.