### PR TITLE
[RealJenkinsRule] Switching hardcoded IPv4 address to loopback address

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -49,6 +49,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -162,7 +163,7 @@ public final class RealJenkinsRule implements TestRule {
      */
     private int port;
 
-    private String httpListenAddress = "127.0.0.1";
+    private String httpListenAddress = InetAddress.getLoopbackAddress().getHostAddress();
 
     private File war;
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
As described in https://github.com/jenkinsci/jenkins-test-harness/issues/711.

This change removes the hardcoded `127.0.0.1` address used in `RealJenkinsRule` and replaces it with the real loopback address, so it will use the IPv4 loopback address, 127.0.0.1, or the IPv6 loopback address, ::1 (in long format, so 0:0:0:0:0:0:0:1).

Regardless address can be overriden via `withHttpListenAddress` it makes sense to have default address use the right protocol so that method is used only for specific cases.

This change won't affect any test using `getUrl()` method, as that method returns an URL pointing to `localhost` so should be version-agnostic.

### Testing done
Check running tests using snapshot:
With IPv6
```
mvn clean test -Djava.net.preferIPv6Addresses=true -Dtest=[......]
...
JENKINS_HOME=[..] SUREFIRE_FORK_NUMBER=1 java -DRealJenkinsRule.location=file:[PATH]/.m2/repository/org/jenkins-ci/main/jenkins-test-harness/999999-SNAPSHOT/jenkins-test-harness-999999-SNAPSHOT.jar [...] --httpPort=0 --httpListenAddress=0:0:0:0:0:0:0:1 --prefix=/jenkins
```
With IPv4
```
mvn clean test -Djava.net.preferIPv6Addresses=false -Dtest=[......]
...
JENKINS_HOME=[..] SUREFIRE_FORK_NUMBER=1 java -DRealJenkinsRule.location=file:[PATH]/.m2/repository/org/jenkins-ci/main/jenkins-test-harness/999999-SNAPSHOT/jenkins-test-harness-999999-SNAPSHOT.jar [...] --httpPort=0 --httpListenAddress=127.0.0.1 --prefix=/jenkins
```

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
