### PR TITLE
Let callers specify some debug options

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -188,7 +188,6 @@ public final class RealJenkinsRule implements TestRule {
 
     private int debugPort = 0;
     private boolean debugServer = true;
-
     private boolean debugSuspend;
 
     // TODO may need to be relaxed for Gradle-based plugins
@@ -337,9 +336,9 @@ public final class RealJenkinsRule implements TestRule {
 
     /**
      * Allows usage of a static debug port instead of a random one.
-     *
+     * <p>
      * This allows to use predefined debug configurations in the IDE.
-     *
+     * <p>
      * Typical usage is in a base test class where multiple named controller instances are defined with fixed ports
      *
      * <pre>
@@ -349,15 +348,19 @@ public final class RealJenkinsRule implements TestRule {
      * </pre>
      *
      * Then have debug configurations in the IDE set for ports
-     * - 5005 (test VM) - debugger mode "attach to remote vm"
-     * - 4001 (cc1) - debugger mode "listen to remote vm"
-     * - 4002 (cc2) - debugger mode "listen to remote vm"
-     *
+     * <ul>
+     * <li>5005 (test VM) - debugger mode "attach to remote vm"</li>
+     * <li>4001 (cc1) - debugger mode "listen to remote vm"</li>
+     * <li>4002 (cc2) - debugger mode "listen to remote vm"</li>
+     * </ul>
+     * <p>
      * This allows for debugger to reconnect in scenarios where restarts of controllers are involved.
      *
-     * @param debugPort
+     * @param debugPort the TCP port to use for debugging this Jenkins instance. Between 0 (random) and 65536 (excluded).
      */
     public RealJenkinsRule withDebugPort(int debugPort) {
+        if (debugPort < 0) throw new IllegalArgumentException("debugPort must be positive");
+        if (!(debugPort < 65536)) throw new IllegalArgumentException("debugPort must be a valid TCP port (< 65536)");
         this.debugPort = debugPort;
         return this;
     }

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -367,7 +367,7 @@ public final class RealJenkinsRule implements TestRule {
     /**
      * Allows to use debug in server mode or client mode. Client mode is friendlier to controller restarts.
      *
-     * @see #withDebugPort(int).
+     * @see #withDebugPort(int)
      *
      * @param debugServer true to use server=y, false to use server=n
      */

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -72,7 +72,7 @@ import org.kohsuke.stapler.Stapler;
 public class RealJenkinsRuleTest {
 
     // TODO addPlugins does not currently take effect when used inside test method
-    @Rule public RealJenkinsRule rr = new RealJenkinsRule().addPlugins("plugins/structs.hpi");
+    @Rule public RealJenkinsRule rr = new RealJenkinsRule().addPlugins("plugins/structs.hpi").withDebugPort(4001).withDebugServer(false);
     @Rule public RealJenkinsRule rrWithFailure = new RealJenkinsRule().addPlugins("plugins/failure.hpi");
 
     @Test public void smokes() throws Throwable {


### PR DESCRIPTION
When writing RJR tests involving multiple controller instances, it's tedious to debug because each controller starts with a random debug port, and it changes on each run.

When debugging interactively, it's easier to rely on static ports (which can be specified in a test base class declaring the different controller instances involved in tests). I've found as well `server=n` to be useful for this case as test cases can involve restarts, and IDE can set up their debugger in server mode (so that the VM connects to it) with auto restart.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
