### PR TITLE
Make failure to load NetBeans Insane hook non-fatal

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
+++ b/src/main/java/org/jvnet/hudson/test/MemoryAssert.java
@@ -26,6 +26,7 @@ package org.jvnet.hudson.test;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNoException;
 import static org.junit.Assume.assumeTrue;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -294,7 +295,16 @@ public class MemoryAssert {
         }
         // TODO consider also: rootsHint2.add(Thread.getAllStackTraces().keySet()); // https://stackoverflow.com/a/3018672/12916
 
-        return engine.trace(objs, rootsHint2);
+        try {
+            return engine.trace(objs, rootsHint2);
+        } catch (NoClassDefFoundError e) {
+            if (e.getMessage().contains("MakeAccessible")) {
+                assumeNoException(e);
+                return null;
+            } else {
+                throw e;
+            }
+        }
     }
 
 }


### PR DESCRIPTION
We get flaky test failures like this regularly in `jenkinsci/bom`:

```
java.lang.NoClassDefFoundError: org/netbeans/insane/hook/MakeAccessible
	at org.netbeans.insane.impl.InsaneEngine.processClass(InsaneEngine.java:224)
	at org.netbeans.insane.impl.InsaneEngine.process(InsaneEngine.java:185)
	at org.netbeans.insane.impl.InsaneEngine.traverse(InsaneEngine.java:73)
	at org.netbeans.insane.impl.LiveEngine.traceImpl(LiveEngine.java:165)
	at org.netbeans.insane.impl.LiveEngine.trace(LiveEngine.java:143)
	at org.jvnet.hudson.test.MemoryAssert.fromRoots(MemoryAssert.java:297)
	at org.jvnet.hudson.test.MemoryAssert.assertGC(MemoryAssert.java:208)
	at org.jvnet.hudson.test.MemoryAssert.assertGC(MemoryAssert.java:148)
	at org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest.loaderReleased(LibraryMemoryTest.java:85)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:606)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ClassNotFoundException: org.netbeans.insane.hook.MakeAccessible
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 21 more
```

This at least makes the problem non-fatal by skipping the test in such cases.

### Testing done

`mvn clean verify -Djenkins-test-harness.version=2063.v18e80b_125c99 -Dtest=org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest`