### PR TITLE
Use `FutureImpl.get` from `waitForCompletion`

### DIFF
--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -5,6 +5,8 @@ import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 
 import hudson.EnvVars;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
 import hudson.model.RootAction;
 import hudson.model.User;
 import jenkins.model.Jenkins;
@@ -413,4 +415,13 @@ public class JenkinsRuleTest {
         j.createSlave("agent", "agent", new EnvVars());
         j.jenkins.save();
     }
+
+    @Test
+    public void waitForCompletion() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new SleepBuilder(1000));
+        FreeStyleBuild b = p.scheduleBuild2(0).getStartCondition().get();
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+    }
+
 }


### PR DESCRIPTION
Since https://github.com/jenkinsci/workflow-job-plugin/pull/357 I have noticed some flakes like

```
java.lang.AssertionError: expected:<SUCCESS> but was:<FAILURE>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.jenkinsci.plugins.workflow.job.CpsPersistenceTest.lambda$completedExecutionButRunIncomplete$23(CpsPersistenceTest.java:416)
```

The build log shows

```
[Pipeline] End of Pipeline
Finished: SUCCESS
```

yet the Jenkins log shows

```
WARNING	hudson.model.Run#onEndBuilding: testJob #1: No build result is set, so marking as failure. This should not happen.
```

I cannot reproduce this locally but I suspect the cause is that `isLogUpdated` is returning false before `WorkflowRun.finish` has completed, sometime before it calls `save()` or `onEndBuilding()`. The right way to listen for a build to complete is via its `Executor`.
