### PR TITLE
Let `InboundAgentRule.stop` tolerate a dead controller in `RealJenkinsRule` mode

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -377,7 +377,11 @@ public final class InboundAgentRule extends ExternalResource {
      */
     public void stop(@NonNull RealJenkinsRule rjr, @NonNull String name) throws Throwable {
         stop(name);
-        rjr.runRemotely(InboundAgentRule::waitForAgentOffline, name);
+        if (rjr.isAlive()) {
+            rjr.runRemotely(InboundAgentRule::waitForAgentOffline, name);
+        } else {
+            LOGGER.warning(() -> "Controller seems to have already shut down; not waiting for " + name + " to go offline");
+        }
     }
 
     /**


### PR DESCRIPTION
Otherwise putting this in a `finally` block can obscure the root cause of a test failure particularly if the test failed with a timeout.