### PR TITLE
Update Jetty from 10.0.21 to 10.0.22 on Java 11 branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.116</version>
+    <version>1.119</version>
     <relativePath />
   </parent>
 
@@ -70,7 +70,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Might as well keep this branch current as long as it is still getting updates.

### Testing done

Winstone tests for 10.0.22 passed already.