### PR TITLE
Deprecate `MIME_TYPES`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -556,7 +556,6 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         context.addBean(new NoListenerConfiguration(context));
         server.setHandler(context);
         JettyWebSocketServletContainerInitializer.configure(context, null);
-        context.setMimeTypes(MIME_TYPES);
         context.getSecurityHandler().setLoginService(configureUserRealm());
 
         ServerConnector connector = new ServerConnector(server);
@@ -1812,6 +1811,10 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      */
     public static int SLAVE_DEBUG_PORT = Integer.getInteger(HudsonTestCase.class.getName()+".slaveDebugPort",-1);
 
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
     public static final MimeTypes MIME_TYPES = new MimeTypes();
     static {
         MIME_TYPES.addMimeMapping("js","text/javascript");

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -861,7 +861,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         context.addBean(new NoListenerConfiguration(context));
         server.setHandler(context);
         JettyWebSocketServletContainerInitializer.configure(context, null);
-        context.setMimeTypes(MIME_TYPES);
         context.getSecurityHandler().setLoginService(loginServiceSupplier.get());
         context.setResourceBase(WarExploder.getExplodedDir().getPath());
 
@@ -2981,6 +2980,10 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      */
     public static final int SLAVE_DEBUG_PORT = Integer.getInteger(HudsonTestCase.class.getName()+".slaveDebugPort",-1);
 
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
     public static final MimeTypes MIME_TYPES;
     static {
         jettyLevel(Level.WARNING); // suppress Log.initialize message


### PR DESCRIPTION
This code wasn't actually necessary, as demonstrated by the fact that the new test passes both with and without the changes to `src/main`. And since it would otherwise need to change for Jetty 12, simplest to delete it rather than adapt it for Jetty 12. This PR begins the process by deprecating it and removing consumption from this repository. A GitHub code search shows that there are a handful of consumers that aren't doing anything interesting. I will file some PRs to adapt the ones in `jenkinsci/`.

### Testing done

New test passes both with and without the changes to `src/main`.