### PR TITLE
Use correct key for `Request.maxFormContentSize`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -147,6 +147,7 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.security.Password;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.Configuration;
@@ -1753,7 +1754,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         });
 
         // remove the upper bound of the POST data size in Jetty.
-        System.setProperty("org.mortbay.jetty.Request.maxFormContentSize","-1");
+        System.setProperty(ContextHandler.MAX_FORM_CONTENT_SIZE_KEY, "-1");
     }
 
     private static final Logger LOGGER = Logger.getLogger(HudsonTestCase.class.getName());

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -187,6 +187,7 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.security.Password;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.Configuration;
@@ -2862,7 +2863,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         });
 
         // remove the upper bound of the POST data size in Jetty.
-        System.setProperty("org.mortbay.jetty.Request.maxFormContentSize","-1");
+        System.setProperty(ContextHandler.MAX_FORM_CONTENT_SIZE_KEY, "-1");
     }
 
     private static final Logger LOGGER = Logger.getLogger(HudsonTestCase.class.getName());


### PR DESCRIPTION
Recent versions of Jetty, which we have been using since 2016 or so, use `org.eclipse.jetty.server.Request.maxFormContentSize` rather than `org.mortbay.jetty.Request.maxFormContentSize` to set the maximum form content size. While I was here I also updated this to use a constant rather than a hard-coded string to make this code easier to maintain going forward. I tested this in Jenkins core and BOM and it did not make anything worse. While I am not fully convinced this setting is still needed, I am also not fully convinced that this setting is not needed either. Making the code work as intended (rather than as it was working previously) seems to be at least a mildly positive step in the right direction in the sense of improving readability. If someone can clearly demonstrate with certainty that this code is not needed then it could be removed entirely in the future.