### PR TITLE
Exclusion is no longer needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,25 +283,6 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <rules>
-            <requireUpperBoundDeps>
-              <excludes combine.children="append">
-                <!--
-                  Stapler requests Guava 14.0 and Jenkins core requests Guice 4.0 which requests
-                  Guava 16.0.1. Core actually provides 11.0.1. Work around this mess by just
-                  excluding Guava from the RequireUpperBoundDeps check. The long-term fix is
-                  tracked in JENKINS-36779.
-                -->
-                <exclude>com.google.guava:guava</exclude>
-              </excludes>
-            </requireUpperBoundDeps>
-          </rules>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <!-- version specified in grandparent pom -->
         <configuration>


### PR DESCRIPTION
Fixes

```
[2022-10-13T07:50:05.173Z] [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-enforcer-plugin @ org.jenkins-ci.main:jenkins-test-harness:${changelist}, /home/jenkins/workspace/Core_jenkins-test-harness_PR-499/pom.xml, line 290, column 15
```

Stapler actually pulls guava 11.0.1 so there doesn't seem to be an upperboundcheck problem.
https://github.com/jenkinsci/stapler/pull/123


- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
