### PR TITLE
Synchronize `CSSErrorHandler#ignore` in `HudsonTestCase` with the primary version in `JenkinsRule`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -1443,10 +1443,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
                 }
 
                 private boolean ignore(final CSSParseException exception) {
-                    String uri = exception.getURI();
-                    return uri.contains("/yui/")
-                            // TODO JENKINS-14749: these are a mess today, and we know that
-                            || uri.contains("/css/style.css") || uri.contains("/css/responsive-grid.css");
+                    return exception.getURI().contains("/yui/");
                 }
             });
 


### PR DESCRIPTION
This PR does not attempt to solve JENKINS-14749 (which I think was solved but regressed at some point), but it does synchronize the code in `HudsonTestCase` with that in `JenkinsRule` by favoring the version in `JenkinsRule` and applying that to `HudsonTestCase`. Once synchronized in this PR, the two versions should be kept in sync going forward.

### Testing done

Will rely on the CI build.

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
