### PR TITLE
Bump baseline from 2.204 to 2.249

### DIFF
--- a/RealJenkinsRuleInit/pom.xml
+++ b/RealJenkinsRuleInit/pom.xml
@@ -12,7 +12,7 @@
     <version>0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.204</jenkins.version>
+        <jenkins.version>2.249</jenkins.version>
         <java.level>8</java.level>
         <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
         <spotbugs.skip>true</spotbugs.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ THE SOFTWARE.
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.204</jenkins.version>
+    <jenkins.version>2.249</jenkins.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
Consistent with the baseline in `plugin-pom` and `maven-hpi-plugin`. I hope this should not be controversial as this is still a pretty ancient version of Jenkins.