### PR TITLE
Remove deprecated `hamcrest-core` and `hamcrest-library` modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,16 +188,6 @@ THE SOFTWARE.
       <version>${hamcrest.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${hamcrest.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>


### PR DESCRIPTION
Both modules named are deprecated since 2019, in favor of `hamcrest` where the logic of both modules live on since then.
Consumers are advised to replace hamcrest-x with hamcrest, if not already done.