### PR TITLE
Add jenkins-core to dependencyManagement to avoid pulling all stapler versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@ THE SOFTWARE.
         <artifactId>access-modifier-annotation</artifactId>
         <version>1.27</version>
       </dependency>
+      <dependency>
+        <!-- Avoid downloading multiple jenkins core versions and tons of stapler versions due to version range usage in older libs -->
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-core</artifactId>
+        <version>${jenkins.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
`maven-enforcer-plugin` `requireUpperBoundsCheck` rule will retrieve transitive dependencies of all plugins specified in the pom, which use various versions of jenkins core. These depend on old versions of stapler-adjunct-xxx, which used to depend on stapler using a version range. This causes indirectly to retrieve all versions of stapler, causing unnecessary additional time to download.

Adding `jenkins-core` to `dependencyManagement` directly allows to cut this since no older jenkins version will be resolved, and thus no old stapler artifacts.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
