### PR TITLE
Reduce usages of Guava

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -57,7 +57,6 @@ import com.gargoylesoftware.htmlunit.javascript.host.xml.XMLHttpRequest;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.gargoylesoftware.htmlunit.util.WebResponseWrapper;
 import com.gargoylesoftware.htmlunit.xml.XmlPage;
-import com.google.common.net.HttpHeaders;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.CloseProofOutputStream;
@@ -2700,7 +2699,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         public @NonNull WebClient withBasicCredentials(@NonNull String login, @NonNull String passwordOrToken) {
             String authCode = Base64.getEncoder().encodeToString((login + ":" + passwordOrToken).getBytes(StandardCharsets.UTF_8));
 
-            addRequestHeader(HttpHeaders.AUTHORIZATION, "Basic " + authCode);
+            addRequestHeader("Authorization", "Basic " + authCode);
             return this;
         }
 


### PR DESCRIPTION
The fewer third-party dependencies this test framework has, the easier it is to maintain.