### PR TITLE
Revert "Bump org.jenkins-ci.main:jenkins-test-harness-htmlunit from 164.v87e5a_1809c10 to 168.v36080d5e8d36"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness-htmlunit</artifactId>
-      <version>168.v36080d5e8d36</version>
+      <version>164.v87e5a_1809c10</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>


### PR DESCRIPTION
Reverts jenkinsci/jenkins-test-harness#715

Seems to be causing intermittent test failures in core as in https://ci.jenkins.io/job/Core/job/jenkins/job/PR-8873/8/