### PR TITLE
Honor `Jenkins.rootUrl` when launching `InboundAgentRule`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -416,7 +416,7 @@ public final class InboundAgentRule extends ExternalResource {
             if (!agentJar.isFile()) {
                 FileUtils.copyURLToFile(new Slave.JnlpJar("agent.jar").getURL(), agentJar);
             }
-            return new AgentArguments(r.getURL() + "computer/" + name + "/slave-agent.jnlp", agentJar, c.getJnlpMac(), r.jenkins.getNodes().size(), commandLineArgs);
+            return new AgentArguments(r.jenkins.getRootUrl() + "computer/" + name + "/slave-agent.jnlp", agentJar, c.getJnlpMac(), r.jenkins.getNodes().size(), commandLineArgs);
         }
 
     }


### PR DESCRIPTION
Can matter for tests which define a specific root URL for a controller.