### PR TITLE
Remove usages of `org.apache.commons.io.IOUtils`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
+++ b/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy.java
@@ -1,10 +1,10 @@
 package org.jvnet.hudson.test;
 
 import hudson.Util;
-import hudson.util.IOUtils;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -67,7 +67,7 @@ public class JavaNetReverseProxy extends HttpServlet {
         }
 
         resp.setContentType(getMimeType(path));
-        IOUtils.copy(cache,resp.getOutputStream());
+        Files.copy(cache.toPath(), resp.getOutputStream());
     }
 
     private String getMimeType(String path) {

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -177,7 +177,6 @@ import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.MimeTypes;
@@ -1302,7 +1301,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
             WebResponseData webResponseData;
             try (InputStream responseStream = conn.getInputStream()) {
-                byte[] bytes = IOUtils.toByteArray(responseStream);
+                byte[] bytes = responseStream.readAllBytes();
                 webResponseData = new WebResponseData(bytes, conn.getResponseCode(), conn.getResponseMessage(), extractHeaders(conn));
             }
 

--- a/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
+++ b/src/main/java/org/jvnet/hudson/test/PropertiesTestSuite.java
@@ -39,7 +39,6 @@ import java.util.Properties;
 import java.util.PropertyResourceBundle;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import org.apache.commons.io.IOUtils;
 
 /**
  * Checks things about {@code *.properties}.
@@ -74,12 +73,14 @@ public class PropertiesTestSuite extends TestSuite {
                 }
             };
 
-            byte[] contents = IOUtils.toByteArray(resource);
-            if (!isEncoded(contents, StandardCharsets.US_ASCII)) {
-                boolean isUtf8 = isEncoded(contents, StandardCharsets.UTF_8);
-                boolean isIso88591 = isEncoded(contents, StandardCharsets.ISO_8859_1);
-                if (!isUtf8 && !isIso88591) {
-                    throw new AssertionError(resource + " must be either valid UTF-8 or valid ISO-8859-1.");
+            try (InputStream is = resource.openStream()) {
+                byte[] contents = is.readAllBytes();
+                if (!isEncoded(contents, StandardCharsets.US_ASCII)) {
+                    boolean isUtf8 = isEncoded(contents, StandardCharsets.UTF_8);
+                    boolean isIso88591 = isEncoded(contents, StandardCharsets.ISO_8859_1);
+                    if (!isUtf8 && !isIso88591) {
+                        throw new AssertionError(resource + " must be either valid UTF-8 or valid ISO-8859-1.");
+                    }
                 }
             }
 

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -89,7 +89,6 @@ import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.util.Timer;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.junit.Assume;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
@@ -717,7 +716,7 @@ public final class RealJenkinsRule implements TestRule {
             String err = "?";
             try (InputStream is = conn.getErrorStream()) {
                 if (is != null) {
-                    err = IOUtils.toString(is, StandardCharsets.UTF_8);
+                    err = new String(is.readAllBytes(), StandardCharsets.UTF_8);
                 }
             } catch (Exception x) {
                 x.printStackTrace();
@@ -803,13 +802,13 @@ public final class RealJenkinsRule implements TestRule {
             }
             return (T) result.result;
         } catch (IOException e) {
-            if (conn.getErrorStream() != null) {
-                try {
-                    String errorMessage = IOUtils.toString(conn.getErrorStream(), StandardCharsets.UTF_8);
+            try (InputStream is = conn.getErrorStream()) {
+                if (is != null) {
+                    String errorMessage = new String(is.readAllBytes(), StandardCharsets.UTF_8);
                     e.addSuppressed(new IOException("Response body: " + errorMessage));
-                } catch (IOException e2) {
-                    e.addSuppressed(e2);
                 }
+            } catch (IOException e2) {
+                e.addSuppressed(e2);
             }
             throw e;
         }

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -48,6 +48,7 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.listeners.ItemListener;
 import hudson.util.PluginServletFilter;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -64,7 +65,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
-import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.recipes.LocalData;
@@ -256,7 +256,7 @@ public class RealJenkinsRuleTest {
     public void test503Errors() throws IOException {
         HttpURLConnection conn = mock(HttpURLConnection.class);
         when(conn.getResponseCode()).thenReturn(503);
-        when(conn.getErrorStream()).thenReturn(IOUtils.toInputStream("Jenkins Custom Error", "UTF-8"));
+        when(conn.getErrorStream()).thenReturn(new ByteArrayInputStream("Jenkins Custom Error".getBytes(StandardCharsets.UTF_8)));
 
         String s = RealJenkinsRule.checkResult(conn);
 
@@ -268,7 +268,7 @@ public class RealJenkinsRuleTest {
 
         HttpURLConnection conn = mock(HttpURLConnection.class);
         when(conn.getResponseCode()).thenReturn(200);
-        when(conn.getInputStream()).thenReturn(IOUtils.toInputStream("blah blah blah", "UTF-8"));
+        when(conn.getInputStream()).thenReturn(new ByteArrayInputStream("blah blah blah".getBytes(StandardCharsets.UTF_8)));
 
         String s = RealJenkinsRule.checkResult(conn);
 


### PR DESCRIPTION
Now that we require Java 11 or newer, we do not need to use this Apache Commons I/O library. The fewer third-party libraries we consume, the easier it is to maintain this component.

### Testing done

Ran the `jenkins-test-harness` tests, the `text-finder-plugin` tests, and these core tests: `mvn clean verify -Dtest=hudson.model.DirectoryBrowserSupportTest,hudson.console.ConsoleAnnotatorTest,jenkins.util.SystemPropertiesTest,jenkins.CoreAutomaticTestBuilder`.