### PR TITLE
Set up file logging when shutting down the Jenkins test instance.

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -586,16 +586,16 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         private final Logger logger;
         private final Level priorLoggerLevel;
 
-        public SetConsoleLogger(String loggerName, Level level) {
+        public SetConsoleLogger(@NonNull String loggerName, @NonNull Level level) {
             logger = Logger.getLogger(loggerName);
             priorLoggerLevel = logger.getLevel();
-            if (level.intValue() < priorLoggerLevel.intValue()) {
+            if (priorLoggerLevel == null || level.intValue() < priorLoggerLevel.intValue()) {
                 logger.setLevel(level);
             }
             handler = Arrays.stream(Logger.getLogger("").getHandlers()).filter(ConsoleHandler.class::isInstance).findFirst().orElse(null);
             if (handler != null) {
                 priorHandlerLevel = handler.getLevel();
-                if (level.intValue() < priorHandlerLevel.intValue()) {
+                if (priorHandlerLevel == null || level.intValue() < priorHandlerLevel.intValue()) {
                     handler.setLevel(level);
                 }
             } else {

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -523,7 +523,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             // TODO use URLClassLoader.close() in Java 7
             System.gc();
 
-            try {
+            try (var ignored = new SetConsoleLogger("hudson.XmlFile", Level.FINEST)) {
                 env.dispose();
             } finally {
                 // restore defaultUseCache
@@ -564,13 +564,13 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                 }
             }
         }
-        try (var ignored = new SetConsoleLogger("hudson.XmlFile", Level.FINEST)) {
-            if (jenkins != null) {
-                jenkins.cleanUp();
-            }
-            ExtensionList.clearLegacyInstances();
-            DescriptorExtensionList.clearLegacyInstances();
+
+        if (jenkins != null) {
+            jenkins.cleanUp();
         }
+        ExtensionList.clearLegacyInstances();
+        DescriptorExtensionList.clearLegacyInstances();
+
         if (exception.getSuppressed().length > 0) {
             throw exception;
         }

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -563,7 +563,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                 }
             }
         }
-
+        tweakXmlFileLogger();
         if (jenkins != null) {
             jenkins.cleanUp();
         }
@@ -572,6 +572,16 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
         if (exception.getSuppressed().length > 0) {
             throw exception;
+        }
+    }
+
+    private static void tweakXmlFileLogger() {
+        var logger = Logger.getLogger("hudson.XmlFile");
+        logger.setLevel(Level.FINEST);
+        for (Handler h : Logger.getLogger("").getHandlers()) {
+            if (h instanceof ConsoleHandler) {
+                h.setLevel(Level.FINEST);
+            }
         }
     }
 


### PR DESCRIPTION
Matching change to https://github.com/jenkinsci/jenkins/pull/8513

This should help to identify race conditions during tests without causing too much noise as it only kicks in just before cleaning up the instance.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
