### PR TITLE
Backport "Bump org.jenkins-ci.main:jenkins-test-harness-htmlunit from 182.v85fe4a_4ee4f0 to 183.v9742e5ca_c784"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness-htmlunit</artifactId>
-      <version>182.v85fe4a_4ee4f0</version>
+      <version>183.v9742e5ca_c784</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>


### PR DESCRIPTION
Backports #790 to the 2225.x (Java 11) branch.

### Testing done

The upgrade seems to be working fine on Jenkins core (on both the Jetty 12 EE 8 and EE 9 branches).