### PR TITLE
Do not suspend the controller JVM on startup when debugging

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -519,7 +519,7 @@ public final class RealJenkinsRule implements TestRule {
             argv.add("-Dwinstone.portFileName=" + portFile);
         }
         if (new DisableOnDebug(null).isDebugging()) {
-            argv.add("-agentlib:jdwp=transport=dt_socket,server=y");
+            argv.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n");
         }
         argv.addAll(javaOptions);
 


### PR DESCRIPTION
When debugging `RealJenkinsRule`, being forced to attach to the controller before proceeding is more annoying than helpful. (If you do want to debug something during startup, set a breakpoint.)