### PR TITLE
Remove unnecessary defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,6 @@ THE SOFTWARE.
     <jenkins.version>2.361</jenkins.version>
     <jmh.version>1.37</jmh.version>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
-
-    <!-- may use e.g. 2C for 2 × (number of cores) -->
-    <forkCount>1</forkCount>
-
     <!-- Normally filled in by "maven-hpi-plugin" with the path to "org-netbeans-insane-hook.jar" extracted from this repository -->
     <jenkins.insaneHook>--patch-module=java.base=${project.build.outputDirectory}/netbeans/harness/modules/ext/org-netbeans-insane-hook.jar --add-exports=java.base/org.netbeans.insane.hook=ALL-UNNAMED</jenkins.insaneHook>
   </properties>
@@ -291,7 +287,6 @@ THE SOFTWARE.
             <buildDirectory>${project.build.directory}</buildDirectory>
           </systemPropertyVariables>
           <reuseForks>false</reuseForks>
-          <forkCount>${forkCount}</forkCount>
           <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>


### PR DESCRIPTION
Amends #635

- The default value of `forkCount` is 1 so not necessary to define it to 1 here
- The default property for `<forkCount>` is `${forkCount}` so not necessary to define it to `${forkCount}` here