### PR TITLE
Improve `InboundAgentRule`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -211,7 +211,6 @@ public final class InboundAgentRule extends ExternalResource {
         }
         if (options.isStart()) {
             start(r, options);
-            r.waitOnline(s);
         }
         return s;
     }


### PR DESCRIPTION
Various improvements to `InboundAgentRule`:

- Support WebSocket
- Support secrets
- Support skipping agent start
- Improve determinism by waiting for `SlaveComputer#_connect` to finish after adding the agent but before starting it
- Add work directory options
- Use thread-safe data structures

The motivation behind this is to enable most tests in Jenkins core to be converted to this rule. That way flakiness fixes can be implemented in one place and apply to all tests, which isn't possible with the copypasta we have today.

Once I get an incremental I'll post a core PR demonstrating how this is used.