### PR TITLE
Use Java 11 language features where possible

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlElementUtil.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlElementUtil.java
@@ -28,8 +28,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.WebClientUtil;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -70,7 +68,7 @@ public class HtmlElementUtil {
      */
     public static boolean hasClassName(HtmlElement element, String className) {
         String classAttribute = element.getAttribute("class");
-        Set<String> classes = new HashSet<>(Arrays.asList(classAttribute.split(" ")));
+        Set<String> classes = Set.of(classAttribute.split(" "));
         return classes.contains(className);
     }
 }

--- a/src/main/java/hudson/cli/CLICommandInvoker.java
+++ b/src/main/java/hudson/cli/CLICommandInvoker.java
@@ -37,11 +37,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -74,9 +71,9 @@ public class CLICommandInvoker {
     private SecurityContext originalSecurityContext = null;
 
     private InputStream stdin;
-    private List<String> args = Collections.emptyList();
+    private List<String> args = List.of();
     @Deprecated
-    private List<Permission> permissions = Collections.emptyList();
+    private List<Permission> permissions = List.of();
     private Locale locale = Locale.ENGLISH;
 
     public CLICommandInvoker(final JenkinsRule rule, final CLICommand command) {
@@ -99,8 +96,7 @@ public class CLICommandInvoker {
      */
     @Deprecated
     public CLICommandInvoker authorizedTo(final Permission... permissions) {
-
-        this.permissions = Arrays.asList(permissions);
+        this.permissions = List.of(permissions);
         return this;
     }
 
@@ -126,8 +122,7 @@ public class CLICommandInvoker {
     }
 
     public CLICommandInvoker withArgs(final String... args) {
-
-        this.args = Arrays.asList(args);
+        this.args = List.of(args);
         return this;
     }
 
@@ -153,18 +148,13 @@ public class CLICommandInvoker {
             throw new RuntimeException(e);
         }
 
-        final int returnCode;
-        try {
-            returnCode =
-                    command.main(
-                            args,
-                            locale,
-                            stdin,
-                            new PrintStream(out, false, outCharset.name()),
-                            new PrintStream(err, false, errCharset.name()));
-        } catch (UnsupportedEncodingException e) {
-            throw new AssertionError(e);
-        }
+        final int returnCode =
+                command.main(
+                        args,
+                        locale,
+                        stdin,
+                        new PrintStream(out, false, outCharset),
+                        new PrintStream(err, false, errCharset));
 
         restoreAuth();
 
@@ -203,7 +193,7 @@ public class CLICommandInvoker {
         @NonNull
         @Override
         public Collection<String> getGroups() {
-            return Collections.emptySet();
+            return Set.of();
         }
     }
 
@@ -280,12 +270,7 @@ public class CLICommandInvoker {
         }
 
         public String stdout() {
-
-            try {
-                return out.toString(outCharset.name());
-            } catch (UnsupportedEncodingException e) {
-                throw new AssertionError(e);
-            }
+            return out.toString(outCharset);
         }
 
         public byte[] stdoutBinary() {
@@ -293,12 +278,7 @@ public class CLICommandInvoker {
         }
 
         public String stderr() {
-
-            try {
-                return err.toString(errCharset.name());
-            } catch (UnsupportedEncodingException e) {
-                throw new AssertionError(e);
-            }
+            return err.toString(errCharset);
         }
 
         public byte[] stderrBinary() {

--- a/src/main/java/org/jvnet/hudson/test/ExtractChangeLogParser.java
+++ b/src/main/java/org/jvnet/hudson/test/ExtractChangeLogParser.java
@@ -39,7 +39,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -68,7 +67,7 @@ public class ExtractChangeLogParser extends ChangeLogParser {
             while ((fileName = br.readLine()) != null) {
                 entry.addFile(new FileInZip(fileName));
             }
-            return new ExtractChangeLogSet(build, Collections.singletonList(entry));
+            return new ExtractChangeLogSet(build, List.of(entry));
         }
     }
 

--- a/src/main/java/org/jvnet/hudson/test/ExtractChangeLogSet.java
+++ b/src/main/java/org/jvnet/hudson/test/ExtractChangeLogSet.java
@@ -27,7 +27,6 @@ import hudson.model.AbstractBuild;
 import hudson.scm.ChangeLogSet;
 
 import java.util.List;
-import java.util.Collections;
 import java.util.Iterator;
 
 
@@ -42,7 +41,7 @@ public class ExtractChangeLogSet extends ChangeLogSet<ExtractChangeLogParser.Ext
         for (ExtractChangeLogParser.ExtractChangeLogEntry entry : changeLogs) {
             entry.setParent(this);
         }
-        this.changeLogs = Collections.unmodifiableList(changeLogs);
+        this.changeLogs = List.copyOf(changeLogs);
     }
 
     @Override

--- a/src/main/java/org/jvnet/hudson/test/ExtractResourceWithChangesSCM.java
+++ b/src/main/java/org/jvnet/hudson/test/ExtractResourceWithChangesSCM.java
@@ -114,7 +114,7 @@ public class ExtractResourceWithChangesSCM extends NullSCM {
     }
 
     public void saveToChangeLog(File changeLogFile, Charset charset, ExtractChangeLogParser.ExtractChangeLogEntry changeLog) throws IOException {
-        try (PrintStream ps = new PrintStream(changeLogFile, charset.name())) {
+        try (PrintStream ps = new PrintStream(changeLogFile, charset)) {
             ps.println(changeLog.getZipFile());
             for (String fileName : changeLog.getAffectedPaths()) {
                 ps.println(fileName);
@@ -128,6 +128,6 @@ public class ExtractResourceWithChangesSCM extends NullSCM {
     protected Object writeReplace() { return new Object(); }
 
     @Override public SCMDescriptor<?> getDescriptor() {
-        return new SCMDescriptor<ExtractResourceWithChangesSCM>(ExtractResourceWithChangesSCM.class, null) {};
+        return new SCMDescriptor<>(ExtractResourceWithChangesSCM.class, null) {};
     }
 }

--- a/src/main/java/org/jvnet/hudson/test/FakeChangeLogSCM.java
+++ b/src/main/java/org/jvnet/hudson/test/FakeChangeLogSCM.java
@@ -35,7 +35,6 @@ import hudson.scm.ChangeLogSet.Entry;
 import hudson.scm.EditType;
 import hudson.scm.NullSCM;
 import hudson.scm.RepositoryBrowser;
-import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
 import hudson.scm.SCMRevisionState;
 import org.xml.sax.SAXException;
@@ -45,9 +44,9 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Fake SCM implementation that can report arbitrary commits from arbitrary users.
@@ -80,7 +79,7 @@ public class FakeChangeLogSCM extends NullSCM implements Serializable {
     }
 
     @Override public SCMDescriptor<?> getDescriptor() {
-        return new SCMDescriptor<SCM>(null) {};
+        return new SCMDescriptor<>(null) {};
     }
 
     public static class ChangelogAction extends InvisibleAction {
@@ -102,7 +101,7 @@ public class FakeChangeLogSCM extends NullSCM implements Serializable {
                     return new FakeChangeLogSet(build, action.entries);
                 }
             }
-            return new FakeChangeLogSet(build, Collections.emptyList());
+            return new FakeChangeLogSet(build, List.of());
         }
     }
 
@@ -159,7 +158,7 @@ public class FakeChangeLogSCM extends NullSCM implements Serializable {
 
         @Override
         public Collection<String> getAffectedPaths() {
-            return Collections.singleton(path);
+            return Set.of(path);
         }
 
         @Override
@@ -175,7 +174,7 @@ public class FakeChangeLogSCM extends NullSCM implements Serializable {
                     return EditType.EDIT;
                 }
             };
-            return Collections.singleton(affectedFile);
+            return Set.of(affectedFile);
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jvnet/hudson/test/HudsonHomeLoader.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonHomeLoader.java
@@ -26,7 +26,6 @@ package org.jvnet.hudson.test;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.FilePath;
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -132,7 +132,6 @@ import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -669,7 +668,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         synchronized (jenkins) {
             DumbSlave slave = new DumbSlave(nodeName, "dummy",
     				createTmpDir().getPath(), "1", Mode.NORMAL, labels==null?"":labels, createComputerLauncher(env),
-			        RetentionStrategy.NOOP, Collections.emptyList());
+			        RetentionStrategy.NOOP, List.of());
     		jenkins.addNode(slave);
     		return slave;
     	}
@@ -1005,7 +1004,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      *      ','-separated list of properties whose help files should exist.
      */
     public void assertHelpExists(final Class<? extends Describable> type, final String properties) throws Exception {
-        executeOnServer(new Callable<Object>() {
+        executeOnServer(new Callable<>() {
             @Override
             public Object call() throws Exception {
                 Descriptor d = jenkins.getDescriptor(type);
@@ -1265,7 +1264,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
                     }
                 }
                 throw new AssertionError(String.format("Jenkins is still doing something after %dms: queue=%s building=%s",
-                        timeout, Arrays.asList(jenkins.getQueue().getItems()), building));
+                        timeout, List.of(jenkins.getQueue().getItems()), building));
             }
         }
     }
@@ -1294,12 +1293,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
                 if(r==null)     continue;
                 final Runner runner = r.value().newInstance();
                 recipes.add(runner);
-                tearDowns.add(new LenientRunnable() {
-                    @Override
-                    public void run() throws Exception {
-                        runner.tearDown(HudsonTestCase.this,a);
-                    }
-                });
+                tearDowns.add(() -> runner.tearDown(HudsonTestCase.this, a));
                 runner.setup(this,a);
             }
         } catch (NoSuchMethodException e) {
@@ -1690,7 +1684,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             com.gargoylesoftware.htmlunit.util.NameValuePair crumb = new com.gargoylesoftware.htmlunit.util.NameValuePair(
                     jenkins.getCrumbIssuer().getDescriptor().getCrumbRequestField(),
                     jenkins.getCrumbIssuer().getCrumb( null ));
-            req.setRequestParameters(Collections.singletonList(crumb));
+            req.setRequestParameters(List.of(crumb));
             return req;
         }
         
@@ -1786,7 +1780,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
     private static final Logger LOGGER = Logger.getLogger(HudsonTestCase.class.getName());
 
-    protected static final List<ToolProperty<?>> NO_PROPERTIES = Collections.emptyList();
+    protected static final List<ToolProperty<?>> NO_PROPERTIES = List.of();
 
     /**
      * Specify this to a TCP/IP port number to have slaves started with the debugger.

--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -40,8 +40,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -281,7 +279,7 @@ public final class InboundAgentRule extends ExternalResource {
     public void start(AgentArguments agentArguments, Options options) throws Exception {
         Objects.requireNonNull(options.getName());
         stop(options.getName());
-        List<String> cmd = new ArrayList<>(Arrays.asList(JavaEnvUtils.getJreExecutable("java"),
+        List<String> cmd = new ArrayList<>(List.of(JavaEnvUtils.getJreExecutable("java"),
             "-Xmx512m",
             "-XX:+PrintCommandLineFlags",
             "-Djava.awt.headless=true"));
@@ -289,12 +287,12 @@ public final class InboundAgentRule extends ExternalResource {
             cmd.add("-Xdebug");
             cmd.add("Xrunjdwp:transport=dt_socket,server=y,address=" + (JenkinsRule.SLAVE_DEBUG_PORT + agentArguments.numberOfNodes - 1));
         }
-        cmd.addAll(Arrays.asList(
+        cmd.addAll(List.of(
                 "-jar", agentArguments.agentJar.getAbsolutePath(),
                 "-jnlpUrl", agentArguments.agentJnlpUrl));
         if (options.isSecret()) {
             // To watch it fail: secret = secret.replace('1', '2');
-            cmd.addAll(Arrays.asList("-secret", agentArguments.secret));
+            cmd.addAll(List.of("-secret", agentArguments.secret));
         }
         cmd.addAll(agentArguments.commandLineArgs);
         ProcessBuilder pb = new ProcessBuilder(cmd);
@@ -410,7 +408,7 @@ public final class InboundAgentRule extends ExternalResource {
                 throw new AssertionError("agent " + node + " has no executor");
             }
             JNLPLauncher launcher = (JNLPLauncher) c.getLauncher();
-            List<String> commandLineArgs = Collections.emptyList();
+            List<String> commandLineArgs = List.of();
             if (!launcher.getWorkDirSettings().isDisabled()) {
                 commandLineArgs = launcher.getWorkDirSettings().toCommandLineArgs(c);
             }

--- a/src/main/java/org/jvnet/hudson/test/JellyTestSuiteBuilder.java
+++ b/src/main/java/org/jvnet/hudson/test/JellyTestSuiteBuilder.java
@@ -141,7 +141,7 @@ public class JellyTestSuiteBuilder {
 
         @Override
         protected void runGroupedTests(final TestResult result) throws Exception {
-            h.executeOnServer(new Callable<Object>() {
+            h.executeOnServer(new Callable<>() {
                 // this code now inside a request handling thread
                 @Override
                 public Object call() throws Exception {

--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.RingBufferLogHandler;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -183,7 +182,7 @@ public class LoggerRule extends ExternalResource {
      */
     public List<String> getMessages() {
         synchronized (messages) {
-            return Collections.unmodifiableList(new ArrayList<>(messages));
+            return List.copyOf(messages);
         }
     }
 

--- a/src/main/java/org/jvnet/hudson/test/MockAuthorizationStrategy.java
+++ b/src/main/java/org/jvnet/hudson/test/MockAuthorizationStrategy.java
@@ -35,7 +35,6 @@ import hudson.security.AuthorizationStrategy;
 import hudson.security.Permission;
 import hudson.security.SidACL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -64,7 +63,7 @@ public class MockAuthorizationStrategy extends AuthorizationStrategy {
      * @param permissions which permissions to grant ({@link Permission#impliedBy} is honored)
      */
     public Grant grant(Permission... permissions) {
-        Set<Permission> effective = new HashSet<>(Arrays.asList(permissions));
+        Set<Permission> effective = new HashSet<>(List.of(permissions));
         boolean added = true;
         while (added) {
             added = false;
@@ -79,7 +78,7 @@ public class MockAuthorizationStrategy extends AuthorizationStrategy {
      * Like {@link #grant} but does <em>not</em> honor {@link Permission#impliedBy}.
      */
     public Grant grantWithoutImplication(Permission... permissions) {
-        return new Grant(new HashSet<>(Arrays.asList(permissions)));
+        return new Grant(new HashSet<>(List.of(permissions)));
     }
 
     /**
@@ -166,7 +165,7 @@ public class MockAuthorizationStrategy extends AuthorizationStrategy {
 
             /** To some users or groups. */
             public MockAuthorizationStrategy to(String... sids) {
-                return new GrantOnTo(new HashSet<>(Arrays.asList(sids))).add();
+                return new GrantOnTo(new HashSet<>(List.of(sids))).add();
             }
 
             /** To some users. */

--- a/src/main/java/org/jvnet/hudson/test/MockFolder.java
+++ b/src/main/java/org/jvnet/hudson/test/MockFolder.java
@@ -48,7 +48,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +72,7 @@ import org.kohsuke.stapler.WebMethod;
 public class MockFolder extends AbstractItem implements DirectlyModifiableTopLevelItemGroup, TopLevelItem, ModifiableViewGroup, StaplerFallback {
 
     private transient Map<String,TopLevelItem> items = new TreeMap<>();
-    private final List<View> views = new ArrayList<>(Collections.singleton(new AllView("All", this)));
+    private final List<View> views = new ArrayList<>(Set.of(new AllView("All", this)));
     private String primaryView;
     private ViewsTabBar viewsTabBar;
 
@@ -251,7 +250,7 @@ public class MockFolder extends AbstractItem implements DirectlyModifiableTopLev
     @Override public List<Action> getViewActions() {
         // TODO what should the default be? View.getOwnerViewActions uses Jenkins.actions; Jenkins.viewActions would make more sense as a default;
         // or should it be empty by default since non-top-level folders probably do not need the same actions as root?
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override public Object getStaplerFallback() {

--- a/src/main/java/org/jvnet/hudson/test/PrefixedOutputStream.java
+++ b/src/main/java/org/jvnet/hudson/test/PrefixedOutputStream.java
@@ -49,7 +49,7 @@ public final class PrefixedOutputStream extends LineTransformationOutputStream.D
 
         private final String code;
 
-        private Color(String code) {
+        Color(String code) {
             this.code = code;
         }
 

--- a/src/main/java/org/jvnet/hudson/test/PretendSlave.java
+++ b/src/main/java/org/jvnet/hudson/test/PretendSlave.java
@@ -11,7 +11,7 @@ import hudson.model.TaskListener;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.RetentionStrategy;
 import java.io.IOException;
-import java.util.Collections;
+import java.util.List;
 
 /**
  * Slave that pretends to fork processes.
@@ -28,7 +28,7 @@ public class PretendSlave extends Slave {
     public int numLaunch;
 
     public PretendSlave(String name, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, FakeLauncher faker) throws IOException, FormException {
-        super(name, "pretending a slave", remoteFS, String.valueOf(numExecutors), mode, labelString, launcher, RetentionStrategy.NOOP, Collections.emptyList());
+        super(name, "pretending a slave", remoteFS, String.valueOf(numExecutors), mode, labelString, launcher, RetentionStrategy.NOOP, List.of());
         this.faker = faker;
     }
 

--- a/src/main/java/org/jvnet/hudson/test/ResponseCapturingOutput.java
+++ b/src/main/java/org/jvnet/hudson/test/ResponseCapturingOutput.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -77,11 +76,7 @@ class ResponseCapturingOutput implements StaplerResponse {
         private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         public String getOutputContent() {
-            try {
-                return baos.toString(StandardCharsets.UTF_8.name());
-            } catch (UnsupportedEncodingException e) {
-                throw new AssertionError("UTF8 not available");
-            }
+            return baos.toString(StandardCharsets.UTF_8);
         }
         
         @Override

--- a/src/main/java/org/jvnet/hudson/test/RestartableJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RestartableJenkinsRule.java
@@ -1,6 +1,5 @@
 package org.jvnet.hudson.test;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import groovy.lang.Closure;
 import hudson.PluginManager;
 import java.io.File;
@@ -16,9 +15,9 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -216,7 +215,7 @@ public class RestartableJenkinsRule implements MethodRule {
          File newHome = tmp.allocate();
 
          // Copy efficiently
-         Files.walkFileTree(homeDir.toPath(), Collections.emptySet(), 99, new CopyFileVisitor(newHome.toPath()));
+         Files.walkFileTree(homeDir.toPath(), Set.of(), 99, new CopyFileVisitor(newHome.toPath()));
          LOGGER.log(Level.INFO, "Finished snapshot of JENKINS_HOME, any disk writes by Jenkins after this are lost as we will simulate suddenly killing the Jenkins process and switch to the snapshot.");
          home = newHome;
     }

--- a/src/main/java/org/jvnet/hudson/test/SingleFileSCM.java
+++ b/src/main/java/org/jvnet/hudson/test/SingleFileSCM.java
@@ -33,7 +33,6 @@ import hudson.scm.SCMRevisionState;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
@@ -53,7 +52,7 @@ public class SingleFileSCM extends NullSCM {
         this.contents = contents;
     }
 
-    public SingleFileSCM(String path, String contents) throws UnsupportedEncodingException {
+    public SingleFileSCM(String path, String contents) {
         this.path = path;
         this.contents = contents.getBytes(StandardCharsets.UTF_8);
     }

--- a/src/main/java/org/jvnet/hudson/test/TestBuilder.java
+++ b/src/main/java/org/jvnet/hudson/test/TestBuilder.java
@@ -50,7 +50,7 @@ public abstract class TestBuilder extends Builder {
     @Override
     public Descriptor<Builder> getDescriptor() {
         // throw new UnsupportedOperationException();
-        return new BuildStepDescriptor<Builder>() {
+        return new BuildStepDescriptor<>() {
             @Override
             public boolean isApplicable(Class<? extends AbstractProject> jobType) {
                 return true;

--- a/src/main/java/org/jvnet/hudson/test/TestNotifier.java
+++ b/src/main/java/org/jvnet/hudson/test/TestNotifier.java
@@ -36,7 +36,7 @@ public abstract class TestNotifier extends Notifier {
 
     @Override
     public BuildStepDescriptor<Publisher> getDescriptor() {
-        return new BuildStepDescriptor<Publisher>() {
+        return new BuildStepDescriptor<>() {
             @Override
             public boolean isApplicable(Class<? extends AbstractProject> jobType) {
                 return true;

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -25,7 +25,6 @@ import org.kohsuke.stapler.verb.PUT;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -47,7 +46,7 @@ public class JenkinsRuleTest {
 
     @Test(expected = AssertionError.class)
     public void givenOneNullListAndOneNonnullListAssertShouldFail() throws Exception {
-        j.assertEqualDataBoundBeans(new SomeClass(Collections.emptyList()), new SomeClass(null));
+        j.assertEqualDataBoundBeans(new SomeClass(List.of()), new SomeClass(null));
     }
 
     public static class SomeClass {

--- a/src/test/java/org/jvnet/hudson/test/MemoryAssertTest.java
+++ b/src/test/java/org/jvnet/hudson/test/MemoryAssertTest.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import hudson.util.VersionNumber;
 import org.junit.Test;
 
 public class MemoryAssertTest {
@@ -58,10 +57,10 @@ public class MemoryAssertTest {
 
     @Test
     public void gc() {
-        VersionNumber javaVersion = new VersionNumber(System.getProperty("java.specification.version"));
+        Runtime.Version runtimeVersion = Runtime.version();
         assumeTrue(
-                "TODO JENKINS-67974 works on Java 8 and 17 but not 11",
-                javaVersion.isOlderThan(new VersionNumber("9")) || javaVersion.isNewerThanOrEqualTo(new VersionNumber("17")));
+                "TODO JENKINS-67974 works on Java 17 but not 11",
+                runtimeVersion.feature() >= 17);
         List<String> strings = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             strings.add(Integer.toString(i));

--- a/src/test/java/org/jvnet/hudson/test/PrefixedOutputStreamTest.java
+++ b/src/test/java/org/jvnet/hudson/test/PrefixedOutputStreamTest.java
@@ -26,6 +26,7 @@ package org.jvnet.hudson.test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import org.junit.Rule;
@@ -63,7 +64,7 @@ public class PrefixedOutputStreamTest {
             ps.println("split across\ntwo lines");
             ps.print("missing trailing newline");
         }
-        assertThat(baos.toString("UTF-8").replace("\r\n", "\n"),
+        assertThat(baos.toString(StandardCharsets.UTF_8).replace("\r\n", "\n"),
             is(expected));
     }
 

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -46,11 +46,11 @@ import hudson.model.BuildListener;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.util.PluginServletFilter;
-import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import javax.servlet.Filter;
@@ -61,7 +61,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.core.IsNull;
 import org.hamcrest.core.StringContains;
@@ -201,11 +200,11 @@ public class RealJenkinsRuleTest {
     }
     private static void _restart1(JenkinsRule r) throws Throwable {
         assertEquals(r.jenkins.getRootUrl(), r.getURL().toString());
-        FileUtils.write(new File(r.jenkins.getRootDir(), "url.txt"), r.getURL().toString(), StandardCharsets.UTF_8);
+        Files.writeString(r.jenkins.getRootDir().toPath().resolve("url.txt"), r.getURL().toString(), StandardCharsets.UTF_8);
     }
     private static void _restart2(JenkinsRule r) throws Throwable {
         assertEquals(r.jenkins.getRootUrl(), r.getURL().toString());
-        assertEquals(r.jenkins.getRootUrl(), FileUtils.readFileToString(new File(r.jenkins.getRootDir(), "url.txt"), StandardCharsets.UTF_8));
+        assertEquals(r.jenkins.getRootUrl(), Files.readString(r.jenkins.getRootDir().toPath().resolve("url.txt"), StandardCharsets.UTF_8));
     }
 
     @Test public void stepsDoNotRunOnHttpWorkerThread() throws Throwable {


### PR DESCRIPTION
Tested in core with `mvn clean verify -Dtest=hudson.bugs.JnlpAccessWithSecuredHudsonTest,hudson.cli.AddJobToViewCommandTest,hudson.cli.BuildCommandTest,hudson.cli.CancelQuietDownCommandTest,hudson.cli.ClearQueueCommandTest,hudson.cli.ComputerStateTest,hudson.cli.ConnectNodeCommandTest,hudson.cli.ConsoleCommandTest,hudson.cli.CopyJobCommandTest,hudson.cli.CreateJobCommandTest,hudson.cli.CreateNodeCommandTest,hudson.cli.CreateViewCommandTest,hudson.cli.DeleteBuildsCommandTest,hudson.cli.DeleteJobCommandTest,hudson.cli.DeleteNodeCommandTest,hudson.cli.DeleteViewCommandTest,hudson.cli.DisablePluginCommandTest,hudson.cli.DisconnectNodeCommandTest,hudson.cli.EnableJobCommandTest,hudson.cli.EnablePluginCommandTest,hudson.cli.GetJobCommandTest,hudson.cli.GetNodeCommandTest,hudson.cli.GetViewCommandTest,hudson.cli.GroovyshCommandTest,hudson.cli.HelpCommandTest,hudson.cli.InstallPluginCommandTest,hudson.cli.ListJobsCommandTest,hudson.cli.ListPluginsCommandTest,hudson.cli.OfflineNodeCommandTest,hudson.cli.OnlineNodeCommandTest,hudson.cli.QuietDownCommandTest,hudson.cli.ReloadConfigurationCommandTest,hudson.cli.ReloadJobCommandTest,hudson.cli.RemoveJobFromViewCommandTest,hudson.cli.RunRangeCommand2Test,hudson.cli.RunRangeCommandTest,hudson.cli.SetBuildDescriptionCommandTest,hudson.cli.SetBuildDisplayNameCommandTest,hudson.cli.UpdateNodeCommandTest,hudson.cli.UpdateViewCommandTest,hudson.cli.WaitNodeOfflineCommandTest,hudson.cli.WaitNodeOnlineCommandTest,hudson.diagnosis.OldDataMonitorTest,hudson.jobs.CreateItemTest,hudson.model.AbstractBuildTest,hudson.model.AbstractProjectTest,hudson.model.ComputerConfigDotXmlTest,hudson.model.ComputerSetTest,hudson.model.ComputerTest,hudson.model.DirectlyModifiableViewTest,hudson.model.DisplayNameTest,hudson.model.FingerprintTest,hudson.model.ItemGroupMixInTest,hudson.model.ItemsTest,hudson.model.JobTest,hudson.model.listeners.ItemListenerTest,hudson.model.ListViewTest,hudson.model.ProjectTest,hudson.model.QueueRestartTest,hudson.model.RunParameterDefinitionTest,hudson.model.UserTest,hudson.model.ViewDescriptorTest,hudson.model.ViewTest,hudson.model.WorkspaceCleanupThreadTest,hudson.node_monitors.ResponseTimeMonitorTest,hudson.scm.ChangeLogSetTest,hudson.search.SearchTest,hudson.slaves.AgentInboundUrlTest,hudson.slaves.JNLPLauncherRealTest,hudson.slaves.NodeParallelTest,hudson.slaves.NodeProvisionerTest,hudson.tasks.BatchFileTest,hudson.tasks.EnvVarsInConfigTasksTest,hudson.tasks.MavenTest,hudson.tasks.ShellTest,hudson.util.ProcessTreeTest,hudson.util.RobustReflectionConverterTest,jenkins.agents.WebSocketAgentsTest,jenkins.cli.StopBuildsCommandTest,jenkins.model.JenkinsBuildsAndWorkspacesDirectoriesTest,jenkins.model.JenkinsLogRecordsTest,jenkins.model.JenkinsManagePermissionTest,jenkins.model.NodeListenerTest,jenkins.model.TransientActionFactoryTest,jenkins.security.Security218Test,jenkins.security.Security2278Test,jenkins.slaves.restarter.JnlpSlaveRestarterInstallerTest,jenkins.util.SetContextClassLoaderTest,jenkins.widgets.BuildListTableTest,lib.form.PasswordTest,lib.layout.RenderOnDemandTest`.