### PR TITLE
Enable fetch polyfill in search method

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -787,7 +787,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      * Performs a search from the search box.
      */
     protected Page search(String q) throws Exception {
-        return new WebClient().search(q);
+        return createWebClient().search(q);
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1321,7 +1321,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * Performs a search from the search box.
      */
     public Page search(String q) throws Exception {
-        return new WebClient().search(q);
+        return createWebClient().search(q);
     }
 
     /**


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

see https://github.com/jenkinsci/jenkins/pull/9148#issuecomment-2049412794

I've searched the repository for other issues with this pattern but there's no others

https://github.com/timja/jenkins-test-harness/blob/d8347b0b5778efb5a5121e2df878b35f7bb94e39/src/main/java/org/jvnet/hudson/test/JenkinsRule.java#L2329-L2333

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
