### PR TITLE
Handle empty port to fix RealJenkinsRule flakiness

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -609,6 +609,10 @@ public final class RealJenkinsRule implements TestRule {
 
     private static int readPort(File portFile) throws IOException {
         String s = FileUtils.readFileToString(portFile, StandardCharsets.UTF_8);
+        if (s.isEmpty()) {
+            LOGGER.warning(() -> String.format("PortFile: %s exists, but value is still not written", portFile.getAbsolutePath()));
+            return 0;
+        }
         try {
             return Integer.parseInt(s);
         } catch (NumberFormatException e) {

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -611,7 +611,7 @@ public final class RealJenkinsRule implements TestRule {
         String s = FileUtils.readFileToString(portFile, StandardCharsets.UTF_8);
 
         // Work around to non-atomic write of port value in Winstone releases prior to 6.1.
-        // Todo When Winstone 6.2 has been widely adopted, this can be deleted.
+        // TODO When Winstone 6.2 has been widely adopted, this can be deleted.
         if (s.isEmpty()) {
             LOGGER.warning(() -> String.format("PortFile: %s exists, but value is still not written", portFile.getAbsolutePath()));
             return 0;

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -385,10 +385,11 @@ public final class RealJenkinsRule implements TestRule {
                     }
                     System.out.println("Will load plugins: " + Stream.of(plugins.list()).filter(n -> n.matches(".+[.][hj]p[il]")).sorted().collect(Collectors.joining(" ")));
                     base.evaluate();
+                } catch (Throwable t) {
+                    LOGGER.log(Level.WARNING, "Something went wrong", t);
+                    throw t;
                 } finally {
-                    if (proc != null) {
-                        stopJenkins();
-                    }
+                    stopJenkins();
                     try {
                         tmp.dispose();
                     } catch (Exception x) {
@@ -615,18 +616,27 @@ public final class RealJenkinsRule implements TestRule {
         }
     }
 
+    /**
+     * Stops Jenkins and releases any system resources associated
+     * with it. If Jenkins is already stopped then invoking this
+     * method has no effect.
+     */
     public void stopJenkins() throws Throwable {
-        endpoint("exit").openStream().close();
-        if (!proc.waitFor(60, TimeUnit.SECONDS) ) {
-            System.err.println("Jenkins failed to stop within 60 seconds, attempting to kill the Jenkins process");
-            proc.destroyForcibly();
-            throw new AssertionError("Jenkins failed to terminate within 60 seconds");
+        if (proc != null) {
+            Process _proc = proc;
+            proc = null;
+            endpoint("exit").openStream().close();
+
+            if (!_proc.waitFor(60, TimeUnit.SECONDS) ) {
+                System.err.println("Jenkins failed to stop within 60 seconds, attempting to kill the Jenkins process");
+                _proc.destroyForcibly();
+                throw new AssertionError("Jenkins failed to terminate within 60 seconds");
+            }
+            int exitValue = _proc.exitValue();
+            if (exitValue != 0) {
+                throw new AssertionError("nonzero exit code: " + exitValue);
+            }
         }
-        int exitValue = proc.exitValue();
-        if (exitValue != 0) {
-            throw new AssertionError("nonzero exit code: " + exitValue);
-        }
-        proc = null;
     }
 
     public void runRemotely(Step s) throws Throwable {

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -609,10 +609,14 @@ public final class RealJenkinsRule implements TestRule {
 
     private static int readPort(File portFile) throws IOException {
         String s = FileUtils.readFileToString(portFile, StandardCharsets.UTF_8);
+
+        // Work around to non-atomic write of port value in Winstone releases prior to 6.1.
+        // Todo When Winstone 6.2 has been widely adopted, this can be deleted.
         if (s.isEmpty()) {
             LOGGER.warning(() -> String.format("PortFile: %s exists, but value is still not written", portFile.getAbsolutePath()));
             return 0;
         }
+
         try {
             return Integer.parseInt(s);
         } catch (NumberFormatException e) {


### PR DESCRIPTION
Cloudbees CI reported a number of flaky tests encountering in [operations-center-context plugin](https://github.com/cloudbees/operations-center-context/blob/master/src/test/java/com/cloudbees/opscenter/artifacts/RemoteArtifactCopyBuilderTest.java#L98)

Logs:
[RemoteArtifactCopyBuilderTest.txt](https://github.com/jenkinsci/jenkins-test-harness/files/9189993/RemoteArtifactCopyBuilderTest.txt)
[RemoteArtifactCopyBuilderTest_stacktrace.txt](https://github.com/jenkinsci/jenkins-test-harness/files/9189995/RemoteArtifactCopyBuilderTest_stacktrace.txt)

Changes made in scope of this PR:

1. Handle empty port. [514bfbf](https://github.com/jenkinsci/jenkins-test-harness/pull/465/commits/514bfbf4b6cc5d93e74d341de0c16f5146b78fe7)
2. Stop proc once. [38b7261](https://github.com/jenkinsci/jenkins-test-harness/pull/465/commits/38b726176ad11ae48b6575aa5260ac024e8cc3e8)