### PR TITLE
Revert jenkinsci/jenkins@84d49ceef2

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2828,8 +2828,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     // needs to keep reference, or it gets GC-ed.
     private static final Logger XML_HTTP_REQUEST_LOGGER = Logger.getLogger(XMLHttpRequest.class.getName());
     private static final Logger SPRING_LOGGER = Logger.getLogger("org.springframework");
-    private static final Logger HTMLUNIT_DOCUMENT_LOGGER = Logger.getLogger("org.htmlunit.javascript.host.Document");
-    private static final Logger HTMLUNIT_JS_LOGGER = Logger.getLogger("org.htmlunit.javascript.StrictErrorReporter");
 
     static {
         // screen scraping relies on locale being fixed.
@@ -2861,17 +2859,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             @Override
             public boolean isLoggable(LogRecord record) {
                 return !record.getMessage().contains("XMLHttpRequest.getResponseHeader() was called before the response was available.");
-            }
-        });
-        // JENKINS-14749: prototype.js intentionally swallows this exception (thrown on Firefox which we simulate), but HtmlUnit still tries to log it.
-        HTMLUNIT_DOCUMENT_LOGGER.setFilter(new Filter() {
-            @Override public boolean isLoggable(LogRecord record) {
-                return !record.getMessage().equals("Unexpected exception occurred while parsing HTML snippet");
-            }
-        });
-        HTMLUNIT_JS_LOGGER.setFilter(new Filter() {
-            @Override public boolean isLoggable(LogRecord record) {
-                return !record.getMessage().contains("Unexpected exception occurred while parsing HTML snippet: input name=\"x\"");
             }
         });
 


### PR DESCRIPTION
`com.gargoylesoftware.htmlunit.javascript.host.Document` was renamed to `com.gargoylesoftware.htmlunit.javascript.host.dom.Document` in HtmlUnit 2.16 in 2015, and `StrictErrorHandler` was removed in HtmlUnit 2.35.0 in 2019, meaning these lines have been dead code for the better part of the past 8 years. Also, the original reason they were added was to work around problems with Prototype which we are now removing, so there is no motivation to rewrite this functionality to work with modern versions of HtmlUnit.