### PR TITLE
Clearer handling of test timeout during step

### DIFF
--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -333,8 +333,16 @@ public class RealJenkinsRuleTest {
         assumeThat("oops", 2 + 2, is(5));
     }
 
-    // TODO interesting scenarios to test:
-    // · throw an exception of a type defined in Jenkins code
-    // · run with optional dependencies disabled
+    @Test
+    public void timeoutDuringStep() throws Throwable {
+        rr.withTimeout(10);
+        assertThat(Functions.printThrowable(assertThrows(RealJenkinsRule.StepException.class, () -> rr.then(RealJenkinsRuleTest::hangs))),
+            containsString("\tat " + RealJenkinsRuleTest.class.getName() + ".hangs(RealJenkinsRuleTest.java:"));
+    }
+
+    private static void hangs(JenkinsRule r) throws Throwable {
+        System.err.println("Hanging step…");
+        Thread.sleep(Long.MAX_VALUE);
+    }
 
 }


### PR DESCRIPTION
If a test times out while waiting for a step to complete (typically a step which waits indefinitely for some condition), you would get a weird HTTP-level error as the test failure, and have to dig into other logs to actually see what happened. New test case without fix:

```
java.lang.AssertionError: unexpected exception type thrown; expected:<org.jvnet.hudson.test.RealJenkinsRule.StepException> but was:<java.net.ConnectException>
	at org.junit.Assert.assertThrows(Assert.java:1020)
	at org.junit.Assert.assertThrows(Assert.java:981)
	at org.jvnet.hudson.test.RealJenkinsRuleTest.timeoutDuringStep(RealJenkinsRuleTest.java:339)
Caused by: java.net.ConnectException: Connection refused (Connection refused)
	at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.base/java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:412)
	at java.base/java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:255)
	at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:237)
	at java.base/java.net.Socket.connect(Socket.java:609)
	at java.base/java.net.Socket.connect(Socket.java:558)
	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:182)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:509)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:604)
	at java.base/sun.net.www.http.HttpClient.parseHTTPHeader(HttpClient.java:910)
	at java.base/sun.net.www.http.HttpClient.parseHTTP(HttpClient.java:724)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1615)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1520)
	at org.jvnet.hudson.test.RealJenkinsRule.runRemotely(RealJenkinsRule.java:929)
	at org.jvnet.hudson.test.RealJenkinsRule.then(RealJenkinsRule.java:661)
	at org.jvnet.hudson.test.RealJenkinsRule.then(RealJenkinsRule.java:652)
	at org.jvnet.hudson.test.RealJenkinsRuleTest.lambda$timeoutDuringStep$7(RealJenkinsRuleTest.java:339)
	at org.junit.Assert.assertThrows(Assert.java:1001)
	... 4 more
```

With the fix, the test gets a clean failure:

```
java.lang.InterruptedException: sleep interrupted
	at java.base/java.lang.Thread.sleep(Native Method)
	at org.jvnet.hudson.test.RealJenkinsRuleTest.hangs(RealJenkinsRuleTest.java:345)
	at org.jvnet.hudson.test.RealJenkinsRule$StepsToStep2.run(RealJenkinsRule.java:1350)
	at org.jvnet.hudson.test.RealJenkinsRule$Endpoint.lambda$doStep$0(RealJenkinsRule.java:1265)
Caused: org.jvnet.hudson.test.RealJenkinsRule$StepException: Remote step threw an exception
	at org.jvnet.hudson.test.RealJenkinsRule.runRemotely(RealJenkinsRule.java:931)
	at org.jvnet.hudson.test.RealJenkinsRule.then(RealJenkinsRule.java:661)
	at org.jvnet.hudson.test.RealJenkinsRule.then(RealJenkinsRule.java:652)
	at org.jvnet.hudson.test.RealJenkinsRuleTest.lambda$timeoutDuringStep$7(RealJenkinsRuleTest.java:339)
	at org.junit.Assert.assertThrows(Assert.java:1001)
	at org.junit.Assert.assertThrows(Assert.java:981)
	at org.jvnet.hudson.test.RealJenkinsRuleTest.timeoutDuringStep(RealJenkinsRuleTest.java:339)
```
