### PR TITLE
Plumb through `JenkinsRule`/`RealJenkinsRule` when possible

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -263,7 +263,7 @@ public final class InboundAgentRule extends ExternalResource {
     public void start(@NonNull JenkinsRule r, Options options) throws Exception {
         String name = options.getName();
         Objects.requireNonNull(name);
-        stop(name);
+        stop(r, name);
         start(GetAgentArguments.get(r, name), options);
     }
 
@@ -273,7 +273,7 @@ public final class InboundAgentRule extends ExternalResource {
     public void start(@NonNull RealJenkinsRule r, Options options) throws Throwable {
         String name = options.getName();
         Objects.requireNonNull(name);
-        stop(name);
+        stop(r, name);
         start(r.runRemotely(new GetAgentArguments(name)), options);
     }
 


### PR DESCRIPTION
Does not make much of a difference in practice one way or another, but in principle the versions of `#stop` that take `JenkinsRule`/`RealJenkinsRule` should be preferred whenever possible (i.e., when not being invoked by JUnit during teardown), since those versions make tests more deterministic by waiting for the agent to disconnect from the controller. To test this I ran `mvn clean verify -Dtest=hudson.slaves.JNLPLauncherRealTest` with these changes.