### PR TITLE
`InboundAgentRule.Options.Builder.withLogger`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -31,6 +31,7 @@ import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Node;
 import hudson.model.Slave;
+import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.RetentionStrategy;
@@ -471,7 +472,9 @@ public final class InboundAgentRule extends ExternalResource {
             }
             r.waitOnline((Slave) node);
             if (!loggers.isEmpty()) {
-                node.getChannel().call(new JenkinsRule.RemoteLogDumper(null, loggers, false));
+                VirtualChannel channel = node.getChannel();
+                assert channel != null;
+                channel.call(new JenkinsRule.RemoteLogDumper(null, loggers, false));
             }
         }
     }


### PR DESCRIPTION
`JenkinsRule.showAgentLogs` is fine for a single Jenkins session, but since the log text is streamed back to the controller, it is not well suited for cross-session tests (like https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/323).