### PR TITLE
Unfork EE 8 servlet API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,11 +118,6 @@ THE SOFTWARE.
       <version>1.2</version>
     </dependency>
     <dependency>
-      <groupId>io.jenkins.servlet</groupId>
-      <artifactId>javax-servlet-api</artifactId>
-      <version>4.0.9</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
@@ -141,11 +136,6 @@ THE SOFTWARE.
       <groupId>org.eclipse.jetty.ee8</groupId>
       <artifactId>jetty-ee8-webapp</artifactId>
       <exclusions>
-        <!-- Provided by io.jenkins.servlet:javax-servlet-api -->
-        <exclusion>
-          <groupId>org.eclipse.jetty.toolchain</groupId>
-          <artifactId>jetty-servlet-api</artifactId>
-        </exclusion>
         <!-- Provided by Jenkins core -->
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -162,11 +152,6 @@ THE SOFTWARE.
         <exclusion>
           <groupId>jakarta.annotation</groupId>
           <artifactId>jakarta.annotation-api</artifactId>
-        </exclusion>
-        <!-- Provided by io.jenkins.servlet:javax-servlet-api -->
-        <exclusion>
-          <groupId>org.eclipse.jetty.toolchain</groupId>
-          <artifactId>jetty-servlet-api</artifactId>
         </exclusion>
         <!-- Provided by Jenkins core -->
         <exclusion>


### PR DESCRIPTION
As of recent revisions of this patch set, I have moved EE 8 compatibility logic out of the EE 8 classes themselves and (back) into Stapler, so this code can be simplified.