### PR TITLE
Include details about `cause` in `StepException.message`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -1025,7 +1025,7 @@ public final class RealJenkinsRule implements TestRule {
 
     public static class StepException extends Exception {
         public StepException(Throwable cause) {
-            super("Remote step threw an exception", cause);
+            super("Remote step threw an exception: " + cause, cause);
         }
     }
 

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -91,9 +91,11 @@ public class RealJenkinsRuleTest {
     }
 
     @Test public void testThrowsException() {
-        assertThrows(RealJenkinsRule.StepException.class, () -> rr.then((RealJenkinsRule.Step2<Serializable>) r -> {
-            throw new Exception("test");
-        }));
+        assertThat(assertThrows(RealJenkinsRule.StepException.class, () -> rr.then(RealJenkinsRuleTest::throwsException)).getMessage(),
+            containsString("IllegalStateException: something is wrong"));
+    }
+    private static void throwsException(JenkinsRule r) throws Throwable {
+        throw new IllegalStateException("something is wrong");
     }
 
     @Test public void testFilter() throws Throwable{


### PR DESCRIPTION
Amending #488. It is conventional for wrapper exceptions to include `cause.message` in their own `message` as a suffix. (Also this is [treated specially by `Functions.printThrowable`](https://github.com/jenkinsci/jenkins/blob/4300daa6679476b1de606ed4636a0542e98231d1/core/src/main/java/hudson/Functions.java#L1696-L1698) though it is unlikely that would be applied to a JUnit error.)