### PR TITLE
Reduce usage of Commons Lang 3

### DIFF
--- a/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
@@ -8,12 +8,12 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletContext;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
-import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.eclipse.jetty.server.Server;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -41,7 +41,7 @@ public abstract class JmhBenchmarkState implements RootAction {
     private static final String contextPath = "/jenkins";
 
     private final TemporaryDirectoryAllocator temporaryDirectoryAllocator = new TemporaryDirectoryAllocator();
-    private final MutableInt localPort = new MutableInt();
+    private final AtomicInteger localPort = new AtomicInteger();
 
     private Jenkins jenkins = null;
     private Server server = null;
@@ -86,8 +86,8 @@ public abstract class JmhBenchmarkState implements RootAction {
     }
 
     private void launchInstance() throws Exception {
-        ImmutablePair<Server, ServletContext> results = JenkinsRule._createWebServer(contextPath, localPort::setValue,
-                getClass().getClassLoader(), localPort.getValue(), JenkinsRule::_configureUserRealm);
+        ImmutablePair<Server, ServletContext> results = JenkinsRule._createWebServer(contextPath, localPort::set,
+                getClass().getClassLoader(), localPort.get(), JenkinsRule::_configureUserRealm);
 
         server = results.left;
         ServletContext webServer = results.right;
@@ -103,7 +103,7 @@ public abstract class JmhBenchmarkState implements RootAction {
     }
 
     private URL getJenkinsURL() throws MalformedURLException {
-        return new URL("http://localhost:" + localPort.getValue() + contextPath + "/");
+        return new URL("http://localhost:" + localPort.get() + contextPath + "/");
     }
 
     /**


### PR DESCRIPTION
Now that Commons Lang 3 is a library plugin, the test harness shouldn't be using it, since a plugin could potentially declare a dependency on a different version that might conflict with the version provided by the test harness. Unfortunately, though, the test harness exposes a `ImmutablePair` type in its public API (via `JenkinsRule._createWebServer`), making it tough to implement this. But we should at least not make the problem worse by using Commons Lang 3 in a private field as we do in `JmhBenchmarkState`. Here we switch to a Java Platform type to lessen our dependency on this problematic library. This should be covered by `BenchmarkTest`.