### PR TITLE
Organize imports

### DIFF
--- a/src/main/java/hudson/model/utils/AbortExceptionPublisher.java
+++ b/src/main/java/hudson/model/utils/AbortExceptionPublisher.java
@@ -10,7 +10,6 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
-
 import java.io.IOException;
 
 /**

--- a/src/main/java/hudson/model/utils/IOExceptionPublisher.java
+++ b/src/main/java/hudson/model/utils/IOExceptionPublisher.java
@@ -9,7 +9,6 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
-
 import java.io.IOException;
 
 /**

--- a/src/main/java/hudson/model/utils/ResultWriterPublisher.java
+++ b/src/main/java/hudson/model/utils/ResultWriterPublisher.java
@@ -10,7 +10,6 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
-
 import java.io.IOException;
 import java.nio.charset.Charset;
 

--- a/src/main/java/hudson/model/utils/TrueFalsePublisher.java
+++ b/src/main/java/hudson/model/utils/TrueFalsePublisher.java
@@ -9,9 +9,8 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import java.io.IOException;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * @author Kanstantsin Shautsou

--- a/src/main/java/hudson/security/pages/SignupPage.java
+++ b/src/main/java/hudson/security/pages/SignupPage.java
@@ -1,12 +1,12 @@
 package hudson.security.pages;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertNotNull;
+
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * The signup page for {@link hudson.security.HudsonPrivateSecurityRealm}

--- a/src/main/java/hudson/slaves/DummyCloudImpl.java
+++ b/src/main/java/hudson/slaves/DummyCloudImpl.java
@@ -25,16 +25,14 @@ package hudson.slaves;
 
 import hudson.model.Computer;
 import hudson.model.Descriptor;
-import hudson.model.Node;
 import hudson.model.Label;
+import hudson.model.Node;
 import hudson.slaves.NodeProvisioner.PlannedNode;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
-
 import org.jvnet.hudson.test.JenkinsRule;
 
 /**

--- a/src/main/java/jenkins/benchmark/jmh/BenchmarkFinder.java
+++ b/src/main/java/jenkins/benchmark/jmh/BenchmarkFinder.java
@@ -1,11 +1,10 @@
 package jenkins.benchmark.jmh;
 
 
-import org.jvnet.hudson.annotation_indexer.Index;
-import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
-
 import java.io.IOException;
 import java.lang.reflect.AnnotatedElement;
+import org.jvnet.hudson.annotation_indexer.Index;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 
 /**
  * Find classes annotated with {@link JmhBenchmark} to run their benchmark methods.

--- a/src/main/java/jenkins/benchmark/jmh/JmhBenchmark.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhBenchmark.java
@@ -1,11 +1,10 @@
 package jenkins.benchmark.jmh;
 
-import org.jvnet.hudson.annotation_indexer.Indexed;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jvnet.hudson.annotation_indexer.Indexed;
 
 /**
  * Annotate your benchmark classes with this annotation to allow them to be discovered by {@link BenchmarkFinder}

--- a/src/main/java/jenkins/model/WorkspaceWriter.java
+++ b/src/main/java/jenkins/model/WorkspaceWriter.java
@@ -24,11 +24,9 @@
 package jenkins.model;
 
 import hudson.Launcher;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
-
+import hudson.model.BuildListener;
 import java.io.IOException;
-
 import org.jvnet.hudson.test.TestBuilder;
 
 /**

--- a/src/main/java/org/htmlunit/WebClientUtil.java
+++ b/src/main/java/org/htmlunit/WebClientUtil.java
@@ -23,12 +23,11 @@
  */
 package org.htmlunit;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.javascript.JavaScriptErrorListener;
 import org.junit.Assert;
-
-import java.net.MalformedURLException;
-import java.net.URL;
 
 /**
  * {@link WebClient} helper methods.

--- a/src/main/java/org/htmlunit/html/DomNodeUtil.java
+++ b/src/main/java/org/htmlunit/html/DomNodeUtil.java
@@ -23,10 +23,10 @@
  */
 package org.htmlunit.html;
 
+import java.util.List;
+import org.htmlunit.WebClient;
 import org.htmlunit.WebClientUtil;
 import org.htmlunit.html.xpath.XPathHelper;
-
-import java.util.List;
 
 /**
  * {@link DomNode} helper methods.
@@ -38,7 +38,7 @@ public class DomNodeUtil {
     /**
      * Evaluates an XPath expression from the specified node, returning the resultant nodes.
      * <p>
-     * Calls {@link WebClientUtil#waitForJSExec(org.htmlunit.WebClient)} before
+     * Calls {@link WebClientUtil#waitForJSExec(WebClient)} before
      * executing the query.
      *
      * @param domNode the node to start searching from
@@ -54,7 +54,7 @@ public class DomNodeUtil {
      * Evaluates the specified XPath expression from this node, returning the first matching element,
      * or {@code null} if no node matches the specified XPath expression.
      * <p>
-     * Calls {@link WebClientUtil#waitForJSExec(org.htmlunit.WebClient)} before
+     * Calls {@link WebClientUtil#waitForJSExec(WebClient)} before
      * executing the query.
      *
      * @param domNode the node to start searching from

--- a/src/main/java/org/htmlunit/html/HtmlElementUtil.java
+++ b/src/main/java/org/htmlunit/html/HtmlElementUtil.java
@@ -23,12 +23,11 @@
  */
 package org.htmlunit.html;
 
+import java.io.IOException;
+import java.util.Set;
 import org.htmlunit.Page;
 import org.htmlunit.WebClient;
 import org.htmlunit.WebClientUtil;
-
-import java.io.IOException;
-import java.util.Set;
 
 /**
  * {@link HtmlElement} helper methods.

--- a/src/main/java/org/htmlunit/html/HtmlFormUtil.java
+++ b/src/main/java/org/htmlunit/html/HtmlFormUtil.java
@@ -23,13 +23,12 @@
  */
 package org.htmlunit.html;
 
+import java.io.IOException;
+import java.util.List;
 import org.htmlunit.ElementNotFoundException;
 import org.htmlunit.Page;
 import org.htmlunit.WebClient;
 import org.htmlunit.WebClientUtil;
-
-import java.io.IOException;
-import java.util.List;
 
 /**
  * {@link HtmlForm} helper functions.

--- a/src/main/java/org/jvnet/hudson/test/ChannelShutdownListener.java
+++ b/src/main/java/org/jvnet/hudson/test/ChannelShutdownListener.java
@@ -7,7 +7,6 @@ import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.ComputerListener;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/jvnet/hudson/test/ClosureExecuterAction.java
+++ b/src/main/java/org/jvnet/hudson/test/ClosureExecuterAction.java
@@ -25,14 +25,13 @@ package org.jvnet.hudson.test;
 
 import hudson.Extension;
 import hudson.model.RootAction;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerResponse;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * Server-side logic that implements {@link HudsonTestCase#executeOnServer(java.util.concurrent.Callable)}.

--- a/src/main/java/org/jvnet/hudson/test/ComputerConnectorTester.java
+++ b/src/main/java/org/jvnet/hudson/test/ComputerConnectorTester.java
@@ -28,11 +28,10 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.slaves.ComputerConnector;
 import hudson.slaves.ComputerConnectorDescriptor;
-import org.kohsuke.stapler.StaplerRequest;
-
-import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.List;
+import javax.servlet.ServletException;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Test bed to verify the configuration roundtripness of the {@link ComputerConnector}.

--- a/src/main/java/org/jvnet/hudson/test/ExtractChangeLogParser.java
+++ b/src/main/java/org/jvnet/hudson/test/ExtractChangeLogParser.java
@@ -28,10 +28,6 @@ import hudson.model.User;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.ChangeLogSet;
 import java.io.BufferedReader;
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
-import org.xml.sax.SAXException;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -40,6 +36,9 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+import org.xml.sax.SAXException;
 
 /**
  * @author Andrew Bayer

--- a/src/main/java/org/jvnet/hudson/test/ExtractChangeLogSet.java
+++ b/src/main/java/org/jvnet/hudson/test/ExtractChangeLogSet.java
@@ -25,10 +25,8 @@ package org.jvnet.hudson.test;
 
 import hudson.model.AbstractBuild;
 import hudson.scm.ChangeLogSet;
-
-import java.util.List;
 import java.util.Iterator;
-
+import java.util.List;
 
 /**
  * @author Andrew Bayer

--- a/src/main/java/org/jvnet/hudson/test/FakeChangeLogSCM.java
+++ b/src/main/java/org/jvnet/hudson/test/FakeChangeLogSCM.java
@@ -37,8 +37,6 @@ import hudson.scm.NullSCM;
 import hudson.scm.RepositoryBrowser;
 import hudson.scm.SCMDescriptor;
 import hudson.scm.SCMRevisionState;
-import org.xml.sax.SAXException;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -47,6 +45,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import org.xml.sax.SAXException;
 
 /**
  * Fake SCM implementation that can report arbitrary commits from arbitrary users.

--- a/src/main/java/org/jvnet/hudson/test/FakeLauncher.java
+++ b/src/main/java/org/jvnet/hudson/test/FakeLauncher.java
@@ -2,7 +2,6 @@ package org.jvnet.hudson.test;
 
 import hudson.Launcher.ProcStarter;
 import hudson.Proc;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/src/main/java/org/jvnet/hudson/test/GroovyHudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/GroovyHudsonTestCase.java
@@ -1,14 +1,13 @@
 package org.jvnet.hudson.test;
 
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 import groovy.lang.Closure;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.tasks.Builder;
-import hudson.Launcher;
-
 import java.io.IOException;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * {@link HudsonTestCase} with more convenience methods for Groovy.

--- a/src/main/java/org/jvnet/hudson/test/HudsonPageCreator.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonPageCreator.java
@@ -23,14 +23,13 @@
  */
 package org.jvnet.hudson.test;
 
-import org.htmlunit.DefaultPageCreator;
-import org.htmlunit.Page;
-import org.htmlunit.WebResponse;
-import org.htmlunit.WebWindow;
-import org.htmlunit.PageCreator;
-
 import java.io.IOException;
 import java.util.Locale;
+import org.htmlunit.DefaultPageCreator;
+import org.htmlunit.Page;
+import org.htmlunit.PageCreator;
+import org.htmlunit.WebResponse;
+import org.htmlunit.WebWindow;
 
 /**
  * {@link PageCreator} that understands JNLP file.

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -28,31 +28,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
-import org.htmlunit.AjaxController;
-import org.htmlunit.AlertHandler;
-import org.htmlunit.BrowserVersion;
-import org.htmlunit.DefaultCssErrorHandler;
-import org.htmlunit.FailingHttpStatusCodeException;
-import org.htmlunit.Page;
-import org.htmlunit.WebClientUtil;
-import org.htmlunit.WebRequest;
-import org.htmlunit.cssparser.parser.CSSErrorHandler;
-import org.htmlunit.cssparser.parser.CSSException;
-import org.htmlunit.cssparser.parser.CSSParseException;
-import org.htmlunit.html.DomNode;
-import org.htmlunit.html.DomNodeUtil;
-import org.htmlunit.html.HtmlButton;
-import org.htmlunit.html.HtmlElement;
-import org.htmlunit.html.HtmlForm;
-import org.htmlunit.html.HtmlFormUtil;
-import org.htmlunit.html.HtmlImage;
-import org.htmlunit.html.HtmlInput;
-import org.htmlunit.html.HtmlPage;
-import org.htmlunit.javascript.AbstractJavaScriptEngine;
-import org.htmlunit.javascript.HtmlUnitContextFactory;
-import org.htmlunit.javascript.JavaScriptEngine;
-import org.htmlunit.javascript.host.xml.XMLHttpRequest;
-import org.htmlunit.xml.XmlPage;
 import com.google.inject.Injector;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.CloseProofOutputStream;
@@ -156,8 +131,6 @@ import jenkins.model.JenkinsAdaptor;
 import jenkins.model.JenkinsLocationConfiguration;
 import junit.framework.TestCase;
 import net.sf.json.JSONObject;
-import org.htmlunit.corejs.javascript.Context;
-import org.htmlunit.corejs.javascript.ContextFactory;
 import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.BadCredentialsException;
 import org.acegisecurity.GrantedAuthority;
@@ -180,6 +153,34 @@ import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
 import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.htmlunit.AjaxController;
+import org.htmlunit.AlertHandler;
+import org.htmlunit.BrowserVersion;
+import org.htmlunit.DefaultCssErrorHandler;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.Page;
+import org.htmlunit.WebClientUtil;
+import org.htmlunit.WebRequest;
+import org.htmlunit.corejs.javascript.Context;
+import org.htmlunit.corejs.javascript.ContextFactory;
+import org.htmlunit.cssparser.parser.CSSErrorHandler;
+import org.htmlunit.cssparser.parser.CSSException;
+import org.htmlunit.cssparser.parser.CSSParseException;
+import org.htmlunit.html.DomNode;
+import org.htmlunit.html.DomNodeUtil;
+import org.htmlunit.html.HtmlButton;
+import org.htmlunit.html.HtmlElement;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlFormUtil;
+import org.htmlunit.html.HtmlImage;
+import org.htmlunit.html.HtmlInput;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.SubmittableElement;
+import org.htmlunit.javascript.AbstractJavaScriptEngine;
+import org.htmlunit.javascript.JavaScriptEngine;
+import org.htmlunit.javascript.host.xml.XMLHttpRequest;
+import org.htmlunit.util.NameValuePair;
+import org.htmlunit.xml.XmlPage;
 import org.jvnet.hudson.test.HudsonHomeLoader.CopyExisting;
 import org.jvnet.hudson.test.recipes.Recipe;
 import org.jvnet.hudson.test.recipes.Recipe.Runner;
@@ -1041,7 +1042,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     /**
      * Submits the form.
      *
-     * Plain {@link HtmlForm#submit(org.htmlunit.html.SubmittableElement)} doesn't work correctly due to the use of YUI in Hudson.
+     * Plain {@link HtmlForm#submit(SubmittableElement)} doesn't work correctly due to the use of YUI in Jenkins.
      */
     public HtmlPage submit(HtmlForm form) throws Exception {
         return (HtmlPage) HtmlFormUtil.submit(form, last(form.getElementsByTagName("button")));
@@ -1617,10 +1618,10 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         }
 
         /**
-         * Requests a page within Hudson.
+         * Requests a page within Jenkins.
          *
          * @param relative
-         *      Relative path within Hudson. Starts without '/'.
+         *      Relative path within Jenkins. Starts without '/'.
          *      For example, "job/test/" to go to a job top page.
          */
         public HtmlPage goTo(String relative) throws IOException, SAXException {
@@ -1684,10 +1685,10 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         }
         
         /**
-         * Adds a security crumb to the quest
+         * Adds a security crumb to the request.
          */
         public WebRequest addCrumb(WebRequest req) {
-            org.htmlunit.util.NameValuePair crumb = new org.htmlunit.util.NameValuePair(
+            NameValuePair crumb = new NameValuePair(
                     jenkins.getCrumbIssuer().getDescriptor().getCrumbRequestField(),
                     jenkins.getCrumbIssuer().getCrumb( null ));
             req.setRequestParameters(List.of(crumb));

--- a/src/main/java/org/jvnet/hudson/test/JellyTestSuiteBuilder.java
+++ b/src/main/java/org/jvnet/hudson/test/JellyTestSuiteBuilder.java
@@ -23,6 +23,15 @@
  */
 package org.jvnet.hudson.test;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import junit.framework.TestCase;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
@@ -33,16 +42,6 @@ import org.dom4j.io.SAXReader;
 import org.jvnet.hudson.test.junit.GroupedTest;
 import org.kohsuke.stapler.MetaClassLoader;
 import org.kohsuke.stapler.jelly.JellyClassLoaderTearOff;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 
 /**
  * Builds up a {@link TestSuite} for performing static syntax checks on Jelly scripts.

--- a/src/main/java/org/jvnet/hudson/test/JenkinsComputerConnectorTester.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsComputerConnectorTester.java
@@ -28,11 +28,10 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.slaves.ComputerConnector;
 import hudson.slaves.ComputerConnectorDescriptor;
-import org.kohsuke.stapler.StaplerRequest;
-
-import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.List;
+import javax.servlet.ServletException;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Test bed to verify the configuration roundtripness of the {@link ComputerConnector}.

--- a/src/main/java/org/jvnet/hudson/test/JenkinsMatchers.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsMatchers.java
@@ -2,17 +2,16 @@ package org.jvnet.hudson.test;
 
 import hudson.util.FormValidation;
 import hudson.util.Secret;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.regex.Pattern;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
-import java.util.regex.Pattern;
 
 /**
  * Some handy matchers.

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRecipe.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRecipe.java
@@ -1,16 +1,14 @@
 package org.jvnet.hudson.test;
 
-import java.lang.annotation.Documented;
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import java.lang.annotation.Retention;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import java.lang.annotation.Target;
-import java.lang.annotation.Annotation;
 import java.io.File;
-
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import junit.framework.TestCase;
 import org.jvnet.hudson.test.recipes.Recipe;
-
 
 /**
  * Meta-annotation for recipe annotations, which controls
@@ -21,9 +19,9 @@ import org.jvnet.hudson.test.recipes.Recipe;
  * @author Kohsuke Kawaguchi
  * @since 1.436
  */
-@Retention(RUNTIME)
+@Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Target(ANNOTATION_TYPE)
+@Target(ElementType.ANNOTATION_TYPE)
 public @interface JenkinsRecipe {
     /**
      * Specifies the class that sets up the test environment.

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -24,39 +24,17 @@
  */
 package org.jvnet.hudson.test;
 
-import org.htmlunit.AjaxController;
-import org.htmlunit.BrowserVersion;
-import org.htmlunit.DefaultCssErrorHandler;
-import org.htmlunit.ElementNotFoundException;
-import org.htmlunit.FailingHttpStatusCodeException;
-import org.htmlunit.HttpMethod;
-import org.htmlunit.Page;
-import org.htmlunit.WebClientOptions;
-import org.htmlunit.WebClientUtil;
-import org.htmlunit.WebRequest;
-import org.htmlunit.WebResponse;
-import org.htmlunit.WebResponseData;
-import org.htmlunit.WebResponseListener;
-import org.htmlunit.cssparser.parser.CSSErrorHandler;
-import org.htmlunit.cssparser.parser.CSSException;
-import org.htmlunit.cssparser.parser.CSSParseException;
-import org.htmlunit.html.DomNode;
-import org.htmlunit.html.DomNodeUtil;
-import org.htmlunit.html.HtmlButton;
-import org.htmlunit.html.HtmlElement;
-import org.htmlunit.html.HtmlElementUtil;
-import org.htmlunit.html.HtmlForm;
-import org.htmlunit.html.HtmlFormUtil;
-import org.htmlunit.html.HtmlImage;
-import org.htmlunit.html.HtmlInput;
-import org.htmlunit.html.HtmlPage;
-import org.htmlunit.javascript.AbstractJavaScriptEngine;
-import org.htmlunit.javascript.HtmlUnitContextFactory;
-import org.htmlunit.javascript.JavaScriptEngine;
-import org.htmlunit.javascript.host.xml.XMLHttpRequest;
-import org.htmlunit.util.NameValuePair;
-import org.htmlunit.util.WebResponseWrapper;
-import org.htmlunit.xml.XmlPage;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.CloseProofOutputStream;
@@ -189,11 +167,8 @@ import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.security.ApiTokenProperty;
 import jenkins.security.MasterToSlaveCallable;
-
 import net.sf.json.JSON;
 import net.sf.json.JSONObject;
-import org.htmlunit.corejs.javascript.Context;
-import org.htmlunit.corejs.javascript.ContextFactory;
 import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.BadCredentialsException;
 import org.acegisecurity.GrantedAuthority;
@@ -220,16 +195,41 @@ import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
 import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.htmlunit.AjaxController;
+import org.htmlunit.BrowserVersion;
+import org.htmlunit.DefaultCssErrorHandler;
+import org.htmlunit.ElementNotFoundException;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.HttpMethod;
+import org.htmlunit.Page;
+import org.htmlunit.WebClientOptions;
+import org.htmlunit.WebClientUtil;
+import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
+import org.htmlunit.WebResponseData;
+import org.htmlunit.WebResponseListener;
+import org.htmlunit.corejs.javascript.Context;
+import org.htmlunit.corejs.javascript.ContextFactory;
+import org.htmlunit.cssparser.parser.CSSErrorHandler;
+import org.htmlunit.cssparser.parser.CSSException;
+import org.htmlunit.cssparser.parser.CSSParseException;
+import org.htmlunit.html.DomNode;
+import org.htmlunit.html.DomNodeUtil;
+import org.htmlunit.html.HtmlButton;
+import org.htmlunit.html.HtmlElement;
+import org.htmlunit.html.HtmlElementUtil;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlFormUtil;
+import org.htmlunit.html.HtmlImage;
+import org.htmlunit.html.HtmlInput;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.SubmittableElement;
+import org.htmlunit.javascript.AbstractJavaScriptEngine;
+import org.htmlunit.javascript.JavaScriptEngine;
+import org.htmlunit.javascript.host.xml.XMLHttpRequest;
+import org.htmlunit.util.NameValuePair;
+import org.htmlunit.util.WebResponseWrapper;
+import org.htmlunit.xml.XmlPage;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.MethodRule;
@@ -1691,7 +1691,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     /**
      * Submits the form.
      *
-     * Plain {@link HtmlForm#submit(org.htmlunit.html.SubmittableElement)} doesn't work correctly due to the use of YUI in Hudson.
+     * Plain {@link HtmlForm#submit(SubmittableElement)} doesn't work correctly due to the use of YUI in Jenkins.
      */
     public HtmlPage submit(HtmlForm form) throws Exception {
         return (HtmlPage) HtmlFormUtil.submit(form);
@@ -2425,7 +2425,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
          * Short-hand method to ease discovery of feature + improve readability
          * 
          * @param enabled {@code true} to enable automatic redirection
-         * @see org.htmlunit.WebClientOptions#setRedirectEnabled(boolean)
+         * @see WebClientOptions#setRedirectEnabled(boolean)
          * @since 2.42
          */
         public void setRedirectEnabled(boolean enabled) {
@@ -2438,7 +2438,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
          *
          * @param enabled {@code true} to enable automatic redirection
          * @return self for fluent method chaining
-         * @see org.htmlunit.WebClientOptions#setRedirectEnabled(boolean)
+         * @see WebClientOptions#setRedirectEnabled(boolean)
          * @since 2.42
          */
         public WebClient withRedirectEnabled(boolean enabled) {

--- a/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
+++ b/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
@@ -24,6 +24,10 @@
 
 package org.jvnet.hudson.test;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
@@ -38,11 +42,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import javax.swing.BoundedRangeModel;
-
 import jenkins.model.Jenkins;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
-
 import org.netbeans.insane.impl.LiveEngine;
 import org.netbeans.insane.live.LiveReferences;
 import org.netbeans.insane.live.Path;

--- a/src/main/java/org/jvnet/hudson/test/NoListenerConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/test/NoListenerConfiguration.java
@@ -25,10 +25,9 @@ package org.jvnet.hudson.test;
 
 import hudson.WebAppMain;
 import java.util.EventListener;
+import javax.servlet.ServletContextListener;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.webapp.WebAppContext;
-
-import javax.servlet.ServletContextListener;
 
 /**
  * Kills off the {@link WebAppMain} {@link ServletContextListener}.

--- a/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
+++ b/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
@@ -41,15 +41,13 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.apache.commons.io.IOUtils;
 
-import static org.jvnet.hudson.test.JellyTestSuiteBuilder.scan;
-
 /**
  * Checks things about {@code *.properties}.
  */
 public class PropertiesTestSuite extends TestSuite {
 
     public PropertiesTestSuite(File resources) throws IOException {
-        for (Map.Entry<URL,String> entry : scan(resources, "properties").entrySet()) {
+        for (Map.Entry<URL,String> entry : JellyTestSuiteBuilder.scan(resources, "properties").entrySet()) {
             addTest(new PropertiesTest(entry.getKey(), entry.getValue()));
         }
     }

--- a/src/main/java/org/jvnet/hudson/test/SingleFileSCM.java
+++ b/src/main/java/org/jvnet/hudson/test/SingleFileSCM.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-
 import org.apache.commons.io.IOUtils;
 
 /**

--- a/src/main/java/org/jvnet/hudson/test/SleepBuilder.java
+++ b/src/main/java/org/jvnet/hudson/test/SleepBuilder.java
@@ -23,15 +23,14 @@
  */
 package org.jvnet.hudson.test;
 
-import hudson.Launcher;
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.tasks.Builder;
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import java.io.IOException;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * {@link Builder} that just sleeps for the specified amount of milli-seconds.

--- a/src/main/java/org/jvnet/hudson/test/TestBuilder.java
+++ b/src/main/java/org/jvnet/hudson/test/TestBuilder.java
@@ -23,14 +23,13 @@
  */
 package org.jvnet.hudson.test;
 
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Descriptor;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
-import hudson.model.Descriptor;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.Launcher;
-
 import java.io.IOException;
 
 /**

--- a/src/main/java/org/jvnet/hudson/test/TestExtension.java
+++ b/src/main/java/org/jvnet/hudson/test/TestExtension.java
@@ -24,14 +24,12 @@
 package org.jvnet.hudson.test;
 
 import hudson.Extension;
-import net.java.sezpoz.Indexable;
-
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import net.java.sezpoz.Indexable;
 
 /**
  * Works like {@link Extension} except used for inserting extensions during unit tests.
@@ -44,8 +42,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see TestExtensionLoader
  */
 @Indexable
-@Retention(RUNTIME)
-@Target({TYPE, FIELD, METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
 @Documented
 public @interface TestExtension {
     /**

--- a/src/main/java/org/jvnet/hudson/test/TestExtensionLoader.java
+++ b/src/main/java/org/jvnet/hudson/test/TestExtensionLoader.java
@@ -26,7 +26,6 @@ package org.jvnet.hudson.test;
 import hudson.Extension;
 import hudson.ExtensionFinder.GuiceExtensionAnnotation;
 import java.lang.annotation.AnnotationTypeMismatchException;
-
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -34,7 +33,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.junit.runner.Description;
 
 /**

--- a/src/main/java/org/jvnet/hudson/test/TestNotifier.java
+++ b/src/main/java/org/jvnet/hudson/test/TestNotifier.java
@@ -23,11 +23,11 @@
  */
 package org.jvnet.hudson.test;
 
+import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
-import hudson.model.AbstractProject;
 
 /**
  * Partial {@link Notifier} implementation to facilitate notifier implementation for testing.

--- a/src/main/java/org/jvnet/hudson/test/TestPluginManager.java
+++ b/src/main/java/org/jvnet/hudson/test/TestPluginManager.java
@@ -1,11 +1,10 @@
 package org.jvnet.hudson.test;
 
-import java.io.IOException;
-
 import hudson.Plugin;
 import hudson.PluginManager;
 import hudson.PluginWrapper;
 import hudson.Util;
+import java.io.IOException;
 
 /** 
  * {@link PluginManager} to speed up unit tests.

--- a/src/main/java/org/jvnet/hudson/test/TouchBuilder.java
+++ b/src/main/java/org/jvnet/hudson/test/TouchBuilder.java
@@ -28,7 +28,6 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.tasks.Builder;
-
 import java.io.IOException;
 import java.io.Serializable;
 

--- a/src/main/java/org/jvnet/hudson/test/UnitTestSupportingPluginManager.java
+++ b/src/main/java/org/jvnet/hudson/test/UnitTestSupportingPluginManager.java
@@ -27,7 +27,6 @@ package org.jvnet.hudson.test;
 import hudson.LocalPluginManager;
 import hudson.Plugin;
 import hudson.PluginManager;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -43,7 +42,6 @@ import java.util.Set;
 import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 

--- a/src/main/java/org/jvnet/hudson/test/WithoutJenkins.java
+++ b/src/main/java/org/jvnet/hudson/test/WithoutJenkins.java
@@ -1,22 +1,20 @@
 package org.jvnet.hudson.test;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.jvnet.hudson.test.recipes.Recipe;
 import org.jvnet.hudson.test.recipes.WithPlugin;
-
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * An annotation for test methods that do not require the {@link JenkinsRule}/{@link HudsonTestCase} to create and tear down the jenkins
  * instance.
  */
-@Retention(RUNTIME)
+@Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Target(METHOD)
+@Target(ElementType.METHOD)
 @Recipe(WithoutJenkins.RunnerImpl.class)
 public @interface WithoutJenkins {
     class RunnerImpl extends Recipe.Runner<WithPlugin> {

--- a/src/main/java/org/jvnet/hudson/test/junit/GroupedTest.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/GroupedTest.java
@@ -23,8 +23,8 @@
  */
 package org.jvnet.hudson.test.junit;
 
-import junit.framework.TestSuite;
 import junit.framework.TestResult;
+import junit.framework.TestSuite;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.Filterable;
 import org.junit.runner.manipulation.NoTestsRemainException;

--- a/src/main/java/org/jvnet/hudson/test/recipes/LocalData.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/LocalData.java
@@ -23,18 +23,17 @@
  */
 package org.jvnet.hudson.test.recipes;
 
-import org.junit.runner.Description;
-import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.HudsonHomeLoader.Local;
-import org.jvnet.hudson.test.JenkinsRecipe;
-import org.jvnet.hudson.test.TailLog;
-
 import java.lang.annotation.Documented;
-import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static java.lang.annotation.ElementType.METHOD;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.runner.Description;
+import org.jvnet.hudson.test.HudsonHomeLoader.Local;
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRecipe;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TailLog;
 
 /**
  * Runs a test case with a data set local to test method or the test class.
@@ -82,8 +81,8 @@ import static java.lang.annotation.ElementType.METHOD;
 @Documented
 @Recipe(LocalData.RunnerImpl.class)
 @JenkinsRecipe(LocalData.RuleRunnerImpl.class)
-@Target(METHOD)
-@Retention(RUNTIME)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface LocalData {
     String value() default "";
 

--- a/src/main/java/org/jvnet/hudson/test/recipes/PresetData.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/PresetData.java
@@ -23,16 +23,15 @@
  */
 package org.jvnet.hudson.test.recipes;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Locale;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.JenkinsRecipe;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.lang.annotation.Documented;
-import static java.lang.annotation.ElementType.METHOD;
-import java.lang.annotation.Retention;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import java.lang.annotation.Target;
-import java.util.Locale;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
 /**
@@ -45,8 +44,8 @@ import org.jvnet.hudson.test.MockAuthorizationStrategy;
 @Documented
 @Recipe(PresetData.RunnerImpl.class)
 @JenkinsRecipe(PresetData.RuleRunnerImpl.class)
-@Target(METHOD)
-@Retention(RUNTIME)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
 @Deprecated
 public @interface PresetData {
     /**

--- a/src/main/java/org/jvnet/hudson/test/recipes/Recipe.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/Recipe.java
@@ -23,17 +23,15 @@
  */
 package org.jvnet.hudson.test.recipes;
 
-import org.jvnet.hudson.test.HudsonTestCase;
-
-import java.lang.annotation.Documented;
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import java.lang.annotation.Retention;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import java.lang.annotation.Target;
-import java.lang.annotation.Annotation;
 import java.io.File;
-
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import junit.framework.TestCase;
+import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.JenkinsRecipe;
 
 /**
@@ -44,9 +42,9 @@ import org.jvnet.hudson.test.JenkinsRecipe;
  * 
  * @author Kohsuke Kawaguchi
  */
-@Retention(RUNTIME)
+@Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Target(ANNOTATION_TYPE)
+@Target(ElementType.ANNOTATION_TYPE)
 public @interface Recipe {
     /**
      * Specifies the class that sets up the test environment.

--- a/src/main/java/org/jvnet/hudson/test/recipes/WithPlugin.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/WithPlugin.java
@@ -23,19 +23,17 @@
  */
 package org.jvnet.hudson.test.recipes;
 
+import java.io.File;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.net.URL;
+import org.apache.commons.io.FileUtils;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.JenkinsRecipe;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.apache.commons.io.FileUtils;
-
-
-import java.io.File;
-import java.lang.annotation.Documented;
-import static java.lang.annotation.ElementType.METHOD;
-import java.lang.annotation.Retention;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import java.lang.annotation.Target;
-import java.net.URL;
 
 /**
  * Installs the specified plugins before launching Jenkins.
@@ -45,8 +43,8 @@ import java.net.URL;
 @Documented
 @Recipe(WithPlugin.RunnerImpl.class)
 @JenkinsRecipe(WithPlugin.RuleRunnerImpl.class)
-@Target(METHOD)
-@Retention(RUNTIME)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface WithPlugin {
     /**
      * Filenames of the plugins to install.

--- a/src/main/java/org/jvnet/hudson/test/recipes/WithPluginManager.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/WithPluginManager.java
@@ -26,9 +26,9 @@ package org.jvnet.hudson.test.recipes;
 import hudson.PluginManager;
 import java.io.File;
 import java.lang.annotation.Documented;
-import static java.lang.annotation.ElementType.METHOD;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Constructor;
 import org.jvnet.hudson.test.HudsonTestCase;
@@ -43,8 +43,8 @@ import org.jvnet.hudson.test.JenkinsRule;
 @Documented
 @Recipe(WithPluginManager.RunnerImpl.class)
 @JenkinsRecipe(WithPluginManager.RuleRunnerImpl.class)
-@Target(METHOD)
-@Retention(RUNTIME)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface WithPluginManager {
     Class<? extends PluginManager> value();
 

--- a/src/main/java/org/jvnet/hudson/test/recipes/WithTimeout.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/WithTimeout.java
@@ -23,14 +23,13 @@
  */
 package org.jvnet.hudson.test.recipes;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.lang.annotation.Documented;
-import static java.lang.annotation.ElementType.METHOD;
-import java.lang.annotation.Retention;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import java.lang.annotation.Target;
 
 /**
  * Times out the test after the specified number of seconds.
@@ -44,8 +43,8 @@ import java.lang.annotation.Target;
 @Recipe(WithTimeout.RunnerImpl.class)
 // No need for @JenkinsRecipe in JUnit 4 as it's implemented directly in JenkinsRule 
 // by the private method: getTestTimeoutOverride.
-@Target(METHOD)
-@Retention(RUNTIME)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface WithTimeout {
     /**
      * Number of seconds.

--- a/src/main/java/org/jvnet/hudson/test/rhino/CallStackFrame.java
+++ b/src/main/java/org/jvnet/hudson/test/rhino/CallStackFrame.java
@@ -23,13 +23,12 @@
  */
 package org.jvnet.hudson.test.rhino;
 
+import java.util.SortedMap;
+import java.util.TreeMap;
 import org.htmlunit.corejs.javascript.Context;
 import org.htmlunit.corejs.javascript.Scriptable;
 import org.htmlunit.corejs.javascript.debug.DebugFrame;
 import org.htmlunit.corejs.javascript.debug.DebuggableScript;
-
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Stack frame.

--- a/src/main/java/org/jvnet/hudson/test/rhino/JavaScriptDebugger.java
+++ b/src/main/java/org/jvnet/hudson/test/rhino/JavaScriptDebugger.java
@@ -23,14 +23,13 @@
  */
 package org.jvnet.hudson.test.rhino;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.htmlunit.corejs.javascript.Context;
 import org.htmlunit.corejs.javascript.debug.DebugFrame;
 import org.htmlunit.corejs.javascript.debug.DebuggableScript;
 import org.htmlunit.corejs.javascript.debug.Debugger;
 import org.jvnet.hudson.test.HudsonTestCase;
-
-import java.util.List;
-import java.util.ArrayList;
 
 /**
  * Monitors the execution of the JavaScript inside HtmlUnit, and provides debug information

--- a/src/test/java/jenkins/benchmark/jmh/BenchmarkTest.java
+++ b/src/test/java/jenkins/benchmark/jmh/BenchmarkTest.java
@@ -1,15 +1,14 @@
 package jenkins.benchmark.jmh;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Runs sample benchmarks from JUnit tests.

--- a/src/test/java/jenkins/benchmark/jmh/samples/JmhStateBenchmark.java
+++ b/src/test/java/jenkins/benchmark/jmh/samples/JmhStateBenchmark.java
@@ -1,10 +1,9 @@
 package jenkins.benchmark.jmh.samples;
 
+import java.util.Objects;
 import jenkins.benchmark.jmh.JmhBenchmark;
 import jenkins.benchmark.jmh.JmhBenchmarkState;
 import org.openjdk.jmh.annotations.Benchmark;
-
-import java.util.Objects;
 
 /**
  * Sample benchmark without doing anything special to the Jenkins instance.

--- a/src/test/java/org/jvnet/hudson/main/AppTest.java
+++ b/src/test/java/org/jvnet/hudson/main/AppTest.java
@@ -25,14 +25,13 @@ package org.jvnet.hudson.main;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import hudson.tasks.Shell;
 import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Experimenting with Hudson test suite.

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout2Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout2Test.java
@@ -25,13 +25,12 @@
 package org.jvnet.hudson.main;
 
 import org.junit.Test;
-import static org.jvnet.hudson.main.JenkinsRuleTimeoutTestBase.hangUninterruptibly;
 
 public class JenkinsRuleTimeout2Test extends JenkinsRuleTimeoutTestBase {
 
     @Test
     public void hangUninterruptiblyInTest() {
-        hangUninterruptibly();
+        JenkinsRuleTimeoutTestBase.hangUninterruptibly();
     }
 
 }

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout3Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout3Test.java
@@ -26,7 +26,6 @@ package org.jvnet.hudson.main;
 
 import hudson.model.listeners.ItemListener;
 import org.junit.Test;
-import static org.jvnet.hudson.main.JenkinsRuleTimeoutTestBase.hangInterruptibly;
 import org.jvnet.hudson.test.TestExtension;
 
 public class JenkinsRuleTimeout3Test extends JenkinsRuleTimeoutTestBase {
@@ -41,7 +40,7 @@ public class JenkinsRuleTimeout3Test extends JenkinsRuleTimeoutTestBase {
         @Override
         public void onBeforeShutdown() {
             try {
-                hangInterruptibly();
+                JenkinsRuleTimeoutTestBase.hangInterruptibly();
             } catch (InterruptedException x) {
                 System.err.println("Interrupted, good.");
             }

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout4Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout4Test.java
@@ -26,7 +26,6 @@ package org.jvnet.hudson.main;
 
 import hudson.model.listeners.ItemListener;
 import org.junit.Test;
-import static org.jvnet.hudson.main.JenkinsRuleTimeoutTestBase.hangUninterruptibly;
 import org.jvnet.hudson.test.TestExtension;
 
 public class JenkinsRuleTimeout4Test extends JenkinsRuleTimeoutTestBase {
@@ -40,7 +39,7 @@ public class JenkinsRuleTimeout4Test extends JenkinsRuleTimeoutTestBase {
     public static class HangsUninterruptibly extends ItemListener {
         @Override
         public void onBeforeShutdown() {
-            hangUninterruptibly();
+            JenkinsRuleTimeoutTestBase.hangUninterruptibly();
         }
     }
 

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout5Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout5Test.java
@@ -26,7 +26,6 @@ package org.jvnet.hudson.main;
 
 import hudson.model.listeners.ItemListener;
 import org.junit.Test;
-import static org.jvnet.hudson.main.JenkinsRuleTimeoutTestBase.hangInterruptibly;
 import org.jvnet.hudson.test.TestExtension;
 
 public class JenkinsRuleTimeout5Test extends JenkinsRuleTimeoutTestBase {
@@ -41,7 +40,7 @@ public class JenkinsRuleTimeout5Test extends JenkinsRuleTimeoutTestBase {
         @Override
         public void onLoaded() {
             try {
-                hangInterruptibly();
+                JenkinsRuleTimeoutTestBase.hangInterruptibly();
             } catch (InterruptedException x) {
                 System.err.println("Interrupted, good.");
             }

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout6Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout6Test.java
@@ -26,7 +26,6 @@ package org.jvnet.hudson.main;
 
 import hudson.model.listeners.ItemListener;
 import org.junit.Test;
-import static org.jvnet.hudson.main.JenkinsRuleTimeoutTestBase.hangUninterruptibly;
 import org.jvnet.hudson.test.TestExtension;
 
 public class JenkinsRuleTimeout6Test extends JenkinsRuleTimeoutTestBase {
@@ -40,7 +39,7 @@ public class JenkinsRuleTimeout6Test extends JenkinsRuleTimeoutTestBase {
     public static class HangsUninterruptibly extends ItemListener {
         @Override
         public void onLoaded() {
-            hangUninterruptibly();
+            JenkinsRuleTimeoutTestBase.hangUninterruptibly();
         }
     }
 

--- a/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout7Test.java
+++ b/src/test/java/org/jvnet/hudson/main/JenkinsRuleTimeout7Test.java
@@ -25,6 +25,7 @@
 package org.jvnet.hudson.main;
 
 import static org.junit.Assert.fail;
+
 import org.junit.Test;
 import org.jvnet.hudson.test.recipes.WithTimeout;
 

--- a/src/test/java/org/jvnet/hudson/main/UseRecipesWithJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/main/UseRecipesWithJenkinsRuleTest.java
@@ -1,17 +1,18 @@
 package org.jvnet.hudson.main;
 
-import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import hudson.LocalPluginManager;
 
+import hudson.LocalPluginManager;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-
+import javax.servlet.http.HttpServletResponse;
+import jenkins.model.JenkinsLocationConfiguration;
+import org.htmlunit.html.HtmlPage;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -22,9 +23,6 @@ import org.jvnet.hudson.test.recipes.PresetData.DataSet;
 import org.jvnet.hudson.test.recipes.WithPlugin;
 import org.jvnet.hudson.test.recipes.WithPluginManager;
 import org.xml.sax.SAXException;
-
-import org.htmlunit.html.HtmlPage;
-import jenkins.model.JenkinsLocationConfiguration;
 
 public class UseRecipesWithJenkinsRuleTest {
 
@@ -53,7 +51,7 @@ public class UseRecipesWithJenkinsRuleTest {
     @PresetData(DataSet.ANONYMOUS_READONLY)
     public void testPresetData() throws Exception {
         WebClient wc = rule.createWebClient();
-        wc.assertFails("loginError", SC_UNAUTHORIZED);
+        wc.assertFails("loginError", HttpServletResponse.SC_UNAUTHORIZED);
         // but not once the user logs in.
         verifyNotError(wc.login("alice"));
     }

--- a/src/test/java/org/jvnet/hudson/test/ExtractResourceWithChangesSCMTest.java
+++ b/src/test/java/org/jvnet/hudson/test/ExtractResourceWithChangesSCMTest.java
@@ -24,10 +24,11 @@
 
 package org.jvnet.hudson.test;
 
+import static org.junit.Assert.assertEquals;
+
 import hudson.model.FreeStyleProject;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/src/test/java/org/jvnet/hudson/test/FlagRuleNoReplacementTest.java
+++ b/src/test/java/org/jvnet/hudson/test/FlagRuleNoReplacementTest.java
@@ -24,11 +24,12 @@
 
 package org.jvnet.hudson.test;
 
+import static org.junit.Assert.assertFalse;
+
 import org.junit.AfterClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestRule;
 
 public class FlagRuleNoReplacementTest {

--- a/src/test/java/org/jvnet/hudson/test/FlagRuleReplacementTest.java
+++ b/src/test/java/org/jvnet/hudson/test/FlagRuleReplacementTest.java
@@ -24,11 +24,13 @@
 
 package org.jvnet.hudson.test;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.AfterClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestRule;
 
 public class FlagRuleReplacementTest {

--- a/src/test/java/org/jvnet/hudson/test/FlagRuleSystemPropertyTest.java
+++ b/src/test/java/org/jvnet/hudson/test/FlagRuleSystemPropertyTest.java
@@ -24,11 +24,13 @@
 
 package org.jvnet.hudson.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.junit.AfterClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestRule;
 
 public class FlagRuleSystemPropertyTest {

--- a/src/test/java/org/jvnet/hudson/test/InboundAgentRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/InboundAgentRuleTest.java
@@ -25,6 +25,7 @@
 package org.jvnet.hudson.test;
 
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/src/test/java/org/jvnet/hudson/test/JenkinsMatchersTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsMatchersTest.java
@@ -1,16 +1,15 @@
 package org.jvnet.hudson.test;
 
-import hudson.util.Secret;
-import org.junit.Test;
-
-import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
-
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jvnet.hudson.test.JenkinsMatchers.hasPlainText;
 import static org.jvnet.hudson.test.JenkinsMatchers.matchesPattern;
+
+import hudson.util.Secret;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.Test;
 
 public class JenkinsMatchersTest {
 

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -1,17 +1,30 @@
 package org.jvnet.hudson.test;
 
-import org.htmlunit.FailingHttpStatusCodeException;
-import org.htmlunit.Page;
-import org.htmlunit.WebRequest;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.EnvVars;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.RootAction;
 import hudson.model.User;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import jenkins.model.Jenkins;
 import jenkins.security.ApiTokenProperty;
 import net.sf.json.JSONObject;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.Page;
+import org.htmlunit.WebRequest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -24,22 +37,6 @@ import org.kohsuke.stapler.json.JsonHttpResponse;
 import org.kohsuke.stapler.verb.GET;
 import org.kohsuke.stapler.verb.POST;
 import org.kohsuke.stapler.verb.PUT;
-
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class JenkinsRuleTest {
 

--- a/src/test/java/org/jvnet/hudson/test/LoggerRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/LoggerRuleTest.java
@@ -23,22 +23,20 @@
  */
 package org.jvnet.hudson.test;
 
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.junit.Test;
-import org.junit.Rule;
-
-import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
-import static org.jvnet.hudson.test.LoggerRule.recorded;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class LoggerRuleTest {
 
@@ -52,11 +50,11 @@ public class LoggerRuleTest {
     public void testRecordedSingleLogger() {
         logRule.record("Foo", Level.INFO).capture(1);
         FOO_LOGGER.log(Level.INFO, "Entry 1");
-        assertThat(logRule, recorded(Level.INFO, equalTo("Entry 1")));
-        assertThat(logRule, not(recorded(Level.WARNING, equalTo("Entry 1"))));
+        assertThat(logRule, LoggerRule.recorded(Level.INFO, equalTo("Entry 1")));
+        assertThat(logRule, not(LoggerRule.recorded(Level.WARNING, equalTo("Entry 1"))));
         FOO_LOGGER.log(Level.INFO, "Entry 2");
-        assertThat(logRule, not(recorded(equalTo("Entry 1"))));
-        assertThat(logRule, recorded(equalTo("Entry 2")));
+        assertThat(logRule, not(LoggerRule.recorded(equalTo("Entry 1"))));
+        assertThat(logRule, LoggerRule.recorded(equalTo("Entry 2")));
     }
 
     @Test
@@ -64,7 +62,7 @@ public class LoggerRuleTest {
         logRule.record("Foo", Level.INFO).capture(2);
         FOO_LOGGER.log(Level.INFO, "Entry 1");
         FOO_LOGGER.log(Level.INFO, "Entry 3");
-        AssertionError assertionError = assertThrows(AssertionError.class, () -> assertThat(logRule, recorded(Level.INFO, equalTo("Entry 2"))));
+        AssertionError assertionError = assertThrows(AssertionError.class, () -> assertThat(logRule, LoggerRule.recorded(Level.INFO, equalTo("Entry 2"))));
 
         assertThat(assertionError.getMessage(), containsString("Expected: has LogRecord with level \"INFO\" with a message matching \"Entry 2\""));
         assertThat(assertionError.getMessage(), containsString("     but: was <INFO->Entry 3,INFO->Entry 1>"));
@@ -75,19 +73,19 @@ public class LoggerRuleTest {
         logRule.record("Foo", Level.INFO).record("Bar", Level.SEVERE).capture(2);
         FOO_LOGGER.log(Level.INFO, "Foo Entry 1");
         BAR_LOGGER.log(Level.SEVERE, "Bar Entry 1");
-        assertThat(logRule, recorded(equalTo("Foo Entry 1")));
-        assertThat(logRule, recorded(equalTo("Bar Entry 1")));
+        assertThat(logRule, LoggerRule.recorded(equalTo("Foo Entry 1")));
+        assertThat(logRule, LoggerRule.recorded(equalTo("Bar Entry 1")));
         // All criteria must match a single LogRecord.
-        assertThat(logRule, not(recorded(Level.INFO, equalTo("Bar Entry 1"))));
+        assertThat(logRule, not(LoggerRule.recorded(Level.INFO, equalTo("Bar Entry 1"))));
     }
 
     @Test
     public void testRecordedThrowable() {
         logRule.record("Foo", Level.INFO).capture(1);
         FOO_LOGGER.log(Level.INFO, "Foo Entry 1", new IllegalStateException());
-        assertThat(logRule, recorded(equalTo("Foo Entry 1"), instanceOf(IllegalStateException.class)));
-        assertThat(logRule, recorded(Level.INFO, equalTo("Foo Entry 1"), instanceOf(IllegalStateException.class)));
-        assertThat(logRule, not(recorded(Level.INFO, equalTo("Foo Entry 1"), instanceOf(IOException.class))));
+        assertThat(logRule, LoggerRule.recorded(equalTo("Foo Entry 1"), instanceOf(IllegalStateException.class)));
+        assertThat(logRule, LoggerRule.recorded(Level.INFO, equalTo("Foo Entry 1"), instanceOf(IllegalStateException.class)));
+        assertThat(logRule, not(LoggerRule.recorded(Level.INFO, equalTo("Foo Entry 1"), instanceOf(IOException.class))));
     }
 
     @Test
@@ -95,8 +93,8 @@ public class LoggerRuleTest {
         logRule.record("Foo", Level.INFO).capture(2);
         FOO_LOGGER.log(Level.INFO, "Foo Entry", new IllegalStateException());
         FOO_LOGGER.log(Level.INFO, "Foo Entry", new IOException());
-        assertThat(logRule, recorded(Level.INFO, equalTo("Foo Entry"), instanceOf(IllegalStateException.class)));
-        assertThat(logRule, recorded(Level.INFO, equalTo("Foo Entry"), instanceOf(IOException.class)));
+        assertThat(logRule, LoggerRule.recorded(Level.INFO, equalTo("Foo Entry"), instanceOf(IllegalStateException.class)));
+        assertThat(logRule, LoggerRule.recorded(Level.INFO, equalTo("Foo Entry"), instanceOf(IOException.class)));
     }
 
     @Test

--- a/src/test/java/org/jvnet/hudson/test/MemoryAssertTest.java
+++ b/src/test/java/org/jvnet/hudson/test/MemoryAssertTest.java
@@ -24,14 +24,16 @@
 
 package org.jvnet.hudson.test;
 
-import java.lang.ref.WeakReference;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
-import static org.jvnet.hudson.test.MemoryAssert.*;
+import static org.jvnet.hudson.test.MemoryAssert.assertGC;
+import static org.jvnet.hudson.test.MemoryAssert.assertHeapUsage;
+
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/test/java/org/jvnet/hudson/test/MockAuthorizationStrategyTest.java
+++ b/src/test/java/org/jvnet/hudson/test/MockAuthorizationStrategyTest.java
@@ -24,15 +24,17 @@
 
 package org.jvnet.hudson.test;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import jenkins.model.Jenkins;
-import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.Rule;
+import org.junit.Test;
 
 public class MockAuthorizationStrategyTest {
 

--- a/src/test/java/org/jvnet/hudson/test/MockFolderTest.java
+++ b/src/test/java/org/jvnet/hudson/test/MockFolderTest.java
@@ -24,11 +24,13 @@
 
 package org.jvnet.hudson.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Items;
 import hudson.model.listeners.ItemListener;
-import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/src/test/java/org/jvnet/hudson/test/PrefixedOutputStreamTest.java
+++ b/src/test/java/org/jvnet/hudson/test/PrefixedOutputStreamTest.java
@@ -24,11 +24,12 @@
 
 package org.jvnet.hudson.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -50,7 +50,6 @@ import hudson.model.listeners.ItemListener;
 import hudson.util.PluginServletFilter;
 import java.io.File;
 import java.io.IOException;
-import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/org/jvnet/hudson/test/RestartableJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RestartableJenkinsRuleTest.java
@@ -1,5 +1,12 @@
 package org.jvnet.hudson.test;
 
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeThat;
+
 import hudson.PluginManager;
 import hudson.PluginWrapper;
 import java.io.File;
@@ -11,13 +18,6 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import jenkins.model.Jenkins;
-
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeThat;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.recipes.WithPluginManager;

--- a/src/test/java/org/jvnet/hudson/test/TestExtensionTest.java
+++ b/src/test/java/org/jvnet/hudson/test/TestExtensionTest.java
@@ -23,16 +23,14 @@
  */
 package org.jvnet.hudson.test;
 
-import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import hudson.model.listeners.ItemListener;
 import java.util.List;
-
+import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
-
-import hudson.model.listeners.ItemListener;
 
 /**
  * Tests for {@link TestExtension}
@@ -54,7 +52,7 @@ public class TestExtensionTest {
     }
 
     private List<Class<? extends ItemListener>> getExtensionClasses() {
-        return j.jenkins.getExtensionList(ItemListener.class).stream().map(ItemListener::getClass).collect(toList());
+        return j.jenkins.getExtensionList(ItemListener.class).stream().map(ItemListener::getClass).collect(Collectors.toList());
     }
 
     @Test

--- a/src/test/java/org/jvnet/hudson/test/recipes/LocalDataTest.java
+++ b/src/test/java/org/jvnet/hudson/test/recipes/LocalDataTest.java
@@ -23,9 +23,11 @@
  */
 package org.jvnet.hudson.test.recipes;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.main.UseRecipesWithJenkinsRuleTest;
 import org.jvnet.hudson.test.JenkinsRule;
 

--- a/src/test/java/org/jvnet/hudson/test/recipes/LocalDataZipTest.java
+++ b/src/test/java/org/jvnet/hudson/test/recipes/LocalDataZipTest.java
@@ -23,9 +23,10 @@
  */
 package org.jvnet.hudson.test.recipes;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /**


### PR DESCRIPTION
The imports in this repository have gotten quite messy and out-of-order, so I took a pass to clean them up:

- Sort imports following configuration used in Jenkins core and project-wide Spotless configuration
- Remove unused imports
- Remove star imports as in Jenkins core
- Import some classes that were previously referred to by fully qualified class name
- Turn some unnecessary static imports into non-static imports to improve readability

To test this I successfully ran `mvn clean verify` locally and also built the Javadocs.