### PR TITLE
`RealJenkinsRule`: option to provide a custom port/listen address

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -160,6 +160,15 @@ public final class RealJenkinsRule implements TestRule {
      */
     private int port;
 
+    /**
+     * HTTP interface the server listens to.
+     * <p>
+     * Defaults to 127.0.0.1.
+     * <p>
+     * Should be overridden only in specific testing use cases, like testing inside a docker container.
+     */
+    private String httpListenAddress = "127.0.0.1";
+
     private File war;
 
     private boolean includeTestClasspathPlugins = true;
@@ -312,6 +321,15 @@ public final class RealJenkinsRule implements TestRule {
      */
     public RealJenkinsRule withPort(int port) {
         this.port = port;
+        return this;
+    }
+
+    /**
+     * Provides a custom interface to listen to. This should be restricted for specific testing use cases (like running inside a docker container)
+     * @param httpListenAddress network interface such as <pre>0.0.0.0</pre>. Defaults to <pre>127.0.0.1</pre>.
+     */
+    public RealJenkinsRule withHttpListenAddress(String httpListenAddress) {
+        this.httpListenAddress = httpListenAddress;
         return this;
     }
 
@@ -556,7 +574,7 @@ public final class RealJenkinsRule implements TestRule {
                 "-jar", war.getAbsolutePath(),
                 "--enable-future-java",
                 "--httpPort=" + port, // initially port=0. On subsequent runs, the port is set to the port used allocated randomly on the first run.
-                "--httpListenAddress=127.0.0.1",
+                "--httpListenAddress=" + httpListenAddress,
                 "--prefix=/jenkins"));
         Map<String, String> env = new TreeMap<>();
         env.put("JENKINS_HOME", home.getAbsolutePath());

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -307,6 +307,15 @@ public final class RealJenkinsRule implements TestRule {
     }
 
     /**
+     * Provides a custom fixed port instead of a random one.
+     * @param port a custom port to use instead of a random one.
+     */
+    public RealJenkinsRule withPort(int port) {
+        this.port = port;
+        return this;
+    }
+
+    /**
      * The intended use case for this is to use the plugins bundled into the war {@link RealJenkinsRule#withWar(File)}
      * instead of the plugins in the pom. A typical scenario for this feature is a test which does not live inside a
      * plugin's src/test/java

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -160,13 +160,6 @@ public final class RealJenkinsRule implements TestRule {
      */
     private int port;
 
-    /**
-     * HTTP interface the server listens to.
-     * <p>
-     * Defaults to 127.0.0.1.
-     * <p>
-     * Should be overridden only in specific testing use cases, like testing inside a docker container.
-     */
     private String httpListenAddress = "127.0.0.1";
 
     private File war;
@@ -325,7 +318,11 @@ public final class RealJenkinsRule implements TestRule {
     }
 
     /**
-     * Provides a custom interface to listen to. This should be restricted for specific testing use cases (like running inside a docker container)
+     * Provides a custom interface to listen to.
+     * <p><em>Important:</em> for security reasons this should be overridden only in special scenarios,
+     * such as testing inside a Docker container.
+     * Otherwise a developer running tests could inadvertently expose a Jenkins service without password protection,
+     * allowing remote code execution.
      * @param httpListenAddress network interface such as <pre>0.0.0.0</pre>. Defaults to <pre>127.0.0.1</pre>.
      */
     public RealJenkinsRule withHttpListenAddress(String httpListenAddress) {


### PR DESCRIPTION
Kubernetes-plugin is running its tests within a kubernetes pod running in Kind.

During test execution, agents need to loopback to the running controller running in another container, and so the controller needs to bind another network interface than localhost.

A [special](https://github.com/jenkinsci/kubernetes-plugin/blob/54f40a5e7fb1798bad69977b00fa8634260d8852/src/test/java/org/jvnet/hudson/test/JenkinsRuleNonLocalhost.java) version of JenkinsRule is used for regular tests, considering prior attempts to introduce such option were not merged.

For RealJenkinsRule-based tests, it seems much simpler to have the option available directly in the framework.

See usage in https://github.com/jenkinsci/kubernetes-plugin/pull/1290

Relates to https://github.com/jenkinsci/jenkins-test-harness/pull/289#issuecomment-809560892, for RJR.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
