### PR TITLE
Allow `RealJenkinsRule` instances to specify a `name` & `color`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -83,6 +83,7 @@ public final class InboundAgentRule extends ExternalResource {
         private boolean secret;
         private boolean webSocket;
         private boolean start = true;
+        private final PrefixedOutputStream.Builder prefixedOutputStreamBuilder = PrefixedOutputStream.builder();
 
         public String getName() {
             return name;
@@ -90,6 +91,7 @@ public final class InboundAgentRule extends ExternalResource {
 
         public void setName(@CheckForNull String name) {
             this.name = name;
+            prefixedOutputStreamBuilder.withName(name);
         }
 
         public boolean isSecret() {
@@ -133,6 +135,14 @@ public final class InboundAgentRule extends ExternalResource {
             Builder name(String name);
 
             /**
+             * Set a color for agent logs.
+             *
+             * @param color the color
+             * @return this builder
+             */
+            Builder color(PrefixedOutputStream.Color color);
+
+            /**
              * Use secret when connecting.
              *
              * @return this builder
@@ -168,6 +178,12 @@ public final class InboundAgentRule extends ExternalResource {
             @Override
             public Builder name(String name) {
                 options.setName(name);
+                return this;
+            }
+
+            @Override
+            public Builder color(PrefixedOutputStream.Color color) {
+                options.prefixedOutputStreamBuilder.withColor(color);
                 return this;
             }
 
@@ -286,7 +302,7 @@ public final class InboundAgentRule extends ExternalResource {
         System.err.println("Running: " + pb.command());
         Process proc = pb.start();
         procs.put(options.getName(), proc);
-        new StreamCopyThread("inbound-agent-" + options.getName(), proc.getInputStream(), System.err).start();
+        new StreamCopyThread("inbound-agent-" + options.getName(), proc.getInputStream(), options.prefixedOutputStreamBuilder.build(System.err)).start();
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/test/PrefixedOutputStream.java
+++ b/src/main/java/org/jvnet/hudson/test/PrefixedOutputStream.java
@@ -97,6 +97,8 @@ public final class PrefixedOutputStream extends LineTransformationOutputStream.D
 
     public static final class Builder implements Serializable {
 
+        static boolean SKIP_CHECK_FOR_CI;
+
         @CheckForNull private String name;
         @CheckForNull private Color color;
 
@@ -112,7 +114,7 @@ public final class PrefixedOutputStream extends LineTransformationOutputStream.D
         }
 
         public Builder withColor(@CheckForNull Color color) {
-            if (!"true".equals(System.getenv("CI"))) {
+            if (SKIP_CHECK_FOR_CI || !"true".equals(System.getenv("CI"))) {
                 this.color = color;
             }
             return this;

--- a/src/main/java/org/jvnet/hudson/test/PrefixedOutputStream.java
+++ b/src/main/java/org/jvnet/hudson/test/PrefixedOutputStream.java
@@ -1,0 +1,130 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2022 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.test;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.console.LineTransformationOutputStream;
+import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Decorating {@link OutputStream} which prefixes lines of text with an identifier and optional color.
+ * (Does not include a timestamp, since typically something like {@link SupportLogFormatter} should already cover that.)
+ */
+public final class PrefixedOutputStream extends LineTransformationOutputStream.Delegating {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public enum Color {
+
+        RED("31"), GREEN("32"), YELLOW("33"), BLUE("34"), MAGENTA("35"), CYAN("36");
+
+        private final String code;
+
+        private Color(String code) {
+            this.code = code;
+        }
+
+    }
+
+    @CheckForNull private final String name;
+    @CheckForNull private final Color color;
+
+    private PrefixedOutputStream(OutputStream out, String name, Color color) {
+        super(out);
+        this.name = name;
+        this.color = color;
+    }
+
+    @Override protected void eol(byte[] b, int len) throws IOException {
+        if (name != null) {
+            out.write('[');
+            out.write(name.getBytes(StandardCharsets.US_ASCII));
+            out.write(']');
+            out.write(' ');
+        }
+        if (color != null) {
+            out.write(27); // ESC
+            out.write('[');
+            out.write(color.code.getBytes(StandardCharsets.US_ASCII));
+            out.write('m');
+            int preNlLen = len;
+            while (preNlLen > 0 && (b[preNlLen - 1] == '\n' || b[preNlLen - 1] == '\r')) {
+                preNlLen--;
+            }
+            assert 0 <= preNlLen;
+            assert preNlLen <= len;
+            assert len <= b.length;
+            out.write(b, 0, preNlLen);
+            out.write(27);
+            out.write('[');
+            out.write('0');
+            out.write('m');
+            out.write(b, preNlLen, len - preNlLen);
+        } else {
+            out.write(b, 0, len);
+        }
+    }
+
+    public static final class Builder implements Serializable {
+
+        @CheckForNull private String name;
+        @CheckForNull private Color color;
+
+        private Builder() {}
+
+        public Builder withName(@CheckForNull String name) {
+            this.name = name;
+            return this;
+        }
+
+        public @CheckForNull String getName() {
+            return name;
+        }
+
+        public Builder withColor(@CheckForNull Color color) {
+            if (!"true".equals(System.getenv("CI"))) {
+                this.color = color;
+            }
+            return this;
+        }
+
+        public @CheckForNull Color getColor() {
+            return color;
+        }
+
+        public @NonNull OutputStream build(@NonNull OutputStream delegate) {
+            return name != null || color != null ? new PrefixedOutputStream(delegate, name, color) : delegate;
+        }
+
+    }
+
+}

--- a/src/main/java/org/jvnet/hudson/test/PrefixedOutputStream.java
+++ b/src/main/java/org/jvnet/hudson/test/PrefixedOutputStream.java
@@ -76,6 +76,7 @@ public final class PrefixedOutputStream extends LineTransformationOutputStream.D
             out.write('[');
             out.write(color.code.getBytes(StandardCharsets.US_ASCII));
             out.write('m');
+            // Preserving original line ending, so not using trimEOL:
             int preNlLen = len;
             while (preNlLen > 0 && (b[preNlLen - 1] == '\n' || b[preNlLen - 1] == '\r')) {
                 preNlLen--;

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -27,6 +27,7 @@ package org.jvnet.hudson.test;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.ExtensionList;
+import hudson.console.LineTransformationOutputStream;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
@@ -193,6 +194,9 @@ public final class RealJenkinsRule implements TestRule {
     private static final Pattern SNAPSHOT_INDEX_JELLY = Pattern.compile("(file:/.+/target)/classes/index.jelly");
     private transient boolean supportsPortFileName;
 
+    private String name;
+    private Color color;
+
     /**
      * Add some plugins to the test classpath.
      *
@@ -281,6 +285,36 @@ public final class RealJenkinsRule implements TestRule {
 
     public RealJenkinsRule withLogger(String logger, Level level) {
         this.loggers.put(logger, level);
+        return this;
+    }
+
+    /**
+     * Sets a name for this instance, which will be prefixed to log messages to simplify debugging.
+     */
+    public RealJenkinsRule withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public enum Color {
+        RED("31"), GREEN("32"), YELLOW("33"), BLUE("34"), MAGENTA("35"), CYAN("36");
+        final String code;
+        Color(String code) {
+            this.code = code;
+        }
+    }
+    /**
+     * Applies ANSI coloration to log lines produced by this instance, complementing {@link #withName}.
+     * Ignored when on CI.
+     */
+    public RealJenkinsRule withColor(Color color) {
+        if (!"true".equals(System.getenv("CI"))) {
+            this.color = color;
+        }
         return this;
     }
 
@@ -541,10 +575,41 @@ public final class RealJenkinsRule implements TestRule {
         // TODO options to set Winstone options, etc.
         // TODO pluggable launcher interface to support a Dockerized Jenkins JVM
         // TODO if test JVM is running in a debugger, start Jenkins JVM in a debugger also
+        pb.redirectErrorStream(true);
         proc = pb.start();
-        // TODO prefix streams with per-test timestamps & port
-        new StreamCopyThread(description.toString(), proc.getInputStream(), System.out).start();
-        new StreamCopyThread(description.toString(), proc.getErrorStream(), System.err).start();
+        OutputStream out = System.out;
+        if (name != null) {
+            out = new LineTransformationOutputStream.Delegating(out) {
+                @Override protected void eol(byte[] b, int len) throws IOException {
+                    out.write('[');
+                    out.write(name.getBytes(StandardCharsets.US_ASCII));
+                    out.write(']');
+                    out.write(' ');
+                    if (color != null) {
+                        out.write(27); // ESC
+                        out.write('[');
+                        out.write(color.code.getBytes(StandardCharsets.US_ASCII));
+                        out.write('m');
+                        int preNlLen = len;
+                        while (preNlLen > 0 && (b[preNlLen - 1] == '\n' || b[preNlLen - 1] == '\r')) {
+                            preNlLen--;
+                        }
+                        assert 0 <= preNlLen;
+                        assert preNlLen <= len;
+                        assert len <= b.length;
+                        out.write(b, 0, preNlLen);
+                        out.write(27);
+                        out.write('[');
+                        out.write('0');
+                        out.write('m');
+                        out.write(b, preNlLen, len - preNlLen);
+                    } else {
+                        out.write(b, 0, len);
+                    }
+                }
+            };
+        }
+        new StreamCopyThread(description.toString(), proc.getInputStream(), out).start();
         int tries = 0;
         while (true) {
             if (!proc.isAlive()) {
@@ -562,6 +627,7 @@ public final class RealJenkinsRule implements TestRule {
 
                     String checkResult = checkResult(conn);
                     if (checkResult == null) {
+                        System.out.println((name != null ? name : "Jenkins") + " is running at " + getUrl());
                         break;
                     }else {
                         throw new IOException("Response code " + conn.getResponseCode() + " for " + status + ": " + checkResult +

--- a/src/test/java/org/jvnet/hudson/test/PrefixedOutputStreamTest.java
+++ b/src/test/java/org/jvnet/hudson/test/PrefixedOutputStreamTest.java
@@ -26,59 +26,42 @@ package org.jvnet.hudson.test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import org.junit.Test;
 
 public class PrefixedOutputStreamTest {
 
-    @Test public void name() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (PrintStream ps = new PrintStream(PrefixedOutputStream.builder().withName("xxx").build(baos))) {
-            ps.println("regular line");
-            ps.println(); // blank line
-            ps.println("split across\ntwo lines");
-            ps.print("missing trailing newline");
-        }
-        assertThat(baos.toString(StandardCharsets.UTF_8).replace("\r\n", "\n"),
-            is("[xxx] regular line\n[xxx] \n[xxx] split across\n[xxx] two lines\n[xxx] missing trailing newline"));
+    @Test public void name() throws Exception {
+        assertOutput(PrefixedOutputStream.builder().withName("xxx"),
+            "[xxx] regular line\n[xxx] \n[xxx] split across\n[xxx] two lines\n[xxx] missing trailing newline");
     }
 
-    @Test public void color() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (PrintStream ps = new PrintStream(PrefixedOutputStream.builder().withColor(PrefixedOutputStream.Color.RED).build(baos))) {
-            ps.println("regular line");
-            ps.println(); // blank line
-            ps.println("split across\ntwo lines");
-            ps.print("missing trailing newline");
-        }
-        assertThat(baos.toString(StandardCharsets.UTF_8).replace("\r\n", "\n"),
-            is("\u001b[31mregular line\u001b[0m\n\u001b[31m\u001b[0m\n\u001b[31msplit across\u001b[0m\n\u001b[31mtwo lines\u001b[0m\n\u001b[31mmissing trailing newline\u001b[0m"));
+    @Test public void color() throws Exception {
+        assertOutput(PrefixedOutputStream.builder().withColor(PrefixedOutputStream.Color.RED),
+            "\u001b[31mregular line\u001b[0m\n\u001b[31m\u001b[0m\n\u001b[31msplit across\u001b[0m\n\u001b[31mtwo lines\u001b[0m\n\u001b[31mmissing trailing newline\u001b[0m");
     }
 
-    @Test public void nameAndColor() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (PrintStream ps = new PrintStream(PrefixedOutputStream.builder().withName("xxx").withColor(PrefixedOutputStream.Color.RED).build(baos))) {
-            ps.println("regular line");
-            ps.println(); // blank line
-            ps.println("split across\ntwo lines");
-            ps.print("missing trailing newline");
-        }
-        assertThat(baos.toString(StandardCharsets.UTF_8).replace("\r\n", "\n"),
-            is("[xxx] \u001b[31mregular line\u001b[0m\n[xxx] \u001b[31m\u001b[0m\n[xxx] \u001b[31msplit across\u001b[0m\n[xxx] \u001b[31mtwo lines\u001b[0m\n[xxx] \u001b[31mmissing trailing newline\u001b[0m"));
+    @Test public void nameAndColor() throws Exception {
+        assertOutput(PrefixedOutputStream.builder().withName("xxx").withColor(PrefixedOutputStream.Color.RED),
+            "[xxx] \u001b[31mregular line\u001b[0m\n[xxx] \u001b[31m\u001b[0m\n[xxx] \u001b[31msplit across\u001b[0m\n[xxx] \u001b[31mtwo lines\u001b[0m\n[xxx] \u001b[31mmissing trailing newline\u001b[0m");
     }
 
-    @Test public void neither() {
+    @Test public void neither() throws Exception {
+        assertOutput(PrefixedOutputStream.builder(),
+            "regular line\n\nsplit across\ntwo lines\nmissing trailing newline");
+    }
+
+    private static void assertOutput(PrefixedOutputStream.Builder prefixedOutputStreamBuilder, String expected) throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (PrintStream ps = new PrintStream(PrefixedOutputStream.builder().build(baos))) {
+        try (PrintStream ps = new PrintStream(prefixedOutputStreamBuilder.build(baos))) {
             ps.println("regular line");
             ps.println(); // blank line
             ps.println("split across\ntwo lines");
             ps.print("missing trailing newline");
         }
-        assertThat(baos.toString(StandardCharsets.UTF_8).replace("\r\n", "\n"),
-            is("regular line\n\nsplit across\ntwo lines\nmissing trailing newline"));
+        assertThat(baos.toString("UTF-8").replace("\r\n", "\n"),
+            is(expected));
     }
 
 }

--- a/src/test/java/org/jvnet/hudson/test/PrefixedOutputStreamTest.java
+++ b/src/test/java/org/jvnet/hudson/test/PrefixedOutputStreamTest.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2022 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import org.junit.Test;
+
+public class PrefixedOutputStreamTest {
+
+    @Test public void name() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(PrefixedOutputStream.builder().withName("xxx").build(baos))) {
+            ps.println("regular line");
+            ps.println(); // blank line
+            ps.println("split across\ntwo lines");
+            ps.print("missing trailing newline");
+        }
+        assertThat(baos.toString(StandardCharsets.UTF_8).replace("\r\n", "\n"),
+            is("[xxx] regular line\n[xxx] \n[xxx] split across\n[xxx] two lines\n[xxx] missing trailing newline"));
+    }
+
+    @Test public void color() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(PrefixedOutputStream.builder().withColor(PrefixedOutputStream.Color.RED).build(baos))) {
+            ps.println("regular line");
+            ps.println(); // blank line
+            ps.println("split across\ntwo lines");
+            ps.print("missing trailing newline");
+        }
+        assertThat(baos.toString(StandardCharsets.UTF_8).replace("\r\n", "\n"),
+            is("\u001b[31mregular line\u001b[0m\n\u001b[31m\u001b[0m\n\u001b[31msplit across\u001b[0m\n\u001b[31mtwo lines\u001b[0m\n\u001b[31mmissing trailing newline\u001b[0m"));
+    }
+
+    @Test public void nameAndColor() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(PrefixedOutputStream.builder().withName("xxx").withColor(PrefixedOutputStream.Color.RED).build(baos))) {
+            ps.println("regular line");
+            ps.println(); // blank line
+            ps.println("split across\ntwo lines");
+            ps.print("missing trailing newline");
+        }
+        assertThat(baos.toString(StandardCharsets.UTF_8).replace("\r\n", "\n"),
+            is("[xxx] \u001b[31mregular line\u001b[0m\n[xxx] \u001b[31m\u001b[0m\n[xxx] \u001b[31msplit across\u001b[0m\n[xxx] \u001b[31mtwo lines\u001b[0m\n[xxx] \u001b[31mmissing trailing newline\u001b[0m"));
+    }
+
+    @Test public void neither() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(PrefixedOutputStream.builder().build(baos))) {
+            ps.println("regular line");
+            ps.println(); // blank line
+            ps.println("split across\ntwo lines");
+            ps.print("missing trailing newline");
+        }
+        assertThat(baos.toString(StandardCharsets.UTF_8).replace("\r\n", "\n"),
+            is("regular line\n\nsplit across\ntwo lines\nmissing trailing newline"));
+    }
+
+}

--- a/src/test/java/org/jvnet/hudson/test/PrefixedOutputStreamTest.java
+++ b/src/test/java/org/jvnet/hudson/test/PrefixedOutputStreamTest.java
@@ -28,9 +28,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class PrefixedOutputStreamTest {
+
+    @Rule public FlagRule<Boolean> skipCheckForCI = new FlagRule<>(() -> PrefixedOutputStream.Builder.SKIP_CHECK_FOR_CI, x -> PrefixedOutputStream.Builder.SKIP_CHECK_FOR_CI = x, true);
 
     @Test public void name() throws Exception {
         assertOutput(PrefixedOutputStream.builder().withName("xxx"),


### PR DESCRIPTION
At CloudBees we often multiple `RealJenkinsRule` rules simultaneously to model the interaction among multiple controllers. It is much easier to follow log output when log lines are prefixed with a controller identifier, and (when running interactively) are colored.