### PR TITLE
Print text lines atomically from `TailLog`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TailLog.java
+++ b/src/main/java/org/jvnet/hudson/test/TailLog.java
@@ -99,12 +99,15 @@ public final class TailLog implements AutoCloseable {
             @Override
             public void handle(String line) {
                 if (ps == null) {
-                    ps = new PrintStream(new PlainTextConsoleOutputStream(prefixedOutputStreamBuilder.withName(job + '#' + number).build(System.out)), true, StandardCharsets.UTF_8);
+                    ps = new PrintStream(new PlainTextConsoleOutputStream(prefixedOutputStreamBuilder.withName(job + '#' + number).build(System.out)), false, StandardCharsets.UTF_8);
                 }
-                ps.append(DeltaSupportLogFormatter.elapsedTime());
-                ps.print(' ');
-                ps.print(line);
-                ps.println();
+                synchronized (System.out) {
+                    ps.append(DeltaSupportLogFormatter.elapsedTime());
+                    ps.print(' ');
+                    ps.print(line);
+                    ps.println();
+                    ps.flush();
+                }
                 if (line.startsWith("Finished: ")) {
                     finished.release();
                 }


### PR DESCRIPTION
I noticed that when starting multiple builds nearly simultaneously and running several copies of `TailLog`, often lines of output would get intermixed and mangled. After adding synchronization I have not seen this recur.