### PR TITLE
Remove logic for old Jenkins versions

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
+++ b/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
@@ -24,7 +24,6 @@
 
 package org.jvnet.hudson.test;
 
-import hudson.util.VersionNumber;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,13 +34,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.PropertyResourceBundle;
-import jenkins.model.Jenkins;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.apache.commons.io.IOUtils;
@@ -81,28 +76,21 @@ public class PropertiesTestSuite extends TestSuite {
                 }
             };
 
-            VersionNumber jv = Jenkins.getVersion();
-            if (jv != null && jv.isOlderThan(new VersionNumber("2.357"))) {
-                byte[] contents = IOUtils.toByteArray(resource);
-                if (!isEncoded(contents, StandardCharsets.US_ASCII)) {
-                    boolean isUtf8 = isEncoded(contents, StandardCharsets.UTF_8);
-                    boolean isIso88591 = isEncoded(contents, StandardCharsets.ISO_8859_1);
-                    if (isUtf8 && isIso88591) {
-                        throw new AssertionError(resource + " is valid UTF-8 and valid ISO-8859-1. To avoid problems when auto-detecting the encoding, use the lowest common denominator of ASCII encoding and express non-ASCII characters with escape sequences using a tool like `native2ascii`.");
-                    }
+            byte[] contents = IOUtils.toByteArray(resource);
+            if (!isEncoded(contents, StandardCharsets.US_ASCII)) {
+                boolean isUtf8 = isEncoded(contents, StandardCharsets.UTF_8);
+                boolean isIso88591 = isEncoded(contents, StandardCharsets.ISO_8859_1);
+                if (!isUtf8 && !isIso88591) {
+                    throw new AssertionError(resource + " must be either valid UTF-8 or valid ISO-8859-1.");
                 }
             }
 
             try (InputStream is = resource.openStream()) {
                 PropertyResourceBundle propertyResourceBundle = new PropertyResourceBundle(is);
-                Enumeration<String> keys = propertyResourceBundle.getKeys();
-                // TODO Java 9+ can use 'asIterator' and get rid of below collections conversion
-                List<String> keysAsSaneType = Collections.list(keys);
-
-                for (String localKey : keysAsSaneType) {
-                    String value = propertyResourceBundle.getString(localKey);
-                    props.setProperty(localKey, value);
-                }
+                propertyResourceBundle
+                        .getKeys()
+                        .asIterator()
+                        .forEachRemaining(key -> props.setProperty(key, propertyResourceBundle.getString(key)));
             }
         }
 

--- a/src/main/java/org/jvnet/hudson/test/WarExploder.java
+++ b/src/main/java/org/jvnet/hudson/test/WarExploder.java
@@ -74,19 +74,8 @@ public final class WarExploder {
         } else {
             // locate jenkins.war
             URL winstone = WarExploder.class.getResource("/executable/winstone.jar");
-            String className = "executable.Main";
-
-            // TODO: Delete the next statement once we drop support for versions older than 2.358.
-            if (winstone == null) {
-                // Prior to 2.358
-                winstone = WarExploder.class.getResource("/winstone.jar");
-                if (winstone != null) {
-                    className = "executable.Executable";
-                }
-            }
-
             if (winstone != null) {
-                war = Which.jarFile(Class.forName(className));
+                war = Which.jarFile(Class.forName("executable.Main"));
             } else {
                 // JENKINS-45245: work around incorrect test classpath in IDEA. Note that this will not correctly handle timestamped snapshots; in that case use `mvn test`.
                 File core = Which.jarFile(Jenkins.class); // will fail with IllegalArgumentException if have neither jenkins-war.war nor jenkins-core.jar in ${java.class.path}


### PR DESCRIPTION
Removes logic for old Jenkins versions that is no longer needed because the baseline is now 2.361. I tested this in core with `mvn clean verify -Dtest=hudson.bugs.JnlpAccessWithSecuredHudsonTest,hudson.diagnosis.HudsonHomeDiskUsageMonitorTest,hudson.model.ItemsTest,hudson.model.JobTest,hudson.model.PasswordParameterDefinitionTest,hudson.model.QueueRestartTest,hudson.model.QueueTest,hudson.security.LoginTest,hudson.slaves.JNLPLauncherRealTest,hudson.slaves.NodeProvisionerTest,hudson.util.RobustReflectionConverterTest,jenkins.CoreAutomaticTestBuilder,jenkins.model.JenkinsLogRecordsTest,jenkins.model.JenkinsTest,jenkins.security.ApiCrumbExclusionTest,jenkins.security.ApiTokenPropertyTest,jenkins.security.BasicHeaderProcessorTest,jenkins.util.SetContextClassLoaderTest,jenkins.util.SystemPropertiesTest,lib.form.PasswordTest`.