### PR TITLE
Remove usages of Commons Lang 3

### DIFF
--- a/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
@@ -14,8 +14,8 @@ import java.util.logging.Logger;
 import javax.servlet.ServletContext;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.jvnet.hudson.test.JavaNetReverseProxy;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
@@ -93,11 +93,15 @@ public abstract class JmhBenchmarkState implements RootAction {
     }
 
     private void launchInstance() throws Exception {
-        ImmutablePair<Server, ServletContext> results = JenkinsRule._createWebServer(contextPath, localPort::set,
-                getClass().getClassLoader(), localPort.get(), JenkinsRule::_configureUserRealm);
+        server = JenkinsRule._createWebServer(
+                contextPath,
+                localPort::set,
+                getClass().getClassLoader(),
+                localPort.get(),
+                JenkinsRule::_configureUserRealm);
 
-        server = results.left;
-        ServletContext webServer = results.right;
+        ServletContext webServer =
+                server.getChildHandlerByClass(ContextHandler.class).getServletContext();
 
         jenkins = new Hudson(temporaryDirectoryAllocator.allocate(), webServer, TestPluginManager.INSTANCE);
         JenkinsRule._configureJenkinsForTest(jenkins);


### PR DESCRIPTION
As a prerequisite to #550, remove usages of Commons Lang 3 from this repository. Although Commons Lang 3 was part of a public API, in practice no consumers existed other than a class in a different package in this repository itself (thankfully). In any case, the use of a tuple in the return type was unnecessary — the `Server` object has a reference to the `ServletContext` which can be fished out by any consumers that need it.

### Testing done

Ran Text Finder plugin tests with this PR.

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
