### PR TITLE
Enable fetch polyfill with web client

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -1396,7 +1396,9 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      * This is to assist Groovy test clients who are incapable of instantiating the inner classes properly.
      */
     public WebClient createWebClient() {
-        return new WebClient();
+        WebClient webClient = new WebClient();
+        webClient.getOptions().setFetchPolyfillEnabled(true);
+        return webClient;
     }
     
     /**

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2214,7 +2214,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * This is to assist Groovy test clients who are incapable of instantiating the inner classes properly.
      */
     public WebClient createWebClient() {
-        return new WebClient();
+        WebClient webClient = new WebClient();
+        webClient.getOptions().setFetchPolyfillEnabled(true);
+        return webClient;
     }
 
     /**


### PR DESCRIPTION
thanks to @basil for finding this out in https://github.com/jenkinsci/jenkins/pull/7727#discussion_r1155349075

Required for https://issues.jenkins.io/browse/JENKINS-70906

I've tested this by enabling the option in the failing test in the above pull request and it makes the test pass