### PR TITLE
Improve the case where the Jenkins process stopped unexpectedly

### DIFF
--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -95,6 +95,16 @@ public class RealJenkinsRuleTest {
         assertThat(assertThrows(RealJenkinsRule.StepException.class, () -> rr.then(RealJenkinsRuleTest::throwsException)).getMessage(),
             containsString("IllegalStateException: something is wrong"));
     }
+
+    @Test public void killedExternally() throws Throwable {
+        rr.startJenkins();
+        try {
+            rr.proc.destroy();
+        } finally {
+            assertThrows("nonzero exit code: 143", AssertionError.class, () -> rr.stopJenkins());
+        }
+    }
+
     private static void throwsException(JenkinsRule r) throws Throwable {
         throw new IllegalStateException("something is wrong");
     }


### PR DESCRIPTION
It was printing a stacktrace with Connection refused (Connection refused)

This now prints the exit code.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
