### PR TITLE
`RealJenkinsRule` should not overwrite `JenkinsLocationConfiguration` if otherwise set

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -870,7 +870,9 @@ public final class RealJenkinsRule implements TestRule {
             this.jenkins = Jenkins.get();
             this.url = url;
             jenkins.setNoUsageStatistics(true); // cannot use JenkinsRule._configureJenkinsForTest earlier because it tries to save config before loaded
-            JenkinsLocationConfiguration.get().setUrl(url.toExternalForm());
+            if (JenkinsLocationConfiguration.get().getUrl() == null) {
+                JenkinsLocationConfiguration.get().setUrl(url.toExternalForm());
+            }
             testDescription = Description.createSuiteDescription(System.getProperty("RealJenkinsRule.description"));
             env = new TestEnvironment(this.testDescription);
             env.pin();

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -60,6 +60,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import jenkins.model.Jenkins;
+import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.core.IsNull;
@@ -201,6 +202,17 @@ public class RealJenkinsRuleTest {
         assertNull(Stapler.getCurrentRequest());
     }
 
+    @Test public void stepsDoNotOverwriteJenkinsLocationConfigurationIfOtherwiseSet() throws Throwable {
+        rr.then(RealJenkinsRuleTest::_stepsDoNotOverwriteJenkinsLocationConfigurationIfOtherwiseSet1);
+        rr.then(RealJenkinsRuleTest::_stepsDoNotOverwriteJenkinsLocationConfigurationIfOtherwiseSet2);
+    }
+    private static void _stepsDoNotOverwriteJenkinsLocationConfigurationIfOtherwiseSet1(JenkinsRule r) throws Throwable {
+        assertNotNull(JenkinsLocationConfiguration.get().getUrl());
+        JenkinsLocationConfiguration.get().setUrl("https://example.com/");
+    }
+    private static void _stepsDoNotOverwriteJenkinsLocationConfigurationIfOtherwiseSet2(JenkinsRule r) throws Throwable {
+        assertEquals("https://example.com/", JenkinsLocationConfiguration.get().getUrl());
+    }
 
     @Test
     public void test500Errors() throws IOException {


### PR DESCRIPTION
For example you may wish to test behavior of Jenkins behind a reverse proxy and define a particular root URL explicitly.