### PR TITLE
[JENKINS-69044] Adapt to executable WAR changes in `JenkinsRule`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/WarExploder.java
+++ b/src/main/java/org/jvnet/hudson/test/WarExploder.java
@@ -73,9 +73,20 @@ public final class WarExploder {
             }
         } else {
             // locate jenkins.war
-            URL winstone = WarExploder.class.getResource("/winstone.jar");
+            URL winstone = WarExploder.class.getResource("/executable/winstone.jar");
+            String className = "executable.Main";
+
+            // TODO: Delete the next statement once we drop support for versions older than 2.358.
+            if (winstone == null) {
+                // Prior to 2.358
+                winstone = WarExploder.class.getResource("/winstone.jar");
+                if (winstone != null) {
+                    className = "executable.Executable";
+                }
+            }
+
             if (winstone != null) {
-                war = Which.jarFile(Class.forName("executable.Executable"));
+                war = Which.jarFile(Class.forName(className));
             } else {
                 // JENKINS-45245: work around incorrect test classpath in IDEA. Note that this will not correctly handle timestamped snapshots; in that case use `mvn test`.
                 File core = Which.jarFile(Jenkins.class); // will fail with IllegalArgumentException if have neither jenkins-war.war nor jenkins-core.jar in ${java.class.path}


### PR DESCRIPTION
See [JENKINS-69044](https://issues.jenkins.io/browse/JENKINS-69044). `WarExploder` contains two code paths that do the same thing: a standard code path for Maven, and a fallback code path for IntelliJ. The standard code path for Maven hunts down the WAR file by looking for `winstone.jar` and a class in the `executable` package. Prior to https://github.com/jenkinsci/jenkins/pull/6706 this was working as intended with `winstone.jar` in the root of the WAR file and the class in the `executable` package being the placeholder `executable.Executable`, but https://github.com/jenkinsci/jenkins/pull/6706 moved `winstone.jar` into the `executable` package and got rid of the placeholder class `executable.Executable` in favor of the real `Main` class (previously in the unnamed package but moved to the `executable` package in https://github.com/jenkinsci/jenkins/pull/6706). This broke the primary Maven code path, but this went unnoticed because we went into the secondary IntelliJ code path. However the secondary IntelliJ code path does not seem to work for Gradle plugins as reported in [JENKINS-69044](https://issues.jenkins.io/browse/JENKINS-69044).

This PR corrects the problem by getting adapting the primary Maven code path to work with the changes from https://github.com/jenkinsci/jenkins/pull/6706: looking for `winstone.jar` in the `executable` package and looking for the real `executable.Main` instead of the placeholder `executable.Executable` if we are running with https://github.com/jenkinsci/jenkins/pull/6706. The old code is left for compatibility but separated into an `if` statement that will be easy to delete later on when we eventually drop support.

To test this, I stepped through four scenarios in the debugger:

- Maven, 2.357: Verified that we went into the primary Maven code path before this change and continued to do so after this change.
- Maven, 2.358: Verified that before this change we erroneously went into the secondary IntelliJ code path, but after this change went into the primary Maven code path as expected.
- IntelliJ, 2.357: Verified that we went into the secondary IntelliJ code path before and after this change.
- IntelliJ, 2.358: Verified that we went into the secondary IntelliJ code path before and after this change.