### PR TITLE
Deprecate `NodeProvisionerRule`

### DIFF
--- a/src/main/java/hudson/slaves/NodeProvisionerRule.java
+++ b/src/main/java/hudson/slaves/NodeProvisionerRule.java
@@ -27,8 +27,14 @@ package hudson.slaves;
 import hudson.model.LoadStatistics;
 import hudson.slaves.NodeProvisioner.NodeProvisionerInvoker;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RealJenkinsRule;
 
-/** Overrides {@link LoadStatistics#CLOCK}, {@link NodeProvisionerInvoker#INITIALDELAY}, and/or {@link NodeProvisionerInvoker#RECURRENCEPERIOD} during the test. */
+/**
+ * Overrides {@link LoadStatistics#CLOCK}, {@link NodeProvisionerInvoker#INITIALDELAY}, and/or {@link NodeProvisionerInvoker#RECURRENCEPERIOD} during the test.
+ *
+ * @deprecated use {@link RealJenkinsRule}
+ */
+@Deprecated
 public class NodeProvisionerRule extends JenkinsRule {
 
     private final int clock;


### PR DESCRIPTION
As of https://github.com/jenkinsci/jenkins/pull/7210 `NodeProvisionerRule` will no longer be used anywhere in the Jenkins ecosystem, so deprecate it in favor of `RealJenkinsRule`. I suspect it was never realistic anyway.