### PR TITLE
Allow `RealJenkinsRule` to delay `JENKINS_HOME` initialization until first startup using new `prepareHomeLazily` method

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -197,7 +197,7 @@ public final class RealJenkinsRule implements TestRule {
     private boolean debugServer = true;
     private boolean debugSuspend;
 
-    private boolean lazyProvisioning;
+    private boolean prepareHomeLazily;
     private boolean provisioned;
 
     // TODO may need to be relaxed for Gradle-based plugins
@@ -445,14 +445,14 @@ public final class RealJenkinsRule implements TestRule {
     }
 
     /**
-     * Allows JENKINS_HOME initialization to be delayed until {@link #startJenkins} is called for the first time.
+     * Allows {@code JENKINS_HOME} initialization to be delayed until {@link #startJenkins} is called for the first time.
      * <p>
      * This allows methods such as {@link #addPlugins} to be called dynamically inside of test methods, which enables
      * related tests that need to configure {@link RealJenkinsRule} in different ways to be defined in the same class
      * using only a single instance of {@link RealJenkinsRule}.
      */
-    public RealJenkinsRule withLazyProvisioning(boolean lazyProvisioning) {
-        this.lazyProvisioning = lazyProvisioning;
+    public RealJenkinsRule prepareHomeLazily(boolean prepareHomeLazily) {
+        this.prepareHomeLazily = prepareHomeLazily;
         return this;
     }
 
@@ -482,7 +482,7 @@ public final class RealJenkinsRule implements TestRule {
                 }
                 try {
                     home.set(tmp.allocate());
-                    if (!lazyProvisioning) {
+                    if (!prepareHomeLazily) {
                         provision();
                     }
                     base.evaluate();
@@ -709,7 +709,7 @@ public final class RealJenkinsRule implements TestRule {
         if (proc != null) {
             throw new IllegalStateException("Jenkins is (supposedly) already running");
         }
-        if (lazyProvisioning && !provisioned) {
+        if (prepareHomeLazily && !provisioned) {
             provision();
         }
         String cp = System.getProperty("java.class.path");

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -445,7 +445,7 @@ public final class RealJenkinsRule implements TestRule {
     }
 
     /**
-     * Allows JENKINS_HOME initialization to be delayed until {@link startJenkins} is called for the first time.
+     * Allows JENKINS_HOME initialization to be delayed until {@link #startJenkins} is called for the first time.
      * <p>
      * This allows methods such as {@link #addPlugins} to be called dynamically inside of test methods, which enables
      * related tests that need to configure {@link RealJenkinsRule} in different ways to be defined in the same class

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -466,103 +466,12 @@ public final class RealJenkinsRule implements TestRule {
                     return;
                 }
                 try {
-                    home.set(tmp.allocate());
-                    LocalData localData = description.getAnnotation(LocalData.class);
-                    if (localData != null) {
-                        new HudsonHomeLoader.Local(description.getTestClass().getMethod(description.getMethodName()), localData.value()).copy(getHome());
-                    }
-                    File plugins = new File(getHome(), "plugins");
-                    plugins.mkdir();
-                    FileUtils.copyURLToFile(RealJenkinsRule.class.getResource("RealJenkinsRuleInit.jpi"), new File(plugins, "RealJenkinsRuleInit.jpi"));
-
-                    if (includeTestClasspathPlugins) {
-                        // Adapted from UnitTestSupportingPluginManager & JenkinsRule.recipeLoadCurrentPlugin:
-                        Set<String> snapshotPlugins = new TreeSet<>();
-                        Enumeration<URL> indexJellies = RealJenkinsRule.class.getClassLoader().getResources("index.jelly");
-                        while (indexJellies.hasMoreElements()) {
-                            String indexJelly = indexJellies.nextElement().toString();
-                            Matcher m = SNAPSHOT_INDEX_JELLY.matcher(indexJelly);
-                            if (m.matches()) {
-                                Path snapshotManifest;
-                                snapshotManifest = Paths.get(URI.create(m.group(1) + "/test-classes/the.jpl"));
-                                if (!Files.exists(snapshotManifest)) {
-                                    snapshotManifest = Paths.get(URI.create(m.group(1) + "/test-classes/the.hpl"));
-                                }
-                                if (Files.exists(snapshotManifest)) {
-                                    String shortName;
-                                    try (InputStream is = Files.newInputStream(snapshotManifest)) {
-                                        shortName = new Manifest(is).getMainAttributes().getValue("Short-Name");
-                                    }
-                                    if (shortName == null) {
-                                        throw new IOException("malformed " + snapshotManifest);
-                                    }
-                                    if (skippedPlugins.contains(shortName)) {
-                                        continue;
-                                    }
-                                    // Not totally realistic, but test phase is run before package phase. TODO can we add an option to run in integration-test phase?
-                                    Files.copy(snapshotManifest, plugins.toPath().resolve(shortName + ".jpl"));
-                                    snapshotPlugins.add(shortName);
-                                } else {
-                                    System.out.println("Warning: found " + indexJelly + " but did not find corresponding ../test-classes/the.[hj]pl");
-                                }
-                            } else {
-                                // Do not warn about the common case of jar:file:/**/.m2/repository/**/*.jar!/index.jelly
-                            }
-                        }
-                        URL index = RealJenkinsRule.class.getResource("/test-dependencies/index");
-                        if (index != null) {
-                            try (BufferedReader r = new BufferedReader(new InputStreamReader(index.openStream(), StandardCharsets.UTF_8))) {
-                                String line;
-                                while ((line = r.readLine()) != null) {
-                                    if (snapshotPlugins.contains(line) || skippedPlugins.contains(line)) {
-                                        continue;
-                                    }
-                                    final URL url = new URL(index, line + ".jpi");
-                                    File f;
-                                    try {
-                                        f = new File(url.toURI());
-                                    } catch (IllegalArgumentException x) {
-                                        if (x.getMessage().equals("URI is not hierarchical")) {
-                                            throw new IOException(
-                                                    "You are probably trying to load plugins from within a jarfile (not possible). If" +
-                                                            " you are running this in your IDE and see this message, it is likely" +
-                                                            " that you have a clean target directory. Try running 'mvn test-compile' " +
-                                                            "from the command line (once only), which will copy the required plugins " +
-                                                            "into target/test-classes/test-dependencies - then retry your test", x);
-                                        } else {
-                                            throw new IOException(index + " contains bogus line " + line, x);
-                                        }
-                                    }
-                                    if (f.exists()) {
-                                        FileUtils.copyURLToFile(url, new File(plugins, line + ".jpi"));
-                                    } else {
-                                        FileUtils.copyURLToFile(new URL(index, line + ".hpi"), new File(plugins, line + ".jpi"));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    for (String extraPlugin : extraPlugins) {
-                        URL url = RealJenkinsRule.class.getClassLoader().getResource(extraPlugin);
-                        String name;
-                        try (InputStream is = url.openStream(); JarInputStream jis = new JarInputStream(is)) {
-                            Manifest man = jis.getManifest();
-                            if (man == null) {
-                                throw new IOException("No manifest found in " + extraPlugin);
-                            }
-                            name = man.getMainAttributes().getValue("Short-Name");
-                            if (name == null) {
-                                throw new IOException("No Short-Name found in " + extraPlugin);
-                            }
-                        }
-                        FileUtils.copyURLToFile(url, new File(plugins, name + ".jpi"));
-                    }
-                    System.out.println("Will load plugins: " + Stream.of(plugins.list()).filter(n -> n.matches(".+[.][hj]p[il]")).sorted().collect(Collectors.joining(" ")));
+                    provision(description);
                     base.evaluate();
                 } finally {
                     stopJenkins();
                     try {
-                        tmp.dispose();
+                        deprovision();
                     } catch (Exception x) {
                         LOGGER.log(Level.WARNING, null, x);
                     }
@@ -570,6 +479,131 @@ public final class RealJenkinsRule implements TestRule {
             }
 
         };
+    }
+
+    /**
+     * Initializes {@code JENKINS_HOME}, but does not start Jenkins.
+     *
+     * This method does not need to be invoked when using {@code @Rule} or {@code @ClassRule} to run {@code RealJenkinsRule}.
+     */
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "irrelevant")
+    public void provision(Description description) throws Exception {
+        this.description = description;
+        if (home.get() != null) {
+            throw new IllegalStateException(description + " was already provisioned");
+        }
+        if (war == null) {
+            war = findJenkinsWar();
+        }
+        home.set(tmp.allocate());
+        LocalData localData = description.getAnnotation(LocalData.class);
+        if (localData != null) {
+            new HudsonHomeLoader.Local(description.getTestClass().getMethod(description.getMethodName()), localData.value()).copy(getHome());
+        }
+        File plugins = new File(getHome(), "plugins");
+        Files.createDirectories(plugins.toPath());
+        FileUtils.copyURLToFile(RealJenkinsRule.class.getResource("RealJenkinsRuleInit.jpi"), new File(plugins, "RealJenkinsRuleInit.jpi"));
+
+        if (includeTestClasspathPlugins) {
+            // Adapted from UnitTestSupportingPluginManager & JenkinsRule.recipeLoadCurrentPlugin:
+            Set<String> snapshotPlugins = new TreeSet<>();
+            Enumeration<URL> indexJellies = RealJenkinsRule.class.getClassLoader().getResources("index.jelly");
+            while (indexJellies.hasMoreElements()) {
+                String indexJelly = indexJellies.nextElement().toString();
+                Matcher m = SNAPSHOT_INDEX_JELLY.matcher(indexJelly);
+                if (m.matches()) {
+                    Path snapshotManifest;
+                    snapshotManifest = Paths.get(URI.create(m.group(1) + "/test-classes/the.jpl"));
+                    if (!Files.exists(snapshotManifest)) {
+                        snapshotManifest = Paths.get(URI.create(m.group(1) + "/test-classes/the.hpl"));
+                    }
+                    if (Files.exists(snapshotManifest)) {
+                        String shortName;
+                        try (InputStream is = Files.newInputStream(snapshotManifest)) {
+                            shortName = new Manifest(is).getMainAttributes().getValue("Short-Name");
+                        }
+                        if (shortName == null) {
+                            throw new IOException("malformed " + snapshotManifest);
+                        }
+                        if (skippedPlugins.contains(shortName) || !snapshotPlugins.add(shortName)) {
+                            continue;
+                        }
+                        // Not totally realistic, but test phase is run before package phase. TODO can we add an option to run in integration-test phase?
+                        Files.copy(snapshotManifest, plugins.toPath().resolve(shortName + ".jpl"));
+                        snapshotPlugins.add(shortName);
+                    } else {
+                        System.out.println("Warning: found " + indexJelly + " but did not find corresponding ../test-classes/the.[hj]pl");
+                    }
+                } else {
+                    // Do not warn about the common case of jar:file:/**/.m2/repository/**/*.jar!/index.jelly
+                }
+            }
+            URL index = RealJenkinsRule.class.getResource("/test-dependencies/index");
+            if (index != null) {
+                try (BufferedReader r = new BufferedReader(new InputStreamReader(index.openStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = r.readLine()) != null) {
+                        if (snapshotPlugins.contains(line)) {
+                            continue;
+                        }
+                        final URL url = new URL(index, line + ".jpi");
+                        File f;
+                        try {
+                            f = new File(url.toURI());
+                        } catch (IllegalArgumentException x) {
+                            if (x.getMessage().equals("URI is not hierarchical")) {
+                                throw new IOException(
+                                        "You are probably trying to load plugins from within a jarfile (not possible). If" +
+                                                " you are running this in your IDE and see this message, it is likely" +
+                                                " that you have a clean target directory. Try running 'mvn test-compile' " +
+                                                "from the command line (once only), which will copy the required plugins " +
+                                                "into target/test-classes/test-dependencies - then retry your test", x);
+                            } else {
+                                throw new IOException(index + " contains bogus line " + line, x);
+                            }
+                        }
+                        if (f.exists()) {
+                            FileUtils.copyURLToFile(url, new File(plugins, line + ".jpi"));
+                        } else {
+                            FileUtils.copyURLToFile(new URL(index, line + ".hpi"), new File(plugins, line + ".jpi"));
+                        }
+                    }
+                }
+            }
+        }
+        for (String extraPlugin : extraPlugins) {
+            URL url = RealJenkinsRule.class.getClassLoader().getResource(extraPlugin);
+            String name;
+            try (InputStream is = url.openStream(); JarInputStream jis = new JarInputStream(is)) {
+                Manifest man = jis.getManifest();
+                if (man == null) {
+                    throw new IOException("No manifest found in " + extraPlugin);
+                }
+                name = man.getMainAttributes().getValue("Short-Name");
+                if (name == null) {
+                    throw new IOException("No Short-Name found in " + extraPlugin);
+                }
+            }
+            FileUtils.copyURLToFile(url, new File(plugins, name + ".jpi"));
+        }
+        System.out.println("Will load plugins: " + Stream.of(plugins.list()).filter(n -> n.matches(".+[.][hj]p[il]")).sorted().collect(Collectors.joining(" ")));
+    }
+
+    /**
+     * Deletes {@code JENKINS_HOME}.
+     *
+     * This method does not need to be invoked when using {@code @Rule} or {@code @ClassRule} to run {@code RealJenkinsRule}.
+     */
+    public void deprovision() throws Exception {
+        tmp.dispose();
+        home.set(null);
+    }
+
+    /**
+     * Returns true if the Jenkins process is alive.
+     */
+    public boolean isAlive() {
+        return proc != null && proc.isAlive();
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -537,7 +537,7 @@ public final class RealJenkinsRule implements TestRule {
                         if (shortName == null) {
                             throw new IOException("malformed " + snapshotManifest);
                         }
-                        if (skippedPlugins.contains(shortName) || !snapshotPlugins.add(shortName)) {
+                        if (skippedPlugins.contains(shortName)) {
                             continue;
                         }
                         // Not totally realistic, but test phase is run before package phase. TODO can we add an option to run in integration-test phase?
@@ -555,7 +555,7 @@ public final class RealJenkinsRule implements TestRule {
                 try (BufferedReader r = new BufferedReader(new InputStreamReader(index.openStream(), StandardCharsets.UTF_8))) {
                     String line;
                     while ((line = r.readLine()) != null) {
-                        if (snapshotPlugins.contains(line)) {
+                        if (snapshotPlugins.contains(line) || skippedPlugins.contains(line)) {
                             continue;
                         }
                         final URL url = new URL(index, line + ".jpi");

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -72,7 +72,7 @@ import org.kohsuke.stapler.Stapler;
 
 public class RealJenkinsRuleTest {
 
-    @Rule public RealJenkinsRule rr = new RealJenkinsRule().withLazyProvisioning(true).withDebugPort(4001).withDebugServer(false);
+    @Rule public RealJenkinsRule rr = new RealJenkinsRule().prepareHomeLazily(true).withDebugPort(4001).withDebugServer(false);
 
     @Test public void smokes() throws Throwable {
         rr.addPlugins("plugins/structs.hpi");

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -72,11 +72,10 @@ import org.kohsuke.stapler.Stapler;
 
 public class RealJenkinsRuleTest {
 
-    // TODO addPlugins does not currently take effect when used inside test method
-    @Rule public RealJenkinsRule rr = new RealJenkinsRule().addPlugins("plugins/structs.hpi").withDebugPort(4001).withDebugServer(false);
-    @Rule public RealJenkinsRule rrWithFailure = new RealJenkinsRule().addPlugins("plugins/failure.hpi");
+    @Rule public RealJenkinsRule rr = new RealJenkinsRule().withLazyProvisioning(true).withDebugPort(4001).withDebugServer(false);
 
     @Test public void smokes() throws Throwable {
+        rr.addPlugins("plugins/structs.hpi");
         rr.extraEnv("SOME_ENV_VAR", "value").extraEnv("NOT_SET", null).withLogger(Jenkins.class, Level.FINEST).then(RealJenkinsRuleTest::_smokes);
     }
     private static void _smokes(JenkinsRule r) throws Throwable {
@@ -299,19 +298,20 @@ public class RealJenkinsRuleTest {
     @Test
     public void whenUsingFailurePlugin() throws Throwable {
         RealJenkinsRule.JenkinsStartupException jse = assertThrows(
-                RealJenkinsRule.JenkinsStartupException.class, () -> rrWithFailure.startJenkins());
+                RealJenkinsRule.JenkinsStartupException.class, () -> rr.addPlugins("plugins/failure.hpi").startJenkins());
         assertThat(jse.getMessage(), containsString("Error</h1><pre>java.io.IOException: oops"));
     }
 
     @Test
     public void whenUsingWrongAltJavaHome() throws Throwable {
         IOException ex = assertThrows(
-                IOException.class, () -> rrWithFailure.withAltJavaHome("/noexists").startJenkins());
+                IOException.class, () -> rr.withAltJavaHome("/noexists").startJenkins());
         assertThat(ex.getMessage(), containsString(File.separator + "noexists" + File.separator + "bin" + File.separator + "java"));
     }
 
     @Test public void smokesAltJavaHome() throws Throwable {
         String altJavaHome = System.getProperty("java.home");
+        rr.addPlugins("plugins/structs.hpi");
         rr.extraEnv("SOME_ENV_VAR", "value").extraEnv("NOT_SET", null).withAltJavaHome(altJavaHome).withLogger(Jenkins.class, Level.FINEST).then(RealJenkinsRuleTest::_smokes);
     }
 


### PR DESCRIPTION
Fixes #365.

In addition to what is described in #365, I have a case where I would like to use `RealJenkinsRule` dynamically in tests in a way that is not well suited to `@Rule`/`@ClassRule`. This PR adds a `deprovision` method, which deletes `JENKINS_HOME`, and an `isAlive` method, which checks whether the Jenkins process is alive. In combination with the new `withLazyProvisioning` method that delays `JENKINS_HOME` initialization until Jenkins first starts, this allows `RealJenkinsRule` to be instantiated, provisioned, started, stopped, and deprovisioned fully dynamically. The `deprovision` and `isAlive` methods can be ignored in most cases.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
