### PR TITLE
Replace hamcrest matchers with methods from non-deprecated packages

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsMatchers.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsMatchers.java
@@ -3,10 +3,10 @@ package org.jvnet.hudson.test;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import org.hamcrest.BaseMatcher;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 
 import java.lang.reflect.Constructor;
@@ -128,7 +128,7 @@ public class JenkinsMatchers {
      *         constructors).
      */
     public static Matcher<Class<?>> isUtilityClass() {
-        return CoreMatchers.allOf(isFinalClass(), isClassWithOnlyPrivateConstructors());
+        return Matchers.allOf(isFinalClass(), isClassWithOnlyPrivateConstructors());
     }
 
     /**
@@ -440,7 +440,7 @@ public class JenkinsMatchers {
      * @since 2.50
      */
     public static Matcher<Secret> hasPlainText(String expected) {
-        return new HasPlainText(CoreMatchers.equalTo(expected));
+        return new HasPlainText(Matchers.equalTo(expected));
     }
 
     private static class HasPlainText extends FeatureMatcher<Secret, String> {

--- a/src/main/java/org/jvnet/hudson/test/LoggerRule.java
+++ b/src/main/java/org/jvnet/hudson/test/LoggerRule.java
@@ -214,7 +214,7 @@ public class LoggerRule extends ExternalResource {
      * @param level The {@link Level} of the {@link LoggerRule} to match. Pass {@code null} to match any {@link Level}.
      * @param message the matcher to match against {@link LogRecord#getMessage}
      * @param thrown the matcher to match against {@link LogRecord#getThrown()}. Passing {@code null} is equivalent to
-     * passing {@link org.hamcrest.CoreMatchers#anything}
+     * passing {@link org.hamcrest.Matchers#anything}
      */
     public static Matcher<LoggerRule> recorded(@CheckForNull Level level, @NonNull Matcher<String> message, @CheckForNull Matcher<Throwable> thrown) {
         return new RecordedMatcher(level, message, thrown);
@@ -240,7 +240,7 @@ public class LoggerRule extends ExternalResource {
      *
      * @param message the matcher to match against {@link LogRecord#getMessage}
      * @param thrown the matcher to match against {@link LogRecord#getThrown()}. Passing {@code null} is equivalent to
-     * passing {@link org.hamcrest.CoreMatchers#anything}
+     * passing {@link org.hamcrest.Matchers#anything}
      */
     public static Matcher<LoggerRule> recorded(@NonNull Matcher<String> message, @CheckForNull Matcher<Throwable> thrown) {
         return recorded(null, message, thrown);

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -65,8 +66,6 @@ import javax.servlet.ServletResponse;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.io.IOUtils;
-import org.hamcrest.core.IsNull;
-import org.hamcrest.core.StringContains;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.recipes.LocalData;
@@ -275,7 +274,7 @@ public class RealJenkinsRuleTest {
         String s = RealJenkinsRule.checkResult(conn);
 
         verify(conn, times(1)).getInputStream();
-        assertThat(s, IsNull.nullValue());
+        assertThat(s, nullValue());
     }
 
     /**
@@ -292,7 +291,7 @@ public class RealJenkinsRuleTest {
     public void whenUsingFailurePlugin() throws Throwable {
         RealJenkinsRule.JenkinsStartupException jse = assertThrows(
                 RealJenkinsRule.JenkinsStartupException.class, () -> rrWithFailure.startJenkins());
-        assertThat(jse.getMessage(), StringContains.containsString("Error</h1><pre>java.io.IOException: oops"));
+        assertThat(jse.getMessage(), containsString("Error</h1><pre>java.io.IOException: oops"));
     }
 
     // TODO interesting scenarios to test:

--- a/src/test/java/org/jvnet/hudson/test/RestartableJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RestartableJenkinsRuleTest.java
@@ -11,7 +11,8 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import jenkins.model.Jenkins;
-import static org.hamcrest.CoreMatchers.nullValue;
+
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;


### PR DESCRIPTION
With https://github.com/jenkinsci/jenkins-test-harness/pull/587 in mind, we can make use of the methods from the `hamcrest` package, which is the drop-in replacement for the deprecated -core package.

The code from the deprecated package has been merged in, and the methods return the same, nonetheless I applied the `breaking` label because the method signature changes.
Testing with core in https://github.com/jenkinsci/jenkins/pull/8046 revealed no issues.