### PR TITLE
HTTPS for Update Center

### DIFF
--- a/docs/CHANGELOG-OLD.md
+++ b/docs/CHANGELOG-OLD.md
@@ -43,14 +43,14 @@
 
 * Updated HTMLUnit.
 * New convenience methods in `WebClient`.
-* [JENKINS-53823](https://issues.jenkins-ci.org/browse/JENKINS-53823) -
+* [JENKINS-53823](https://issues.jenkins.io/browse/JENKINS-53823) -
 JDK 11 compatibility.
 
 ### 2.41.1 (2018 Nov 13)
 
 This is a custom release without HTMLUnit upgrade
 
-* [JENKINS-53823](https://issues.jenkins-ci.org/browse/JENKINS-53823) -
+* [JENKINS-53823](https://issues.jenkins.io/browse/JENKINS-53823) -
 JDK 11 compatibility.
 
 ### 2.41 (2018 Sep 21)
@@ -59,7 +59,7 @@ JDK 11 compatibility.
 
 ### 2.40 (2018 Jul 20)
 
-* [JENKINS-49046](https://issues.jenkins-ci.org/browse/JENKINS-49046): Fix `@WithTimeout` handling for `JenkinsRule`.
+* [JENKINS-49046](https://issues.jenkins.io/browse/JENKINS-49046): Fix `@WithTimeout` handling for `JenkinsRule`.
 
 ### 2.39 (2018 Jun 05)
 
@@ -69,8 +69,8 @@ JDK 11 compatibility.
 
 ### 2.38 (2018 Apr 09)
 
-* [JENKINS-50598](https://issues.jenkins-ci.org/browse/JENKINS-50598): ability to run `JenkinsRule`-based tests with a custom WAR file.
-* [JENKINS-50590](https://issues.jenkins-ci.org/browse/JENKINS-50590): fix combination of crumbs with existing request parameters.
+* [JENKINS-50598](https://issues.jenkins.io/browse/JENKINS-50598): ability to run `JenkinsRule`-based tests with a custom WAR file.
+* [JENKINS-50590](https://issues.jenkins.io/browse/JENKINS-50590): fix combination of crumbs with existing request parameters.
 
 ### 2.37 (2018 Apr 06)
 

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -201,7 +201,7 @@ import org.xml.sax.SAXException;
 /**
  * Base class for all Jenkins test cases.
  *
- * @see <a href="http://wiki.jenkins-ci.org/display/JENKINS/Unit+Test">Wiki article about unit testing in Hudson</a>
+ * @see <a href="https://www.jenkins.io/doc/developer/testing/">Wiki article about unit testing in Jenkins</a>
  * @author Kohsuke Kawaguchi
  * @deprecated New code should use {@link JenkinsRule}.
  */
@@ -788,7 +788,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      * Loads a configuration page and submits it without any modifications, to
      * perform a round-trip configuration test.
      * <p>
-     * See http://wiki.jenkins-ci.org/display/JENKINS/Unit+Test#UnitTest-Configurationroundtriptesting
+     * See https://www.jenkins.io/doc/developer/testing/#configuration-round-trip-testing
      */
     protected <P extends Job> P configRoundtrip(P job) throws Exception {
         submit(createWebClient().getPage(job,"configure").getFormByName("config"));

--- a/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
+++ b/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
@@ -18,7 +18,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 /**
- * Acts as a reverse proxy, so that during a test we can avoid hitting updates.jenkins-ci.org.
+ * Acts as a reverse proxy, so that during a test we can avoid hitting updates.jenkins.io.
  *
  * <p>
  * The contents are cached locally.
@@ -62,7 +62,7 @@ public class JavaNetReverseProxy extends HttpServlet {
 
         File cache = new File(cacheFolder, d);
         if(!cache.exists()) {
-            URL url = new URL("http://updates.jenkins-ci.org/" + path);
+            URL url = new URL("https://updates.jenkins.io/" + path);
             FileUtils.copyURLToFile(url,cache);
         }
 
@@ -86,7 +86,7 @@ public class JavaNetReverseProxy extends HttpServlet {
     public static synchronized JavaNetReverseProxy getInstance() throws Exception {
         if(INSTANCE==null)
             // TODO: think of a better location --- ideally inside the target/ dir so that clean would wipe them out
-            INSTANCE = new JavaNetReverseProxy(new File(new File(System.getProperty("java.io.tmpdir")),"jenkins-ci.org-cache2"));
+            INSTANCE = new JavaNetReverseProxy(new File(new File(System.getProperty("java.io.tmpdir")),"jenkins.io-cache2"));
         return INSTANCE;
     }
 }


### PR DESCRIPTION
Fixes #518 by adapting to https://github.com/jenkinsci/jenkins/pull/2996 by replacing links to `jenkins-ci.org` with links to `jenkins.io` and using HTTPS rather than HTTP to access the Update Center. To test this I exercised the code path from a plugin build and verified in a debugger that the new URL was being used and that it was cached as expected. I also successfully ran `mvn clean verify -Dtest=hudson.cli.InstallPluginCommandTest,hudson.core.PluginManagerOverrideTest,hudson.CustomPluginManagerTest,hudson.model.DownloadService2Test,hudson.model.DownloadServiceTest,hudson.model.UpdateCenter2Test,hudson.model.UpdateCenterConnectionStatusTest,hudson.model.UpdateCenterCustomTest,hudson.model.UpdateCenterPluginInstallTest,hudson.model.UpdateCenterTest,hudson.model.UpdateSiteTest,hudson.PluginManagerCheckUpdateCenterTest,hudson.PluginManagerInstalledGUITest,hudson.PluginManagerSecurity2823Test,hudson.PluginManagerSecurity3037Test,hudson.PluginManagerTest,hudson.PluginManagerUtil,hudson.PluginManagerWhichTest,hudson.PluginTest,hudson.PluginWrapperTest,jenkins.install.InstallStateTest,jenkins.install.InstallUtilTest,jenkins.install.LoadDetachedPluginsTest,jenkins.install.SetupWizardRestartTest,jenkins.install.SetupWizardTest` in Jenkins core with these changes.