### PR TITLE
Removing redundant stack trace from output

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -385,9 +385,6 @@ public final class RealJenkinsRule implements TestRule {
                     }
                     System.out.println("Will load plugins: " + Stream.of(plugins.list()).filter(n -> n.matches(".+[.][hj]p[il]")).sorted().collect(Collectors.joining(" ")));
                     base.evaluate();
-                } catch (Throwable t) {
-                    LOGGER.log(Level.WARNING, "Something went wrong", t);
-                    throw t;
                 } finally {
                     stopJenkins();
                     try {


### PR DESCRIPTION
Contrary to the claim in https://github.com/jenkinsci/jenkins-test-harness/pull/465#discussion_r935640464, chained & suppressed exceptions seem to be displayed fine in test output for me, so logging them again just creates noise. Possibly @Pldi23 was using some Maven project that neglected to disable stack trace trimming as Jenkins parent POMs do and which later became the default because that system is so broken.
