### PR TITLE
Require Java 11 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,7 @@
  * allowing one to test against multiple Jenkins versions.
  */
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: 'linux', jdk: '8' ],
   [ platform: 'linux', jdk: '11' ],
   [ platform: 'windows', jdk: '11' ],
-  [ platform: 'linux', jdk: '17', jenkins: '2.377' ],
+  [ platform: 'linux', jdk: '17', jenkins: '2.380' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ THE SOFTWARE.
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.249</jenkins.version>
+    <jenkins.version>2.361</jenkins.version>
     <jetty.version>9.4.49.v20220914</jetty.version>
     <hamcrest.version>2.2</hamcrest.version>
     <jmh.version>1.36</jmh.version>
@@ -64,6 +64,9 @@ THE SOFTWARE.
 
     <!-- may use e.g. 2C for 2 × (number of cores) -->
     <concurrency>1</concurrency>
+
+    <!-- Normally filled in by "maven-hpi-plugin" with the path to "org-netbeans-insane-hook.jar" extracted from this repository -->
+    <jenkins.insaneHook>--patch-module=java.base=${project.build.outputDirectory}/netbeans/harness/modules/ext/org-netbeans-insane-hook.jar --add-exports=java.base/org.netbeans.insane.hook=ALL-UNNAMED</jenkins.insaneHook>
   </properties>
 
   <dependencyManagement>
@@ -71,12 +74,12 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>annotation-indexer</artifactId>
-        <version>1.16</version>
+        <version>1.17</version>
       </dependency>
       <dependency>
         <groupId>org.kohsuke</groupId>
         <artifactId>access-modifier-annotation</artifactId>
-        <version>1.27</version>
+        <version>1.29</version>
       </dependency>
       <dependency>
         <!-- Avoid downloading multiple jenkins core versions and tons of stapler versions due to version range usage in older libs -->
@@ -112,7 +115,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness-htmlunit</artifactId>
-      <version>126.v91b_8a_44dd9b_9</version>
+      <version>127.v28144890db_46</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>
@@ -128,7 +131,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>io.jenkins.lib</groupId>
       <artifactId>support-log-formatter</artifactId>
-      <version>1.1</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -218,7 +221,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
-      <version>1.0.2</version>
+      <version>3.1.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -243,25 +246,6 @@ THE SOFTWARE.
   </pluginRepositories>
   <build>
     <plugins>
-      <!-- TODO When the minimum Jenkins baseline is bumped past 2.357, this can be deleted. -->
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>display-info</id>
-            <configuration>
-              <rules>
-                <requireJavaVersion>
-                  <version>[1.8.0,]</version>
-                </requireJavaVersion>
-                <enforceBytecodeVersion>
-                  <maxJdkVersion>1.8</maxJdkVersion>
-                </enforceBytecodeVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
@@ -276,7 +260,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>structs</artifactId>
-                  <version>1.21</version>
+                  <version>324.va_f5d6774f3a_d</version>
                   <type>hpi</type>
                 </artifactItem>
               </artifactItems>
@@ -340,66 +324,6 @@ THE SOFTWARE.
 
   <profiles>
     <profile>
-      <id>jdk-9-and-above</id>
-      <!-- TODO When the minimum Jenkins baseline is bumped past 2.357, this can be lifted out of the profile. -->
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <properties>
-        <jenkins.insaneHook>--patch-module=java.base=${project.build.outputDirectory}/netbeans/harness/modules/ext/org-netbeans-insane-hook.jar --add-exports=java.base/org.netbeans.insane.hook=ALL-UNNAMED</jenkins.insaneHook>
-      </properties>
-      <!-- TODO When the minimum Jenkins baseline is bumped past 2.357, this can be deleted. -->
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <release>8</release>
-              <testRelease>8</testRelease>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <release>8</release>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <!-- TODO When the minimum Jenkins baseline is bumped past 2.357, this can be deleted. -->
-    <profile>
-      <id>jdk-8-and-below</id>
-      <activation>
-        <jdk>(,1.8]</jdk>
-      </activation>
-      <properties>
-        <jenkins.insaneHook>-Xbootclasspath/p:${project.build.outputDirectory}/netbeans/harness/modules/ext/org-netbeans-insane-hook.jar</jenkins.insaneHook>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-              <testSource>1.8</testSource>
-              <testTarget>1.8</testTarget>
-              <release combine.self="override" />
-              <testRelease combine.self="override" />
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <source>1.8</source>
-              <release combine.self="override" />
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>skip-tests-on-release</id>
       <activation>
         <property>
@@ -432,48 +356,6 @@ THE SOFTWARE.
                 <exclude>org.jvnet.hudson.test.MemoryAssertTest</exclude>
               </excludes>
             </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <!--
-      Our Jenkinsfile has a Java 17 branch that tests a recent weekly release for two reasons:
-
-        1. We want to test on all versions of Java, but only recent weeklies support Java 17.
-
-        2. Testing against a recent weekly release ensures that the test harness can be compiled
-           against the latest core APIs.
-
-      When we are testing against a recent weekly that requires Java 11, the bytecode version
-      check naturally fails. To work around this, we relax the bytecode version check
-      when we are executing the Java 17 branch in the CI environment.
-
-      TODO When the minimum Jenkins baseline is bumped past 2.357, this can be deleted.
-    -->
-    <profile>
-      <id>test-recent-cores-on-ci</id>
-      <activation>
-        <jdk>17</jdk>
-        <property>
-          <name>env.CI</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>display-info</id>
-                <configuration>
-                  <rules>
-                    <enforceBytecodeVersion>
-                      <maxJdkVersion>11</maxJdkVersion>
-                    </enforceBytecodeVersion>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
The first of several PRs to require Java 11 or newer. More cleanup is planned after this PR now that the baseline has been increased to 2.361.