### PR TITLE
Dispose of Windows read-only temporary files

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
@@ -133,6 +133,11 @@ public class TemporaryDirectoryAllocator {
             }
         }
         try {
+            if (isWindows()) {
+                // Windows throws an access denied exception when deleting read-only files
+                boolean ok = p.toFile().setWritable(true);
+                LOGGER.fine(() -> "allow write to " + p + ", result: " + ok);
+            }
             Files.deleteIfExists(p);
         } catch (DirectoryNotEmptyException x) {
             try (Stream<Path> children = Files.list(p)) {
@@ -141,4 +146,7 @@ public class TemporaryDirectoryAllocator {
         }
     }
 
+    private boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
 }


### PR DESCRIPTION
## Dispose of Windows temporary read-only files

When the git plugin and the gitlab plugin upgraded to parent pom 4.64, their tests failed on Windows. The Java delete() method on Windows throws an access denied exception when asked to delete a read-only file.  Command line git creates read-only files in the objects directory when it clones a repository.

This test creates a read-only file and relies on the JenkinsRule cleanup process to remove the file.

### Testing done

[Draft pull request](https://github.com/jenkinsci/git-plugin/pull/1454) submitted to the git plugin confirming that clearing the "read-only" permission on Windows files allowed the 100+ failing tests to pass with parent pom 4.64.

Automated test written that confirms read-only files are deleted as expected on Unix and that read-only files are not deleted on Windows.

The [first commit](https://github.com/jenkinsci/jenkins-test-harness/pull/591/commits/9eee796708cc43f80d15a6b28aaf316cb84fc2ef) is a failing test.  [Second commit](https://github.com/jenkinsci/jenkins-test-harness/pull/591/commits/13e45e0632cdf41e5d862be32ffc1efce88da29e) is the code changes to pass the failing test.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
