### PR TITLE
Inline `ContextHandler.MAX_FORM_CONTENT_SIZE_KEY`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -147,7 +147,6 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.security.Password;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.Configuration;
@@ -1800,7 +1799,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         });
 
         // remove the upper bound of the POST data size in Jetty.
-        System.setProperty(ContextHandler.MAX_FORM_CONTENT_SIZE_KEY, "-1");
+        System.setProperty("org.eclipse.jetty.server.Request.maxFormContentSize", "-1");
     }
 
     private static final Logger LOGGER = Logger.getLogger(HudsonTestCase.class.getName());

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2969,7 +2969,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         });
 
         // remove the upper bound of the POST data size in Jetty.
-        System.setProperty(ContextHandler.MAX_FORM_CONTENT_SIZE_KEY, "-1");
+        System.setProperty("org.eclipse.jetty.server.Request.maxFormContentSize", "-1");
     }
 
     private static final Logger LOGGER = Logger.getLogger(HudsonTestCase.class.getName());


### PR DESCRIPTION
Jetty 10:

```
jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
145:    public static final String MAX_FORM_CONTENT_SIZE_KEY = "org.eclipse.jetty.server.Request.maxFormContentSize";
```

Jetty 12:

```
jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
42:    public static final String MAX_LENGTH_ATTRIBUTE = "org.eclipse.jetty.server.Request.maxFormContentSize";
```

As you can see, the string is the same, but now lives in `FormFields.MAX_LENGTH_ATTRIBUTE` rather than `ContextHandler.MAX_FORM_CONTENT_SIZE_KEY`.

To prepare ourselves for the transition, simplest just to inline the string so that we aren't depending on any particular calling convention.

### Testing done

`mvn clean install -DskipTests`