### PR TITLE
`RealJenkinsRule.getUrl` can now fail

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -444,9 +444,13 @@ public final class RealJenkinsRule implements TestRule {
     }
 
     /**
-     * Like {@link JenkinsRule#getURL} but does not require Jenkins to have been started yet.
+     * Like {@link JenkinsRule#getURL} but does not require Jenkins to have been started yet when running on older versions of Jenkins.
+     * @throws IllegalStateException if running on a newer version of Jenkins and it has not yet been started so we do not yet know the port
      */
-    public URL getUrl() throws MalformedURLException {
+    public URL getUrl() throws MalformedURLException, IllegalStateException {
+        if (port == 0) {
+            throw new IllegalStateException("Port not yet defined");
+        }
         return new URL("http://" + host + ":" + port + "/jenkins/");
     }
 


### PR DESCRIPTION
#348 was incompatible for tests which try to call `getUrl` up front. https://github.com/jenkinsci/jenkins-test-harness/pull/347#discussion_r752340302 https://github.com/jenkinsci/jenkins-test-harness/pull/348#issuecomment-1073009729
