### PR TITLE
`TailLog` closer to real time

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TailLog.java
+++ b/src/main/java/org/jvnet/hudson/test/TailLog.java
@@ -112,7 +112,7 @@ public final class TailLog implements AutoCloseable {
                     finished.release();
                 }
             }
-        });
+        }, 50);
     }
 
     public void waitForCompletion() throws InterruptedException {


### PR DESCRIPTION
The default check time for `Tailer` is 1s. For tests where typically only one or a few files are being tailed, so performance is unimportant, we would prefer something closer to real time so build log lines appear closer to related system log messages. Compare https://github.com/jenkinsci/jenkins-test-harness/blob/fafaf2080a058b49d95c2dbf6f63d93e99ad50d6/src/main/java/org/jvnet/hudson/test/BuildWatcher.java#L60-L67 and to a lesser extent https://github.com/jenkinsci/jenkins-test-harness/blob/fafaf2080a058b49d95c2dbf6f63d93e99ad50d6/src/main/java/org/jvnet/hudson/test/JenkinsRule.java#L1627-L1632