### PR TITLE
Fix potential infinite loop in `InboundAgentRule`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -455,7 +455,7 @@ public final class InboundAgentRule extends ExternalResource {
             return options.getName();
         }
 
-        @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"}, justification = "just for test code")
+        @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "just for test code")
         private static Slave createAgent(JenkinsRule r, Options options) throws Descriptor.FormException, IOException, InterruptedException {
             if (options.getName() == null) {
                 options.setName("agent" + r.jenkins.getNodes().size());
@@ -469,6 +469,7 @@ public final class InboundAgentRule extends ExternalResource {
             Computer computer = s.toComputer();
             while (computer == null || computer.getOfflineCause() == null) {
                 Thread.sleep(100);
+                computer = s.toComputer();
             }
             return s;
         }

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1297,16 +1297,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             }
 
             WebResponseData webResponseData;
-            InputStream responseStream = conn.getInputStream();
-            try {
-                if (responseStream != null) {
-                    byte[] bytes = IOUtils.toByteArray(responseStream);
-                    webResponseData = new WebResponseData(bytes, conn.getResponseCode(), conn.getResponseMessage(), extractHeaders(conn));
-                } else {
-                    webResponseData = new WebResponseData(new byte[0], conn.getResponseCode(), conn.getResponseMessage(), extractHeaders(conn));
-                }
-            } finally {
-                IOUtils.closeQuietly(responseStream);
+            try (InputStream responseStream = conn.getInputStream()) {
+                byte[] bytes = IOUtils.toByteArray(responseStream);
+                webResponseData = new WebResponseData(bytes, conn.getResponseCode(), conn.getResponseMessage(), extractHeaders(conn));
             }
 
             WebResponse webResponse = new WebResponse(webResponseData, postUrl, HttpMethod.POST, (System.currentTimeMillis() - startTime));


### PR DESCRIPTION
waiting for the agent could be an infinite loop if the agent had not connected when we enter the retry (ie computer was null).

Also spotbugs was complaining about a redundant null check from `URLConnection.getInputStream()` as that will return a stream or throw an `UnknownServiceException` if input is not supported - but never null.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
