### PR TITLE
Work around an apparent JDK file deletion bug on Windows

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
@@ -144,6 +144,9 @@ public class TemporaryDirectoryAllocator {
                 throw new IOException(children.map(Path::toString).collect(Collectors.joining(" ")), x);
             }
         }
+        if (isWindows() && Files.deleteIfExists(p)) {
+            LOGGER.warning(() -> "had to try twice to delete " + p);
+        }
     }
 
     private boolean isWindows() {


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-cps-global-lib-http-plugin/pull/167 suppresses a couple of tests on Windows assuming they are flakes introduced by #198. In fact the failures are caused by #198 but are not flakes; I am able to reproduce https://github.com/jenkinsci/workflow-cps-global-lib-http-plugin/runs/16806834502 consistently on Windows 10 running on a VirtualBox file share, and I see no evidence of unclosed file handles or background activity in that plugin. For some reason, the `libs` subdirectory of the build directory does not get deleted the first time you call `Files.delete` on it (after deleting its children). Asking to delete `libs` again works. No other directories are affected. Using `File.delete` rather than the NIO method also deletes `libs` the first time. I suspect a bug in `WindowsFileSystemProvider.implDelete` but have not yet tried to narrow it down to a reproducible test case.