### PR TITLE
remove flakyness expolding war for test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ THE SOFTWARE.
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
 
     <!-- may use e.g. 2C for 2 × (number of cores) -->
-    <concurrency>1</concurrency>
+    <forkCount>1</forkCount>
 
     <!-- Normally filled in by "maven-hpi-plugin" with the path to "org-netbeans-insane-hook.jar" extracted from this repository -->
     <jenkins.insaneHook>--patch-module=java.base=${project.build.outputDirectory}/netbeans/harness/modules/ext/org-netbeans-insane-hook.jar --add-exports=java.base/org.netbeans.insane.hook=ALL-UNNAMED</jenkins.insaneHook>
@@ -291,7 +291,7 @@ THE SOFTWARE.
             <buildDirectory>${project.build.directory}</buildDirectory>
           </systemPropertyVariables>
           <reuseForks>false</reuseForks>
-          <forkCount>${concurrency}</forkCount>
+          <forkCount>${forkCount}</forkCount>
           <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>

--- a/src/main/java/org/jvnet/hudson/test/WarExploder.java
+++ b/src/main/java/org/jvnet/hudson/test/WarExploder.java
@@ -156,7 +156,7 @@ public final class WarExploder {
         File explodeDir = new File(buildDirectory, "jenkins-for-test").getAbsoluteFile();
         explodeDir.getParentFile().mkdirs();
 
-        // multiple surefire forks can be occuring in parallel (which is different processes)
+        // multiple surefire forks can be running in parallel (which are different processes)
         // so we can not use synchronisation here.
         Path lock = new File(explodeDir + ".lock").toPath();
         // it is not the presence of the lock file that prevents reading / writing (as that can not be made reliable
@@ -184,7 +184,7 @@ public final class WarExploder {
             try {
                 lock = channel.tryLock();
             } catch (OverlappingFileLockException ignored) {
-                // should only occur we have multiple threads in this JVM attempting to lock this file
+                // should only occur when we have multiple threads in this JVM attempting to lock this file
                 // by default surefire and junit use JVM per fork - but gradle and other testing frameworks may differ
                 // so be defensive and treat this specific exception as a failure to obtain the lock rather than a 
                 // generic failure
@@ -192,7 +192,7 @@ public final class WarExploder {
             if (lock == null) {
                 if (++iteration % 50 == 0) {
                     // only log every 5 seconds.
-                    LOGGER.log(Level.INFO, "Waiting for an different JVM or thread to finish the unpack of the war");
+                    LOGGER.log(Level.INFO, "Waiting for a different JVM or thread to finish unpacking the war");
                 }
                 Thread.sleep(100);
             }

--- a/src/main/java/org/jvnet/hudson/test/WarExploder.java
+++ b/src/main/java/org/jvnet/hudson/test/WarExploder.java
@@ -159,7 +159,6 @@ public final class WarExploder {
         // multiple surefire forks can be occuring in parallel (which is different processes)
         // so we can not use synchronisation here.
         Path lock = new File(explodeDir + ".lock").toPath();
-        // TODO do we need write to get the lock?
         // it is not the presence of the lock file that prevents reading / writing (as that can not be made reliable
         // but the lock we subsequently obtain on the file.
         try (FileChannel lockChannel = FileChannel.open(lock, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
@@ -180,7 +179,7 @@ public final class WarExploder {
 
     private static FileLock getLockForChannel(FileChannel channel) throws IOException, InterruptedException {
         FileLock lock = null;
-        int itteration = 0;
+        int iteration = 0;
         while (lock == null) {
             try {
                 lock = channel.tryLock();
@@ -191,7 +190,7 @@ public final class WarExploder {
                 // generic failure
             }
             if (lock == null) {
-                if (++itteration % 50 == 0) {
+                if (++iteration % 50 == 0) {
                     // only log every 5 seconds.
                     LOGGER.log(Level.INFO, "Waiting for an different JVM or thread to finish the unpack of the war");
                 }


### PR DESCRIPTION
exploding the war for test had a race condition that caused tests to randomly fail if they had multiple tests running in parallel using JenkinsRule.

this switches a poor mans locking with race conditions to use the OS level file locking facilities

<!-- Please describe your pull request here. -->

### Testing done

in this project created 20 test classes like the following :

```
package org.jvnet.hudson.test.jr;

import org.junit.Rule;
import org.junit.Test;
import org.jvnet.hudson.test.JenkinsRule;

public class JR1Test {

    @Rule
    public JenkinsRule rule = new JenkinsRule();
    
    @Test
    public void anything() {
    }

}
```

ran  `rm -fr target\jenkins-for-test && mvn test -DforkCount=20 -Dtest=JR*Test`  (on windows)

Observed that the tests did not fail and the logging is expected

```
[INFO] --- surefire:3.1.2:test (default-test) @ jenkins-test-harness ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.jvnet.hudson.test.jr.JR12Test
[INFO] Running org.jvnet.hudson.test.jr.JR19Test
[INFO] Running org.jvnet.hudson.test.jr.JR20Test
[INFO] Running org.jvnet.hudson.test.jr.JR2Test
[INFO] Running org.jvnet.hudson.test.jr.JR7Test
[INFO] Running org.jvnet.hudson.test.jr.JR15Test
[INFO] Running org.jvnet.hudson.test.jr.JR11Test
[INFO] Running org.jvnet.hudson.test.jr.JR10Test
[INFO] Running org.jvnet.hudson.test.jr.JR4Test
[INFO] Running org.jvnet.hudson.test.jr.JR14Test
[INFO] Running org.jvnet.hudson.test.jr.JR17Test
[INFO] Running org.jvnet.hudson.test.jr.JR8Test
[INFO] Running org.jvnet.hudson.test.jr.JR18Test
[INFO] Running org.jvnet.hudson.test.jr.JR6Test
[INFO] Running org.jvnet.hudson.test.jr.JR16Test
[INFO] Running org.jvnet.hudson.test.jr.JR5Test
[INFO] Running org.jvnet.hudson.test.jr.JR13Test
[INFO] Running org.jvnet.hudson.test.jr.JR9Test
[INFO] Running org.jvnet.hudson.test.jr.JR1Test
[INFO] Running org.jvnet.hudson.test.jr.JR3Test
=== Starting anything(org.jvnet.hudson.test.jr.JR20Test)
   0.624 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Exploding C:\Users\jnord\.m2\repository\org\jenkins-ci\main\jenkins-war\2.361\jenkins-war-2.361.war into C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
=== Starting anything(org.jvnet.hudson.test.jr.JR7Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR2Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR12Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR19Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR10Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR6Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR11Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR18Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR13Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR16Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR17Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR5Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR14Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR8Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR1Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR15Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR3Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR4Test)
=== Starting anything(org.jvnet.hudson.test.jr.JR9Test)
   6.389 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   7.041 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   7.010 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.735 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.065 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.223 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.193 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.363 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.677 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.300 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.355 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   5.872 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.213 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.469 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   8.317 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.244 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.398 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   7.619 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   5.966 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#getLockForChannel: Waiting for an different JVM or thread to finish the unpack of the war
   6.683 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   6.836 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   9.249 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   9.889 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   7.233 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   7.758 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   8.168 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   7.731 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   9.649 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   6.641 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   6.519 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   7.396 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   9.780 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   8.103 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   8.977 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   7.709 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   7.250 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   8.010 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   7.257 [id=26]        INFO    o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\workarea\source\github\jenkinsci\jenkins-test-harness\target\jenkins-for-test
   7.477 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53296/jenkins/
   8.427 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53294/jenkins/
  11.459 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53189/jenkins/
   8.454 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53192/jenkins/
   8.807 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53298/jenkins/
  11.098 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53295/jenkins/
   9.278 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53297/jenkins/
  11.348 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53319/jenkins/
   9.368 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53303/jenkins/
   9.705 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53301/jenkins/
   9.911 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53299/jenkins/
  11.503 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53323/jenkins/
   8.709 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53190/jenkins/
  11.387 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53293/jenkins/
   8.801 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  10.302 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  12.517 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
   9.598 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53191/jenkins/
  10.103 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
   9.753 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53366/jenkins/
  10.350 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  10.976 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53300/jenkins/
   9.476 [id=62]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  10.179 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  10.838 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  10.783 [id=61]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  10.531 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
   9.516 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53304/jenkins/
  10.227 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53351/jenkins/
  12.006 [id=26]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:53302/jenkins/
  10.892 [id=62]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  13.208 [id=61]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  11.063 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  10.832 [id=62]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  12.976 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  14.101 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  13.264 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  11.088 [id=62]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  13.528 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  10.717 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  11.897 [id=62]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  11.353 [id=61]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  11.908 [id=62]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  13.745 [id=61]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  14.948 [id=61]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  12.003 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  12.609 [id=61]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  12.589 [id=42]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
  13.139 [id=61]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  15.512 [id=61]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  15.464 [id=62]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
  14.335 [id=69]        INFO    jenkins.InitReactorRunner$1#onAttained: Prepared all plug
  .....
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

fixes: #634 


```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
