### PR TITLE
Forward compatibility with Jetty 10 in `JenkinsRule`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/NoListenerConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/test/NoListenerConfiguration.java
@@ -23,13 +23,15 @@
  */
 package org.jvnet.hudson.test;
 
+import hudson.WebAppMain;
+import java.util.EventListener;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 import javax.servlet.ServletContextListener;
 
 /**
- * Kills off {@link ServletContextListener}s loaded from web.xml.
+ * Kills off the {@link WebAppMain} {@link ServletContextListener}.
  *
  * <p>
  * This is so that the harness can create the {@link jenkins.model.Jenkins} object.
@@ -37,7 +39,7 @@ import javax.servlet.ServletContextListener;
  *
  * @author Kohsuke Kawaguchi
  */
-public final class NoListenerConfiguration extends AbstractLifeCycle {
+public class NoListenerConfiguration extends AbstractLifeCycle {
     private final WebAppContext context;
 
     public NoListenerConfiguration(WebAppContext context) {
@@ -45,7 +47,11 @@ public final class NoListenerConfiguration extends AbstractLifeCycle {
     }
 
     @Override
-    protected void doStart() throws Exception {
-        context.setEventListeners(null);
+    protected void doStart() {
+        for (EventListener eventListener : context.getEventListeners()) {
+            if (eventListener instanceof WebAppMain) {
+                context.removeEventListener(eventListener);
+            }
+        }
     }
 }


### PR DESCRIPTION
Required for jenkinsci/jenkins#6805, #453, jenkinsci/jenkins#6802.

### Problem

When the application is started from `java -jar jenkins.war`, `hudson.WebAppMain` runs to initialize the application. In the context of the test harness, we do not want this to happen, since the test harness initializes Jenkins itself.

The current method does this with a call to `context.setEventListeners(null)` in `NoListenerConfiguration`. This has three problems:

1. It is `final`, forcing the need for copypasta in https://github.com/jenkinsci/jenkins/blob/6de288f424f3a76d9fab9e54e379ca171b08e158/test/src/test/java/hudson/util/BootFailureTest.java#L79-L80=.
2. It does not work in Jetty 10, causing opaque test failures in `JenkinsRuleTest`.
3. It not only clears the listener for `hudson.WebAppMain`, which is its purpose, but it also clears all other listeners, including other valuable cleanup listeners. The current (ordered) list of listeners in Jetty 9 is:

- `org.eclipse.jetty.servlet.listener.ELContextCleaner`
- `org.eclipse.jetty.servlet.listener.IntrospectorCleaner`
- `jenkins.util.SystemProperties.Listener`
- `hudson.WebAppMain` (needs to be cleared in the test harness)
- `jenkins.JenkinsHttpSessionListener`

### Solution

We make the class non-`final` and remove only the `WebAppMain` listener. This fixes all three problems:

1. The copypasta can be removed in https://github.com/jenkinsci/jenkins/blob/6de288f424f3a76d9fab9e54e379ca171b08e158/test/src/test/java/hudson/util/BootFailureTest.java#L79-L80=.
2. `JenkinsRuleTest` starts working in Jetty 10.
3. The other listeners run. As of Jetty 10, the new (ordered) list of listeners is:

- `org.eclipse.jetty.websocket.core.server.WebSocketServerComponentsCleanupListener`
- `org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer`
- `org.eclipse.jetty.websocket.server.JettyWebSocketServerContainerCleanupListener`
- `org.eclipse.jetty.servlet.listener.ELContextCleaner`
- `org.eclipse.jetty.servlet.listener.IntrospectorCleaner`
- `jenkins.util.SystemProperties.Listener`
- `hudson.WebAppMain` (needs to be cleared in the test harness)
- `jenkins.JenkinsHttpSessionListener`
- `org.eclipse.jetty.server.AllowedResourceAliasChecker.AllowedResourceAliasCheckListener`

### Testing done

I tested this with `BootFailureTest` in core with both Jetty 9 (jenkinsci/jenkins#6805) and Jetty 10 (jenkinsci/jenkins#6802).