### PR TITLE
IPV6 follow-up

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -185,7 +185,7 @@ public final class RealJenkinsRule implements TestRule {
 
     private int timeout = Integer.getInteger("jenkins.test.timeout", new DisableOnDebug(null).isDebugging() ? 0 : 600);
 
-    private String host = httpListenAddress;
+    private String host = "localhost";
 
     Process proc;
 
@@ -292,13 +292,13 @@ public final class RealJenkinsRule implements TestRule {
 
     /**
      * Sets a custom host name for the Jenkins root URL.
-     * <p>By default, this is the same as the {@link #httpListenAddress}.
-     * But you may wish to set it to something else that resolves to the loopback address,
+     * <p>By default, this is just {@code localhost}.
+     * But you may wish to set it to something else that resolves to localhost,
      * such as {@code some-id.127.0.0.1.nip.io}.
      * This is particularly useful when running multiple copies of Jenkins (and/or other services) in one test case,
      * since browser cookies are sensitive to host but not port and so otherwise {@link HttpServletRequest#getSession}
      * might accidentally be shared across otherwise distinct services.
-     * <p>Calling this method does <em>not</em> change the fact that Jenkins will be configured to listen only on the loopback address for security reasons
+     * <p>Calling this method does <em>not</em> change the fact that Jenkins will be configured to listen only on localhost for security reasons
      * (so others in the same network cannot access your system under test, especially if it lacks authentication).
      */
     public RealJenkinsRule withHost(String host) {

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleTest.java
@@ -27,6 +27,7 @@ package org.jvnet.hudson.test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -53,6 +54,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicReference;
@@ -90,6 +93,14 @@ public class RealJenkinsRuleTest {
     @Test public void testReturnObject() throws Throwable {
         rr.startJenkins();
         assertEquals(rr.getUrl().toExternalForm(), rr.runRemotely(RealJenkinsRuleTest::_getJenkinsUrlFromRemote));
+    }
+
+    @Test public void ipv6() throws Throwable {
+        // Use -Djava.net.preferIPv6Addresses=true if dualstack
+        assumeThat(InetAddress.getLoopbackAddress(), instanceOf(Inet6Address.class));
+        rr.withHost("::1").startJenkins();
+        var externalForm = rr.getUrl().toExternalForm();
+        assertEquals(externalForm, rr.runRemotely(RealJenkinsRuleTest::_getJenkinsUrlFromRemote));
     }
 
     @Test public void testThrowsException() {


### PR DESCRIPTION
Reverts part of #742

Only leaves the relevant part which was to switch to the URL(String,String,String,String) constructor.

The change from localhost to ip caused some test failures in Kubernetes context (It is invalid to provide an IP address as part of an ingress host name)

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
