### PR TITLE
Accept multiple `Step`s in `then` and `runRemotely`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -439,10 +439,10 @@ public final class RealJenkinsRule implements TestRule {
     }
 
     /**
-     * Run one Jenkins session, send a test thunk, and shut down.
+     * Run one Jenkins session, send one or more test thunks, and shut down.
      */
-    public void then(Step s) throws Throwable {
-        then(new StepToStep2(s));
+    public void then(Step... steps) throws Throwable {
+        then(new StepsToStep2(steps));
     }
 
     /**
@@ -670,8 +670,13 @@ public final class RealJenkinsRule implements TestRule {
         }
     }
 
-    public void runRemotely(Step s) throws Throwable {
-        runRemotely(new StepToStep2(s));
+    /**
+     * Runs one or more steps on the remote system.
+     * (Compared to multiple calls, passing a series of steps is slightly more efficient
+     * as only one network call is made.)
+     */
+    public void runRemotely(Step... steps) throws Throwable {
+        runRemotely(new StepsToStep2(steps));
     }
 
     public <T extends Serializable> T runRemotely(Step2<T> s) throws Throwable {
@@ -903,16 +908,18 @@ public final class RealJenkinsRule implements TestRule {
         }
     }
 
-    private static class StepToStep2 implements Step2<Serializable> {
-        private final Step s;
+    private static class StepsToStep2 implements Step2<Serializable> {
+        private final Step[] steps;
 
-        public StepToStep2(Step s) {
-            this.s = s;
+        StepsToStep2(Step... steps) {
+            this.steps = steps;
         }
 
         @Override
         public Serializable run(JenkinsRule r) throws Throwable {
-            s.run(r);
+            for (Step step : steps) {
+                step.run(r);
+            }
             return null;
         }
     }

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -85,12 +85,6 @@ public class RealJenkinsRuleTest {
         assertEquals("value", System.getenv("SOME_ENV_VAR"));
     }
 
-    @Test public void testFilter() throws Throwable{
-        rr.startJenkins();
-        rr.runRemotely(RealJenkinsRuleTest::_testFilter);
-        rr.runRemotely(RealJenkinsRuleTest::_htmlUnit1);
-    }
-
     @Test public void testReturnObject() throws Throwable {
         rr.startJenkins();
         assertEquals(rr.getUrl().toExternalForm(), rr.runRemotely(RealJenkinsRuleTest::_getJenkinsUrlFromRemote));
@@ -102,7 +96,14 @@ public class RealJenkinsRuleTest {
         }));
     }
 
-    private static void _testFilter(JenkinsRule jenkinsRule) throws Throwable{
+    @Test public void testFilter() throws Throwable{
+        rr.startJenkins();
+        rr.runRemotely(RealJenkinsRuleTest::_testFilter1);
+        // Now run another step, body irrelevant just making sure it is not broken
+        // (do *not* combine into one runRemotely call):
+        rr.runRemotely(RealJenkinsRuleTest::_testFilter2);
+    }
+    private static void _testFilter1(JenkinsRule jenkinsRule) throws Throwable {
         PluginServletFilter.addFilter(new Filter() {
 
             @Override
@@ -117,6 +118,18 @@ public class RealJenkinsRuleTest {
             @Override
             public void init(FilterConfig filterConfig) throws ServletException {}
         });
+    }
+    private static void _testFilter2(JenkinsRule jenkinsRule) throws Throwable {}
+
+    @Test public void chainedSteps() throws Throwable {
+        rr.startJenkins();
+        rr.runRemotely(RealJenkinsRuleTest::chainedSteps1, RealJenkinsRuleTest::chainedSteps2);
+    }
+    private static void chainedSteps1(JenkinsRule jenkinsRule) throws Throwable {
+        System.setProperty("key", "xxx");
+    }
+    private static void chainedSteps2(JenkinsRule jenkinsRule) throws Throwable {
+        assertEquals("xxx", System.getProperty("key"));
     }
 
     @Test public void error() {


### PR DESCRIPTION
Sometimes when defining complex suites of tests using `RealJenkinsRule` it is helpful to be able to define reusable `Step` implementations (classes or method handles) and run a series of them at once. This makes that process slightly more convenient and faster.