### PR TITLE
`WarExploder` does not find the Jenkins WAR in the Gradle cache if its SHA-1 hash begins with a 0

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/WarExploder.java
+++ b/src/main/java/org/jvnet/hudson/test/WarExploder.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -98,10 +97,10 @@ public final class WarExploder {
                     coreArtifactDir = core.getParentFile().getParentFile();
                 }
                 if (core.getName().equals("jenkins-core-" + version + ".jar") && coreArtifactDir.getName().equals("jenkins-core")) {
-                    File versionedWarArtifactDir = Path.of(coreArtifactDir.getParentFile().getPath(), "jenkins-war", version).toFile();
-                    war = Path.of(versionedWarArtifactDir.getPath(), "jenkins-war-" + version + ".war").toFile();
+                    File warArtifactDir = new File(coreArtifactDir.getParentFile(), "jenkins-war");
+                    war = new File(new File(warArtifactDir, version), "jenkins-war-" + version + ".war");
                     if (!war.isFile()) {
-                        File[] hashes = versionedWarArtifactDir.listFiles();
+                        File[] hashes = new File(warArtifactDir, version).listFiles();
                         if (hashes != null) {
                             for (File hash : hashes) {
                                 if (HEX_DIGITS.matcher(hash.getName()).matches()) {


### PR DESCRIPTION
Hi!

This PR fixes an issue where the `WarExploder` is unable to find a copy of `jenkins-war` in the Gradle cache on disk if the checksum for the specified version begins with a zero. For some reason the fine folks working on Gradle decided to drop leading zeros from checksums. According to https://discuss.gradle.org/t/sha-1-checksum-portion-of-file-path-in-gradle-cache-is-missing-leading-zeros/1244/2 it could be to save characters in order to respect file path limitations. Either way, because the Gradle cache is an internal API, there's no guarantees in the way the test harness is trying to use it.

### Testing done

I compiled my changes and included them into a Jenkins JobDSL repo we have where I noticed the issue earlier today. With version `1954.v2e3fd5465b_a_6` I saw the following error when attempting to run tests:

```
java.lang.AssertionError: /Users/dgreene/.gradle/caches/modules-2/files-2.1/org.jenkins-ci.main/jenkins-war/2.332.3/jenkins-war-2.332.3.war does not yet exist. Prime your development environment by running `mvn validate`.
	at org.jvnet.hudson.test.WarExploder.findJenkinsWar(WarExploder.java:115)
	at org.jvnet.hudson.test.WarExploder.explode(WarExploder.java:146)
	at org.jvnet.hudson.test.WarExploder.getExplodedDir(WarExploder.java:62)
	at org.jvnet.hudson.test.JenkinsRule._createWebServer(JenkinsRule.java:797)
	at org.jvnet.hudson.test.JenkinsRule.createWebServer(JenkinsRule.java:752)
	at org.jvnet.hudson.test.JenkinsRule.createWebServer(JenkinsRule.java:741)
	at org.jvnet.hudson.test.JenkinsRule.newHudson(JenkinsRule.java:693)
	at org.jvnet.hudson.test.JenkinsRule.before(JenkinsRule.java:407)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:602)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:829) 
```

This is the contents of the directory on disk:
```
/Users/dgreene/.gradle/caches/modules-2/files-2.1/org.jenkins-ci.main/jenkins-war/2.332.3/
├── 68b1e10fdddae7cad6f2b59c8c205d285321940
│   └── jenkins-war-2.332.3.war
└── 94b5703d50ba22c43604ee89ea706535098d782d
    └── jenkins-war-2.332.3-sources.jar
```

I've included `jenkins-war` into the project by adding
```
implementation "org.jenkins-ci.main:jenkins-war:2.3332.3@war"
```
to my `build.gradle` file.

Using the snapshot build, the `jenkins-war` war file was correctly found on disk and was able to be exploded.

This _should_ be a no-op for Maven-based projects.

### Submitter checklist

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Fixes #574