### PR TITLE
Fix JmhBenchmarkState for plugins that depend on bouncycastle-api and make JmhBenchmarkState stop cleanly

### DIFF
--- a/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
@@ -16,6 +16,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.eclipse.jetty.server.Server;
+import org.jvnet.hudson.test.JavaNetReverseProxy;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
 import org.jvnet.hudson.test.TestPluginManager;
@@ -77,6 +78,11 @@ public abstract class JmhBenchmarkState implements RootAction {
             LOGGER.log(Level.SEVERE, "Exception occurred during tearDown of Jenkins instance", e);
         } finally {
             JenkinsRule._stopJenkins(server, null, jenkins);
+            try {
+                JavaNetReverseProxy.getInstance().stop();
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Unable to stop JavaNetReverseProxy server", e);
+            }
             try {
                 temporaryDirectoryAllocator.dispose();
             } catch (InterruptedException | IOException e) {

--- a/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.eclipse.jetty.server.Server;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
+import org.jvnet.hudson.test.TestPluginManager;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -92,7 +93,7 @@ public abstract class JmhBenchmarkState implements RootAction {
         server = results.left;
         ServletContext webServer = results.right;
 
-        jenkins = new Hudson(temporaryDirectoryAllocator.allocate(), webServer);
+        jenkins = new Hudson(temporaryDirectoryAllocator.allocate(), webServer, TestPluginManager.INSTANCE);
         JenkinsRule._configureJenkinsForTest(jenkins);
         JenkinsRule._configureUpdateCenter(jenkins);
         jenkins.getActions().add(this);


### PR DESCRIPTION
This PR makes `JmhBenchmarkState` use `TestPluginManager` when launching Jenkins instances. 
<details>
<summary>
Without that changes, you get warnings like this related to <code>bouncycastle-api</code> when running benchmarks, and if you have plugins that actually depend on <code>bouncycastle-api</code> then those plugins fail to start</summary>

```
Jun 05, 2023 3:08:50 PM hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1 error
WARNING: Failed to instantiate Key[type=org.jenkinsci.main.modules.instance_identity.PageDecoratorImpl, annotation=[none]]; skipping this component
com.google.inject.ProvisionException: Unable to provision, see the following errors:

1) [Guice/ErrorInjectingConstructor]: ExceptionInInitializerError
  at PageDecoratorImpl.<init>(PageDecoratorImpl.java:21)

Learn more:
  https://github.com/google/guice/wiki/ERROR_INJECTING_CONSTRUCTOR

1 error

======================
Full classname legend:
======================
PageDecoratorImpl:           "org.jenkinsci.main.modules.instance_identity.PageDecoratorImpl"
========================
End of classname legend:
========================

    at com.google.inject.internal.InternalProvisionException.toProvisionException(InternalProvisionException.java:251)
    at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:43)
    at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169)
    at hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1.get(ExtensionFinder.java:444)
    at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45)
    at com.google.inject.internal.InjectorImpl$1.get(InjectorImpl.java:1100)
    at hudson.ExtensionFinder$GuiceFinder._find(ExtensionFinder.java:402)
    at hudson.ExtensionFinder$GuiceFinder.find(ExtensionFinder.java:393)
    at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:359)
    at hudson.ExtensionList.load(ExtensionList.java:384)
    at hudson.ExtensionList.ensureLoaded(ExtensionList.java:320)
    at hudson.ExtensionList.iterator(ExtensionList.java:172)
    at jenkins.model.Jenkins.getDescriptorByType(Jenkins.java:1642)
    at hudson.plugins.git.GitSCM.onLoaded(GitSCM.java:2159)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:109)
    at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:185)
    at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
    at jenkins.model.Jenkins$5.runTask(Jenkins.java:1161)
    at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:222)
    at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:121)
    at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:70)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ExceptionInInitializerError
    at org.jenkinsci.main.modules.instance_identity.pem.PEMHelper.encodePEM(PEMHelper.java:72)
    at org.jenkinsci.main.modules.instance_identity.InstanceIdentity.write(InstanceIdentity.java:97)
    at org.jenkinsci.main.modules.instance_identity.InstanceIdentity.<init>(InstanceIdentity.java:67)
    at org.jenkinsci.main.modules.instance_identity.InstanceIdentity.<init>(InstanceIdentity.java:41)
    at org.jenkinsci.main.modules.instance_identity.PageDecoratorImpl.<init>(PageDecoratorImpl.java:22)
    at org.jenkinsci.main.modules.instance_identity.PageDecoratorImpl$$FastClassByGuice$$353477042.GUICE$TRAMPOLINE(<generated>)
    at org.jenkinsci.main.modules.instance_identity.PageDecoratorImpl$$FastClassByGuice$$353477042.apply(<generated>)
    at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:82)
    at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:114)
    at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:33)
    at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:98)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:109)
    at hudson.ExtensionFinder$GuiceFinder$SezpozModule.onProvision(ExtensionFinder.java:568)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:117)
    at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:66)
    at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:93)
    at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296)
    at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
    ... 26 more
Caused by: java.lang.IllegalStateException: Couldn't locate either of bouncy castle FIPS or non fips provider, available providers areSUN,SunRsaSign,SunEC,SunJSSE,SunJCE,SunJGSS,SunSASL,XMLDSig,SunPCSC,JdkLDAP,JdkSASL,Apple,SunPKCS11.
    at jenkins.bouncycastle.api.PEMEncodable.<clinit>(PEMEncodable.java:96)
    ... 44 more
```
</details>

Additionally, right now all tests that use `JmhBenchmarkState` end up waiting for around 20-30 seconds unnecessarily after the benchmark completes because JMH checks for clean shutdown before exiting, and before this PR, we never shut down `JavaNetReverseProxy` when running Benchmarks, so there are non-Daemon threads running and the benchmark JVM does not shutdown. For the record here is the associated warning, which also comes with a thread dump:

```
<JMH had finished, but forked VM did not exit, are there stray running threads? Waiting 24 seconds more...>
```

I am not sure about the best way to fix the latter issue; see my inline comments.

I am also not sure if there is a simple way to test either issue. The latter issue can be seen by running the already existing `BenchmarkTest` / `JmhStateBenchmark` benchmarks in this repo, but the behavior is not easily testable, and I don't see an easy way to test the first issue in this repo alone. (I only noticed it while working on a proprietary plugin.)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
