### PR TITLE
Support of jacoco agent in forked Jenkins instances

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -403,11 +403,6 @@ public final class RealJenkinsRule implements TestRule {
         List<String> agentOptions = arguments.stream()
                 .filter(argument -> argument.startsWith("-javaagent:") && argument.contains("jacoco"))
                 .collect(Collectors.toList());
-        try {
-            Class.forName("org.jacoco.agent.rt.IAgent");
-        } catch (ClassNotFoundException e) {
-            LOGGER.fine("Jacoco agent not loaded");
-        }
         return agentOptions;
     }
 

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -400,10 +400,9 @@ public final class RealJenkinsRule implements TestRule {
     public static List<String> getJacocoAgentOptions() {
         RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
         List<String> arguments = runtimeMxBean.getInputArguments();
-        List<String> agentOptions = arguments.stream()
+        return arguments.stream()
                 .filter(argument -> argument.startsWith("-javaagent:") && argument.contains("jacoco"))
                 .collect(Collectors.toList());
-        return agentOptions;
     }
 
     @Override public Statement apply(final Statement base, Description description) {


### PR DESCRIPTION
Fixes #366

This detects if the jacoco agent is part of the test jvm command line, and copies it to forked jvms.

Jacoco supports appending to the coverage file data, each jvm will report using a different session id.

Can be tested in a Jenkins plugin using RealJenkinsRule and passing `mvn verify -Penable-jacoco` to verify that covered classes include expected classes.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
