### PR TITLE
[JENKINS-73124] Remove `MIME_TYPES`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -138,7 +138,6 @@ import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.eclipse.jetty.http.HttpCompliance;
-import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.LoginService;
@@ -1811,13 +1810,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      */
     public static int SLAVE_DEBUG_PORT = Integer.getInteger(HudsonTestCase.class.getName()+".slaveDebugPort",-1);
 
-    /**
-     * @deprecated removed without replacement
-     */
-    @Deprecated
-    public static final MimeTypes MIME_TYPES = new MimeTypes();
     static {
-        MIME_TYPES.addMimeMapping("js","text/javascript");
         Functions.DEBUG_YUI = true;
 
         if (Functions.isGlibcSupported()) {

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -170,11 +170,9 @@ import jenkins.security.ApiTokenProperty;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSON;
 import net.sf.json.JSONObject;
-import org.acegisecurity.GrantedAuthorityImpl;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jetty.http.HttpCompliance;
-import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.LoginService;
@@ -246,7 +244,6 @@ import org.kohsuke.stapler.MetaClassLoader;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
-import org.springframework.dao.DataAccessException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
@@ -2981,19 +2978,8 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      */
     public static final int SLAVE_DEBUG_PORT = Integer.getInteger(HudsonTestCase.class.getName()+".slaveDebugPort",-1);
 
-    /**
-     * @deprecated removed without replacement
-     */
-    @Deprecated
-    public static final MimeTypes MIME_TYPES;
     static {
-        jettyLevel(Level.WARNING); // suppress Log.initialize message
-        try {
-            MIME_TYPES = new MimeTypes();
-        } finally {
-            jettyLevel(Level.INFO);
-        }
-        MIME_TYPES.addMimeMapping("js","text/javascript");
+        jettyLevel(Level.INFO);
         Functions.DEBUG_YUI = true;
 
         if (Functions.isGlibcSupported()) {


### PR DESCRIPTION
The last significant usage of this is in https://github.com/jenkinsci/kubernetes-pipeline-plugin/pull/97, but that plugin seems to be abandoned. Either way, a PR exists, so if and when that plugin is brought back to life, it should be easy to adapt to this removal.

### Testing done

`mvn clean verify`