### PR TITLE
Improve Javadoc for `createWebClient`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -1392,7 +1392,8 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     }
 
     /**
-     * This is to assist Groovy test clients who are incapable of instantiating the inner classes properly.
+     * Create a web client instance using the browser version returned by {@link BrowserVersion#getDefault()}
+     * with support for the Fetch API.
      */
     public WebClient createWebClient() {
         WebClient webClient = new WebClient();
@@ -1408,8 +1409,6 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         private static final long serialVersionUID = 8720028298174337333L;
 
         public WebClient() {
-            super(BrowserVersion.BEST_SUPPORTED);
-
             setPageCreator(HudsonPageCreator.INSTANCE);
             clients.add(this);
             // make ajax calls run as post-action for predictable behaviors that simplify debugging

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2225,7 +2225,8 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     /**
-     * This is to assist Groovy test clients who are incapable of instantiating the inner classes properly.
+     * Create a web client instance using the browser version returned by {@link BrowserVersion#getDefault()}
+     * with support for the Fetch API.
      */
     public WebClient createWebClient() {
         WebClient webClient = new WebClient();
@@ -2243,8 +2244,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         private List<WebResponseListener> webResponseListeners = new ArrayList<>();
 
         public WebClient() {
-            super(BrowserVersion.BEST_SUPPORTED);
-
 //            setJavaScriptEnabled(false);
             setPageCreator(HudsonPageCreator.INSTANCE);
             clients.add(this);


### PR DESCRIPTION
The comment had become out of date with regard to the method's primary purpose. Also the `super(BrowserVersion.BEST_SUPPORTED)` call was redundant, as the default no-argument constructor was already using `BrowserVersion.BEST_SUPPORTED`.