### PR TITLE
Some `InjectedTest.testPluginActive` failures neglected to identify tested plugin

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/PluginAutomaticTestBuilder.java
+++ b/src/main/java/org/jvnet/hudson/test/PluginAutomaticTestBuilder.java
@@ -95,7 +95,7 @@ public class PluginAutomaticTestBuilder {
             if (plugin != null) {
                 // did any plugin fail to start?
                 for (FailedPlugin fp : Jenkins.get().getPluginManager().getFailedPlugins()) {
-                    throw new Error("Plugin "+fp.name+" failed to start", fp.cause);
+                    throw new AssertionError("While testing " + plugin + ", " + fp.name + " failed to start", fp.cause);
                 }
 
                 PluginWrapper pw = Jenkins.get().getPluginManager().getPlugin(plugin);


### PR DESCRIPTION
Sometimes when testing a number of plugins at once, `InjectedTest.testPluginActive` would fail saying something like `Plugin workflow-support failed to start` where the problem is in `some-other-plugin/pom.xml` which has a (perhaps `test`-scoped) dependency on `workflow-support`, for example because a BOM-related mistake led to `some-other` plugin using an older transitive dep (`workflow-api`, say). The problem is that nothing in the failure stack trace mentions `some-other` plugin. In something like `bom/Jenkinsfile` this is not terrible because each tested plugin is (currently!) run in its own `parallel` branch, causing the `junit` step to record the tested plugin name indirectly in the test report, but that is pretty fragile and does not work at all when running a bunch of plugins serially, or in one multimodule reactor. This simple change makes it clear which POM was actually being tested, not just the plugin which failed to load.