### PR TITLE
Add `BuildWatcher` support to `RealJenkinsRule`

### DIFF
--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -135,7 +135,7 @@ public class RealJenkinsRuleTest {
     }
 
     @Test public void agentBuild() throws Throwable {
-        rr.then(RealJenkinsRuleTest::_agentBuild);
+        rr.watchBuilds().then(RealJenkinsRuleTest::_agentBuild);
     }
     private static void _agentBuild(JenkinsRule r) throws Throwable {
         FreeStyleProject p = r.createFreeStyleProject();


### PR DESCRIPTION
Calling `rjr.watchBuilds()` will register BuildWatcher and print build logs.

Result can be observed by running `mvn test -Dtest=RealJenkinsRuleTest#agentBuild`

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
