### PR TITLE
Remove `junit-bom` from managed dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,6 @@ THE SOFTWARE.
         <version>1.16</version>
       </dependency>
       <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>5.9.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.kohsuke</groupId>
         <artifactId>access-modifier-annotation</artifactId>
         <version>1.27</version>


### PR DESCRIPTION
This is part of the parent POM as of https://github.com/jenkinsci/pom/pull/300.