### PR TITLE
Avoid usage of `Server#getChildHandlerByClass`

### DIFF
--- a/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
@@ -15,7 +15,7 @@ import javax.servlet.ServletContext;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.webapp.WebAppContext;
 import org.jvnet.hudson.test.JavaNetReverseProxy;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
@@ -93,15 +93,15 @@ public abstract class JmhBenchmarkState implements RootAction {
     }
 
     private void launchInstance() throws Exception {
-        server = JenkinsRule._createWebServer(
+        WebAppContext context = JenkinsRule._createWebAppContext(
                 contextPath,
                 localPort::set,
                 getClass().getClassLoader(),
                 localPort.get(),
                 JenkinsRule::_configureUserRealm);
+        server = context.getServer();
 
-        ServletContext webServer =
-                server.getChildHandlerByClass(ContextHandler.class).getServletContext();
+        ServletContext webServer = context.getServletContext();
 
         jenkins = new Hudson(temporaryDirectoryAllocator.allocate(), webServer, TestPluginManager.INSTANCE);
         JenkinsRule._configureJenkinsForTest(jenkins);

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -183,7 +183,6 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.security.Password;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.Configuration;
@@ -800,15 +799,16 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      */
     protected ServletContext createWebServer(@CheckForNull BiConsumer<WebAppContext, Server> contextAndServerConsumer)
             throws Exception {
-        server = _createWebServer(
+        WebAppContext context = _createWebAppContext(
                 contextPath,
                 (x) -> localPort = x,
                 getClass().getClassLoader(),
                 localPort,
                 this::configureUserRealm,
                 contextAndServerConsumer);
+        server = context.getServer();
         LOGGER.log(Level.INFO, "Running on {0}", getURL());
-        return server.getChildHandlerByClass(ContextHandler.class).getServletContext();
+        return context.getServletContext();
     }
 
     /**
@@ -822,14 +822,14 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * @return                     the {@link Server}
      * @since 2.50
      */
-    public static Server _createWebServer(
+    public static WebAppContext _createWebAppContext(
             String contextPath,
             Consumer<Integer> portSetter,
             ClassLoader classLoader,
             int localPort,
             Supplier<LoginService> loginServiceSupplier)
             throws Exception {
-        return _createWebServer(contextPath, portSetter, classLoader, localPort, loginServiceSupplier, null);
+        return _createWebAppContext(contextPath, portSetter, classLoader, localPort, loginServiceSupplier, null);
     }
     /**
      * Creates a web server on which Jenkins can run
@@ -843,7 +843,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * @return                         the {@link Server}
      * @since 2.50
      */
-    public static Server _createWebServer(
+    public static WebAppContext _createWebAppContext(
             String contextPath,
             Consumer<Integer> portSetter,
             ClassLoader classLoader,
@@ -886,7 +886,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
         portSetter.accept(connector.getLocalPort());
 
-        return server;
+        return context;
     }
 
     /**


### PR DESCRIPTION
Jetty 12 has removed the `Server#getChildHandlerByClass` method, but with some simple refactoring we can avoid having to call this method by returning a different object type, and this refactoring can be merged today on Jetty 10. Even though this looks like it's changing a public API, it's really not, since it begins with an underscore and is only used elsewhere in the test harness, and it's only public to be accessible by a different package.

### Testing done

`mvn clean verify -DskipTests`