### PR TITLE
Do not swallow exceptions in `HtmlFormUtil`

### DIFF
--- a/src/main/java/org/htmlunit/html/HtmlFormUtil.java
+++ b/src/main/java/org/htmlunit/html/HtmlFormUtil.java
@@ -70,22 +70,19 @@ public class HtmlFormUtil {
                 return submitElement.click();
             }
 
-            try {
-                htmlForm.submit((SubmittableElement) submitElement);
-            } finally {
-                // The HtmlForm submit doesn't really do anything. It just adds a "LoadJob"
-                // to an internal queue. What we are doing here is manually forcing the load of
-                // the response for that submit LoadJob and then getting the enclosing page
-                // from the current window on the WebClient, allowing us to return the correct
-                // HtmlPage object to the test.
-                webClient.loadDownloadedResponses();
-                Page resultPage = webClient.getCurrentWindow().getEnclosedPage();
+            htmlForm.submit((SubmittableElement) submitElement);
+            // The HtmlForm submit doesn't really do anything. It just adds a "LoadJob"
+            // to an internal queue. What we are doing here is manually forcing the load of
+            // the response for that submit LoadJob and then getting the enclosing page
+            // from the current window on the WebClient, allowing us to return the correct
+            // HtmlPage object to the test.
+            webClient.loadDownloadedResponses();
+            Page resultPage = webClient.getCurrentWindow().getEnclosedPage();
 
-                if (resultPage == htmlPage) {
-                    return HtmlElementUtil.click(submitElement);
-                } else {
-                    return resultPage;
-                }
+            if (resultPage == htmlPage) {
+                return HtmlElementUtil.click(submitElement);
+            } else {
+                return resultPage;
             }
         } finally {
             // Make sure all background JS has executed.
@@ -131,4 +128,7 @@ public class HtmlFormUtil {
         }
         throw new ElementNotFoundException("button", "caption", caption);
     }
+
+    private HtmlFormUtil() {}
+
 }


### PR DESCRIPTION
Spent hours tracking down bizarre behavior which I could finally trace to an error in an `HtmlForm.submit` call (as well as a bogus return value from `getSubmitButton` highlighted by https://github.com/jenkinsci/jenkins/pull/8554 which I will deal with separately). You do not `return` from a `finally` block.

Dates to https://github.com/jenkinsci/jenkins/pull/1774.