### PR TITLE
Remove `oleg-nenashev` from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     interval: weekly
   open-pull-requests-limit: 10
   reviewers:
-  - oleg-nenashev
   - jglick
   ignore:
   - dependency-name: io.jenkins.plugins*


### PR DESCRIPTION
@oleg-nenashev is no longer active in this repository.