### PR TITLE
Fixups to #561

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/WarExploder.java
+++ b/src/main/java/org/jvnet/hudson/test/WarExploder.java
@@ -52,6 +52,8 @@ public final class WarExploder {
     @CheckForNull
     private static final String JENKINS_WAR_PATH = System.getProperty(JENKINS_WAR_PATH_PROPERTY_NAME);
 
+    private static final Pattern SHA1_HASH = Pattern.compile("^[a-f0-9]{40}$");
+
     public static synchronized File getExplodedDir() throws Exception {
         if (EXPLODE_DIR == null) {
             EXPLODE_DIR = explode();
@@ -82,7 +84,7 @@ public final class WarExploder {
                 File core = Which.jarFile(Jenkins.class); // will fail with IllegalArgumentException if have neither jenkins-war.war nor jenkins-core.jar in ${java.class.path}
                 String version;
                 File coreArtifactDir;
-                if (Pattern.matches("^[a-f0-9]{40}$", core.getParentFile().getName())) {
+                if (SHA1_HASH.matcher(core.getParentFile().getName()).matches()) {
                     // Gradle
                     version = core.getParentFile().getParentFile().getName();
                     coreArtifactDir = core.getParentFile().getParentFile().getParentFile();
@@ -98,9 +100,11 @@ public final class WarExploder {
                         File[] hashes = new File(warArtifactDir, version).listFiles();
                         if (hashes != null) {
                             for (File hash : hashes) {
-                                war = new File(hash, "jenkins-war-" + version + ".war");
-                                if (war.isFile()) {
-                                    break;
+                                if (SHA1_HASH.matcher(hash.getName()).matches()) {
+                                    war = new File(hash, "jenkins-war-" + version + ".war");
+                                    if (war.isFile()) {
+                                        break;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Minor fixups to #561; should improve the error message in some pathological cases. I repeated the testing from #561 and also tested that the error message was correct when heading down this bizarre code path without a primed `~/.m2` directory.