### PR TITLE
Accept NPE in MockFolder.createProject() if wrong job type is passed

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/MockFolder.java
+++ b/src/main/java/org/jvnet/hudson/test/MockFolder.java
@@ -25,6 +25,7 @@
 package org.jvnet.hudson.test;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AbstractItem;
 import hudson.model.Action;
@@ -158,6 +159,8 @@ public class MockFolder extends AbstractItem implements DirectlyModifiableTopLev
     }
 
     /** Convenience method to create a {@link FreeStyleProject} or similar. */
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                        justification = "Accept null pointer exception if caller passes an invalid project type")
     public <T extends TopLevelItem> T createProject(Class<T> type, String name) throws IOException {
         return type.cast(createProject((TopLevelItemDescriptor) Jenkins.get().getDescriptor(type), name, true));
     }

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -73,12 +73,6 @@
     <Class name="org.jvnet.hudson.test.RestartableJenkinsRule"/>
     <Field name="j"/>
   </Match>
-  <Match>
-    <!-- Accept null pointer exception if caller passes an invalid project type -->
-    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
-    <Class name="org.jvnet.hudson.test.MockFolder"/> -->
-    <Method name="createProject"/>
-  </Match>
   <!--
     Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
     on this section, pick an exclusion to triage, then:

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -73,6 +73,12 @@
     <Class name="org.jvnet.hudson.test.RestartableJenkinsRule"/>
     <Field name="j"/>
   </Match>
+  <Match>
+    <!-- Accept null pointer exception if caller passes an invalid project type -->
+    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    <Class name="org.jvnet.hudson.test.MockFolder"/> -->
+    <Method name="createProject"/>
+  </Match>
   <!--
     Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
     on this section, pick an exclusion to triage, then:


### PR DESCRIPTION
## Accept NPE in MockFolder.createProject() if wrong job type is passed

The null pointer exception will happen when the test is run and will be an immediate sign to the developer that there is a mistake in the caller.

Detected while prototyping an upgrade of the minimum Jenkins version from 2.361.4 to 2.401.3.  Message is not reported with 2.361.4 as Jenkins minimum version but is reported with Jenkins 2.387.3 or later.

### Testing done

Confirmed that warning is visible when `jenkins.version` is 2.387.3 or higher before this change.  Confirmed that warning is suppressed after this change.  Confirmed that automated tests pass before and after the exclusion was added.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
