### PR TITLE
Provide the means to customize the folder containing the java executable for RJR

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -167,6 +167,8 @@ public final class RealJenkinsRule implements TestRule {
 
     private File war;
 
+    private String altJavaHome;
+
     private boolean includeTestClasspathPlugins = true;
 
     private final String token = UUID.randomUUID().toString();
@@ -306,6 +308,14 @@ public final class RealJenkinsRule implements TestRule {
      */
     public RealJenkinsRule withWar(File war) {
         this.war = war;
+        return this;
+    }
+
+    /**
+     * Allows to specify an alternate, not the one specified in JAVA_HOME, folder containing the JVM to use to launch the instance
+     */
+    public RealJenkinsRule withAltJavaHome(String altJavaHome) {
+        this.altJavaHome = altJavaHome;
         return this;
     }
 
@@ -658,7 +668,7 @@ public final class RealJenkinsRule implements TestRule {
                 Stream.of(cp.split(File.pathSeparator)).collect(Collectors.joining(System.lineSeparator())),
                 StandardCharsets.UTF_8);
         List<String> argv = new ArrayList<>(List.of(
-                new File(System.getProperty("java.home"), "bin/java").getAbsolutePath(),
+                new File(altJavaHome != null ? altJavaHome : System.getProperty("java.home"), "bin/java").getAbsolutePath(),
                 "-ea",
                 "-Dhudson.Main.development=true",
                 "-DRealJenkinsRule.location=" + RealJenkinsRule.class.getProtectionDomain().getCodeSource().getLocation(),

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -303,6 +303,13 @@ public class RealJenkinsRuleTest {
         assertThat(jse.getMessage(), containsString("Error</h1><pre>java.io.IOException: oops"));
     }
 
+    @Test
+    public void whenUsingAltJavaHome() throws Throwable {
+        IOException ex = assertThrows(
+                IOException.class, () -> rrWithFailure.withAltJavaHome("/noexists").startJenkins());
+        assertThat(ex.getMessage(), containsString("Cannot run program \"/noexists/bin/java\""));
+    }
+
     // TODO interesting scenarios to test:
     // · throw an exception of a type defined in Jenkins code
     // · run with optional dependencies disabled

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -307,7 +307,7 @@ public class RealJenkinsRuleTest {
     public void whenUsingWrongAltJavaHome() throws Throwable {
         IOException ex = assertThrows(
                 IOException.class, () -> rrWithFailure.withAltJavaHome("/noexists").startJenkins());
-        assertThat(ex.getMessage(), containsString("Cannot run program \"/noexists/bin/java\""));
+        assertThat(ex.getMessage(), containsString("noexists/bin/java"));
     }
 
     @Test public void smokesAltJavaHome() throws Throwable {

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -304,10 +304,15 @@ public class RealJenkinsRuleTest {
     }
 
     @Test
-    public void whenUsingAltJavaHome() throws Throwable {
+    public void whenUsingWrongAltJavaHome() throws Throwable {
         IOException ex = assertThrows(
                 IOException.class, () -> rrWithFailure.withAltJavaHome("/noexists").startJenkins());
         assertThat(ex.getMessage(), containsString("Cannot run program \"/noexists/bin/java\""));
+    }
+
+    @Test public void smokesAltJavaHome() throws Throwable {
+        String altJavaHome = System.getProperty("java.home");
+        rr.extraEnv("SOME_ENV_VAR", "value").extraEnv("NOT_SET", null).withAltJavaHome(altJavaHome).withLogger(Jenkins.class, Level.FINEST).then(RealJenkinsRuleTest::_smokes);
     }
 
     // TODO interesting scenarios to test:

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -307,7 +307,7 @@ public class RealJenkinsRuleTest {
     public void whenUsingWrongAltJavaHome() throws Throwable {
         IOException ex = assertThrows(
                 IOException.class, () -> rrWithFailure.withAltJavaHome("/noexists").startJenkins());
-        assertThat(ex.getMessage(), containsString("noexists/bin/java"));
+        assertThat(ex.getMessage(), containsString(File.separator + "noexists" + File.separator + "bin" + File.separator + "java"));
     }
 
     @Test public void smokesAltJavaHome() throws Throwable {


### PR DESCRIPTION
Can be used to launch the JuT using any JVM instead of always delegating to JAVA_HOME.

Useful due to the upcoming support process for [different JVM versions](https://www.jenkins.io/blog/2023/11/06/introducing-2-2-2-java-support-plan/) as it would allow to create RJR test configurations that share the same code but run with different JVMs, like 17 and 21

### Testing done
Manual tested by creating a test that uses a custom location on my local system.
There are unit tests that ensures the new code works as expected also.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
