### PR TITLE
Support of `RealJenkinsRule` in `InboundAgentRule`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -428,13 +428,6 @@ public final class InboundAgentRule extends ExternalResource {
         }
     }
 
-    private static class GetNumberOfNodes implements RealJenkinsRule.Step2<Integer> {
-        @Override
-        public Integer run(JenkinsRule r) throws Throwable {
-            return r.jenkins.getNodes().size();
-        }
-    }
-
     private static class CreateAgent implements RealJenkinsRule.Step2<String> {
         private final Options options;
 

--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Computer;
+import hudson.model.Node;
 import hudson.model.Slave;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.JNLPLauncher;
@@ -35,6 +36,8 @@ import hudson.slaves.RetentionStrategy;
 import hudson.slaves.SlaveComputer;
 import hudson.util.StreamCopyThread;
 import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -239,8 +242,25 @@ public final class InboundAgentRule extends ExternalResource {
     /**
      * (Re-)starts an existing inbound agent.
      */
-    @SuppressFBWarnings(value = {"COMMAND_INJECTION", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"}, justification = "just for test code")
     public void start(@NonNull JenkinsRule r, Options options) throws Exception {
+        String name = options.getName();
+        Objects.requireNonNull(name);
+        stop(name);
+        start(GetAgentArguments.get(r, name), options);
+    }
+
+    /**
+     * (Re-)starts an existing inbound agent.
+     */
+    public void start(@NonNull RealJenkinsRule r, Options options) throws Throwable {
+        String name = options.getName();
+        Objects.requireNonNull(name);
+        stop(name);
+        start(r.runRemotely(new GetAgentArguments(name)), options);
+    }
+
+    @SuppressFBWarnings(value = {"COMMAND_INJECTION", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"}, justification = "just for test code")
+    public void start(AgentArguments agentArguments, Options options) throws Exception {
         Objects.requireNonNull(options.getName());
         stop(options.getName());
         List<String> cmd = new ArrayList<>(Arrays.asList(JavaEnvUtils.getJreExecutable("java"),
@@ -249,31 +269,24 @@ public final class InboundAgentRule extends ExternalResource {
             "-Djava.awt.headless=true"));
         if (JenkinsRule.SLAVE_DEBUG_PORT > 0) {
             cmd.add("-Xdebug");
-            cmd.add("Xrunjdwp:transport=dt_socket,server=y,address=" + (JenkinsRule.SLAVE_DEBUG_PORT + r.jenkins.getNodes().size() - 1));
-        }
-        File agentJar = new File(r.jenkins.getRootDir(), "agent.jar");
-        if (!agentJar.isFile()) {
-            FileUtils.copyURLToFile(new Slave.JnlpJar("agent.jar").getURL(), agentJar);
+            cmd.add("Xrunjdwp:transport=dt_socket,server=y,address=" + (JenkinsRule.SLAVE_DEBUG_PORT + agentArguments.numberOfNodes - 1));
         }
         cmd.addAll(Arrays.asList(
-            "-jar", agentJar.getAbsolutePath(),
-            "-jnlpUrl", r.getURL() + "computer/" + options.getName() + "/slave-agent.jnlp"));
-        SlaveComputer c = (SlaveComputer) r.jenkins.getNode(options.getName()).toComputer();
+                "-jar", agentArguments.agentJar.getAbsolutePath(),
+                "-jnlpUrl", agentArguments.agentJnlpUrl));
         if (options.isSecret()) {
-            String secret = c.getJnlpMac();
             // To watch it fail: secret = secret.replace('1', '2');
-            cmd.addAll(Arrays.asList("-secret", secret));
+            cmd.addAll(Arrays.asList("-secret", agentArguments.secret));
         }
-        JNLPLauncher launcher = (JNLPLauncher) c.getLauncher();
-        if (!launcher.getWorkDirSettings().isDisabled()) {
-            cmd.addAll(launcher.getWorkDirSettings().toCommandLineArgs(c));
+        if (agentArguments.commandLineArgs != null) {
+            cmd.addAll(agentArguments.commandLineArgs);
         }
         ProcessBuilder pb = new ProcessBuilder(cmd);
         pb.redirectErrorStream(true);
         System.err.println("Running: " + pb.command());
         Process proc = pb.start();
         procs.put(options.getName(), proc);
-        new StreamCopyThread("jnlp", proc.getInputStream(), System.err).start();
+        new StreamCopyThread("inbound-agent-" + options.getName(), proc.getInputStream(), System.err).start();
     }
 
     /**
@@ -281,12 +294,15 @@ public final class InboundAgentRule extends ExternalResource {
      */
     public void stop(@NonNull JenkinsRule r, @NonNull String name) throws InterruptedException {
         stop(name);
-        Computer c = r.jenkins.getComputer(name);
-        if (c != null) {
-            while (c.isOnline()) {
-                Thread.sleep(100);
-            }
-        }
+        StopAgent.stop(r, name);
+    }
+
+    /**
+     * Stop an existing inbound agent and wait for it to go offline.
+     */
+    public void stop(@NonNull RealJenkinsRule rjr, @NonNull String name) throws Throwable {
+        stop(name);
+        rjr.runRemotely(new StopAgent(name));
     }
 
     /**
@@ -321,4 +337,90 @@ public final class InboundAgentRule extends ExternalResource {
         }
     }
 
+    public static class AgentArguments implements Serializable {
+        /**
+         * URL to the agent JNLP file.
+         */
+        private final String agentJnlpUrl;
+        /**
+         * A reference to the agent jar
+         */
+        private final File agentJar;
+        /**
+         * The secret the agent should use to connect.
+         */
+        private final String secret;
+        /**
+         * The number of nodes in the Jenkins instance where the agent is running.
+         */
+        private final int numberOfNodes;
+        /**
+         * Additional command line arguments to pass to the agent.
+         */
+        private final List<String> commandLineArgs;
+
+        public AgentArguments(String agentJnlpUrl, File agentJar, String secret, int numberOfNodes, List<String> commandLineArgs) {
+            this.agentJnlpUrl = agentJnlpUrl;
+            this.agentJar = agentJar;
+            this.secret = secret;
+            this.numberOfNodes = numberOfNodes;
+            this.commandLineArgs = commandLineArgs;
+        }
+    }
+
+    private static class GetAgentArguments implements RealJenkinsRule.Step2<AgentArguments> {
+
+        private final String name;
+
+        GetAgentArguments(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public AgentArguments run(@NonNull JenkinsRule r) throws Throwable {
+            return get(r, name);
+        }
+        private static AgentArguments get(JenkinsRule r, String name) throws IOException {
+            Node node = r.jenkins.getNode(name);
+            if (node == null) {
+                throw new AssertionError("no such agent: " + name);
+            }
+            SlaveComputer c = (SlaveComputer) node.toComputer();
+            if (c == null) {
+                throw new AssertionError("agent " + node + " has no executor");
+            }
+            JNLPLauncher launcher = (JNLPLauncher) c.getLauncher();
+            List<String> commandLineArgs = null;
+            if (!launcher.getWorkDirSettings().isDisabled()) {
+                commandLineArgs = launcher.getWorkDirSettings().toCommandLineArgs(c);
+            }
+            File agentJar = new File(r.jenkins.getRootDir(), "agent.jar");
+            if (!agentJar.isFile()) {
+                FileUtils.copyURLToFile(new Slave.JnlpJar("agent.jar").getURL(), agentJar);
+            }
+            return new AgentArguments(r.getURL() + "computer/" + name + "/slave-agent.jnlp", agentJar, c.getJnlpMac(), r.jenkins.getNodes().size(), commandLineArgs);
+        }
+
+    }
+
+    private static class StopAgent implements RealJenkinsRule.Step {
+        private final String name;
+        StopAgent(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void run(JenkinsRule r) throws Throwable {
+            stop(r, name);
+        }
+
+        private static void stop(JenkinsRule r, String name) throws InterruptedException {
+            Computer c = r.jenkins.getComputer(name);
+            if (c != null) {
+                while (c.isOnline()) {
+                    Thread.sleep(100);
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -294,7 +294,7 @@ public final class InboundAgentRule extends ExternalResource {
      */
     public void stop(@NonNull JenkinsRule r, @NonNull String name) throws InterruptedException {
         stop(name);
-        StopAgent.stop(r, name);
+        WaitForAgentOffline.stop(r, name);
     }
 
     /**
@@ -302,7 +302,7 @@ public final class InboundAgentRule extends ExternalResource {
      */
     public void stop(@NonNull RealJenkinsRule rjr, @NonNull String name) throws Throwable {
         stop(name);
-        rjr.runRemotely(new StopAgent(name));
+        rjr.runRemotely(new WaitForAgentOffline(name));
     }
 
     /**
@@ -407,9 +407,9 @@ public final class InboundAgentRule extends ExternalResource {
 
     }
 
-    private static class StopAgent implements RealJenkinsRule.Step {
+    private static class WaitForAgentOffline implements RealJenkinsRule.Step {
         private final String name;
-        StopAgent(String name) {
+        WaitForAgentOffline(String name) {
             this.name = name;
         }
 
@@ -444,8 +444,7 @@ public final class InboundAgentRule extends ExternalResource {
         @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"}, justification = "just for test code")
         private static Slave createAgent(JenkinsRule r, Options options) throws Descriptor.FormException, IOException, InterruptedException {
             if (options.getName() == null) {
-                Integer numberOfNodes = r.jenkins.getNodes().size();
-                options.setName("agent" + numberOfNodes);
+                options.setName("agent" + r.jenkins.getNodes().size());
             }
             JNLPLauncher launcher = new JNLPLauncher(true);
             launcher.setWebSocket(options.isWebSocket());

--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -278,9 +279,7 @@ public final class InboundAgentRule extends ExternalResource {
             // To watch it fail: secret = secret.replace('1', '2');
             cmd.addAll(Arrays.asList("-secret", agentArguments.secret));
         }
-        if (agentArguments.commandLineArgs != null) {
-            cmd.addAll(agentArguments.commandLineArgs);
-        }
+        cmd.addAll(agentArguments.commandLineArgs);
         ProcessBuilder pb = new ProcessBuilder(cmd);
         pb.redirectErrorStream(true);
         System.err.println("Running: " + pb.command());
@@ -341,14 +340,17 @@ public final class InboundAgentRule extends ExternalResource {
         /**
          * URL to the agent JNLP file.
          */
+        @NonNull
         private final String agentJnlpUrl;
         /**
          * A reference to the agent jar
          */
+        @NonNull
         private final File agentJar;
         /**
          * The secret the agent should use to connect.
          */
+        @NonNull
         private final String secret;
         /**
          * The number of nodes in the Jenkins instance where the agent is running.
@@ -357,9 +359,10 @@ public final class InboundAgentRule extends ExternalResource {
         /**
          * Additional command line arguments to pass to the agent.
          */
+        @NonNull
         private final List<String> commandLineArgs;
 
-        public AgentArguments(String agentJnlpUrl, File agentJar, String secret, int numberOfNodes, List<String> commandLineArgs) {
+        public AgentArguments(@NonNull String agentJnlpUrl, @NonNull File agentJar, @NonNull String secret, int numberOfNodes, @NonNull List<String> commandLineArgs) {
             this.agentJnlpUrl = agentJnlpUrl;
             this.agentJar = agentJar;
             this.secret = secret;
@@ -390,7 +393,7 @@ public final class InboundAgentRule extends ExternalResource {
                 throw new AssertionError("agent " + node + " has no executor");
             }
             JNLPLauncher launcher = (JNLPLauncher) c.getLauncher();
-            List<String> commandLineArgs = null;
+            List<String> commandLineArgs = Collections.emptyList();
             if (!launcher.getWorkDirSettings().isDisabled()) {
                 commandLineArgs = launcher.getWorkDirSettings().toCommandLineArgs(c);
             }


### PR DESCRIPTION
Add several methods to :
* use this rule in the context of `RealJenkinsRule`
* use this rule in the context of CloudBees way of starting up agents.

See downstream usage in https://github.com/jenkinsci/jenkins/pull/7381

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
