### PR TITLE
Remove unnecessary workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,12 +132,7 @@ THE SOFTWARE.
       <groupId>org.eclipse.jetty.websocket</groupId>
       <!-- or websocket-javax-server -->
       <artifactId>websocket-jetty-server</artifactId>
-      <!-- until Jetty release including https://github.com/eclipse/jetty.project/pull/8199 -->
       <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-annotations</artifactId>
-        </exclusion>
         <!-- Provided by Jenkins core -->
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
https://github.com/jetty/jetty.project/pull/8199 was replaced by https://github.com/jetty/jetty.project/pull/10316, which shipped in Jetty 10.0.16. We're now on 10.0.20, so this workaround can be removed.

### Testing done

`mvn clean verify -Dtest=org.jvnet.hudson.test.JenkinsRuleTest`