### PR TITLE
[JENKINS-72387] Provide JUnit5 Class (static) context for JenkinsRule

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/JUnit5JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/JUnit5JenkinsRule.java
@@ -23,15 +23,15 @@ class JUnit5JenkinsRule extends JenkinsRule {
 
     @Override
     public void recipe() throws Exception {
-        final JenkinsRecipe recipe = this.testDescription.getAnnotation(JenkinsRecipe.class);
+        final JenkinsRecipe jenkinsRecipe = this.testDescription.getAnnotation(JenkinsRecipe.class);
 
-        if (recipe == null) {
+        if (jenkinsRecipe == null) {
             return;
         }
         @SuppressWarnings("unchecked")
         final JenkinsRecipe.Runner<JenkinsRecipe> runner =
-                (JenkinsRecipe.Runner<JenkinsRecipe>) recipe.value().getDeclaredConstructor().newInstance();
+                (JenkinsRecipe.Runner<JenkinsRecipe>) jenkinsRecipe.value().getDeclaredConstructor().newInstance();
         recipes.add(runner);
-        tearDowns.add(() -> runner.tearDown(this, recipe));
+        tearDowns.add(() -> runner.tearDown(this, jenkinsRecipe));
     }
 }

--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/JUnit5JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/JUnit5JenkinsRule.java
@@ -1,9 +1,10 @@
 package org.jvnet.hudson.test.junit.jupiter;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.runner.Description;
 import org.jvnet.hudson.test.JenkinsRecipe;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -12,25 +13,25 @@ import org.jvnet.hudson.test.JenkinsRule;
  * Provides JUnit 5 compatibility for {@link JenkinsRule}.
  */
 class JUnit5JenkinsRule extends JenkinsRule {
-    private final ParameterContext context;
 
-    JUnit5JenkinsRule(@NonNull ParameterContext context, @NonNull ExtensionContext extensionContext) {
-        this.context = context;
+    JUnit5JenkinsRule(@NonNull ExtensionContext extensionContext, Annotation... annotations) {
         this.testDescription = Description.createTestDescription(
-                extensionContext.getTestClass().map(Class::getName).orElse(null),
-                extensionContext.getTestMethod().map(Method::getName).orElse(null));
+            extensionContext.getTestClass().map(Class::getName).orElse(null),
+            extensionContext.getTestMethod().map(Method::getName).orElse(null),
+            annotations);
     }
 
     @Override
     public void recipe() throws Exception {
-        JenkinsRecipe jenkinsRecipe = context.findAnnotation(JenkinsRecipe.class).orElse(null);
-        if (jenkinsRecipe == null) {
+        final JenkinsRecipe recipe = this.testDescription.getAnnotation(JenkinsRecipe.class);
+
+        if (recipe == null) {
             return;
         }
         @SuppressWarnings("unchecked")
         final JenkinsRecipe.Runner<JenkinsRecipe> runner =
-                (JenkinsRecipe.Runner<JenkinsRecipe>) jenkinsRecipe.value().getDeclaredConstructor().newInstance();
+                (JenkinsRecipe.Runner<JenkinsRecipe>) recipe.value().getDeclaredConstructor().newInstance();
         recipes.add(runner);
-        tearDowns.add(() -> runner.tearDown(this, jenkinsRecipe));
+        tearDowns.add(() -> runner.tearDown(this, recipe));
     }
 }

--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsExtension.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/JenkinsExtension.java
@@ -1,21 +1,75 @@
 package org.jvnet.hudson.test.junit.jupiter;
 
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
-import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.*;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.commons.support.ModifierSupport;
+import org.jvnet.hudson.test.JenkinsRecipe;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.lang.reflect.Field;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.junit.platform.commons.support.ReflectionSupport.findFields;
 
 /**
  * JUnit 5 extension providing {@link JenkinsRule} integration.
  *
  * @see WithJenkins
  */
-class JenkinsExtension implements ParameterResolver, AfterEachCallback {
+class JenkinsExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver, AfterEachCallback {
 
     private static final String KEY = "jenkins-instance";
     private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(JenkinsExtension.class);
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        Class<?> clazz = extensionContext.getRequiredTestClass();
+        Predicate<Field> predicate = (field -> ModifierSupport.isStatic(field)
+            && JenkinsRule.class.isAssignableFrom(field.getType()));
+        Field field = findFields(clazz, predicate, HierarchyTraversalMode.BOTTOM_UP).stream()
+            .findFirst()
+            .orElse(null);
+        if (field == null) {
+            return;
+        }
+
+        final JenkinsRecipe recipe = field.getDeclaredAnnotation(JenkinsRecipe.class);
+        final JenkinsRule rule;
+        if (recipe != null) {
+            rule = new JUnit5JenkinsRule(extensionContext, recipe);
+        } else {
+            rule = new JUnit5JenkinsRule(extensionContext);
+        }
+        extensionContext
+            .getStore(NAMESPACE)
+            .getOrComputeIfAbsent(KEY, key -> rule, JenkinsRule.class);
+        try {
+            rule.before();
+        } catch (Throwable e) {
+            throw new ExtensionContextException(e.getMessage(), e);
+        }
+        field.setAccessible(true);
+        field.set(null, rule);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+        Class<?> clazz = extensionContext.getRequiredTestClass();
+        Predicate<Field> predicate = (field -> ModifierSupport.isStatic(field)
+            && JenkinsRule.class.isAssignableFrom(field.getType()));
+        Field field = findFields(clazz, predicate, HierarchyTraversalMode.BOTTOM_UP).stream()
+            .findFirst()
+            .orElse(null);
+        if (field != null) {
+            final JenkinsRule rule =
+                extensionContext.getStore(NAMESPACE).get(KEY, JenkinsRule.class);
+            if (rule == null) {
+                return;
+            }
+            rule.after();
+        }
+    }
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
@@ -33,13 +87,18 @@ class JenkinsExtension implements ParameterResolver, AfterEachCallback {
 
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        JenkinsRecipe recipe = parameterContext.findAnnotation(JenkinsRecipe.class).orElse(null);
+        Function<String, JenkinsRule> compute;
+        if (recipe == null) {
+            compute = key -> new JUnit5JenkinsRule(extensionContext);
+        } else {
+            compute = key -> new JUnit5JenkinsRule(extensionContext, recipe);
+        }
+
         final JenkinsRule rule =
                 extensionContext
                         .getStore(NAMESPACE)
-                        .getOrComputeIfAbsent(
-                                KEY,
-                                key -> new JUnit5JenkinsRule(parameterContext, extensionContext),
-                                JenkinsRule.class);
+                        .getOrComputeIfAbsent(KEY, compute, JenkinsRule.class);
 
         try {
             rule.before();

--- a/src/test/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRuleClassResolverTest.java
+++ b/src/test/java/org/jvnet/hudson/test/junit/jupiter/JenkinsRuleClassResolverTest.java
@@ -1,0 +1,23 @@
+package org.jvnet.hudson.test.junit.jupiter;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+@WithJenkins
+class JenkinsRuleClassResolverTest {
+
+    static JenkinsRule rule;
+
+    @Test
+    void jenkinsRuleIsAccessible() throws IOException {
+        assertThat(rule.jenkins.getJobNames(), empty());
+        rule.createFreeStyleProject("job-0");
+        assertThat(rule.jenkins.getJobNames(), hasSize(1));
+    }
+}


### PR DESCRIPTION
See [JENKINS-72387](https://issues.jenkins.io/browse/JENKINS-72387).

I'd like to add support for creating one running Jenkins instance per Test Class, when using the JUnit5 extension points.

Due to how the JenkinsRule and underlying contexts expect population of the Jenkins `testDescription`, some refactoring of was required. This was necessary to find all annotations that may exist in all contexts - which would define the pre-test state of the Jenkins instance.


### Testing done
All previous tests pass, including the original which tested code this PR has refactored/modified (`JenkinsRuleResolverTest`).
Added an additional test  (`JenkinsRuleClassResolverTest`) to ensure the explicit feature was validated. 


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
