### PR TITLE
Improve exception readability in case a directory can't be deleted because it still contains files

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
@@ -36,6 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Allocates temporary directories and cleans it up at the end.
@@ -140,9 +141,11 @@ public class TemporaryDirectoryAllocator {
             }
             Files.deleteIfExists(p);
         } catch (DirectoryNotEmptyException x) {
+            String pathString = p.toString();
             try (Stream<Path> children = Files.list(p)) {
-                throw new IOException(children.map(Path::toString).collect(Collectors.joining(" ")), x);
+                x.addSuppressed(new IOException("These files still exist : " + children.map(Path::toString).map(s -> StringUtils.removeStart(s, pathString + File.separator)).collect(Collectors.joining(", "))));
             }
+            throw x;
         }
     }
 


### PR DESCRIPTION
Found this while investigating a test flake report and realized the current reported exception was a bit confusing.

So, proposing this:

Use suppressed exceptions rather than wrap the exception so that we get the primary cause first, then details.

Also resolve files relative to their containing folders.

Before:

```
java.io.IOException: [REDACTED]/target/tmp/j h16565971146678333138/users/Fred_10744520479289247763/config.xml
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:144)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.dispose(TemporaryDirectoryAllocator.java:99)
	at org.jvnet.hudson.test.TestEnvironment.dispose(TestEnvironment.java:84)
	at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:527)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:665)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.nio.file.DirectoryNotEmptyException: [REDACTED]/target/tmp/j h16565971146678333138/users/Fred_10744520479289247763
	at java.base/sun.nio.fs.UnixFileSystemProvider.implDelete(UnixFileSystemProvider.java:246)
	at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
	at java.base/java.nio.file.Files.deleteIfExists(Files.java:1191)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:141)
	... 8 more
```

After:

```
java.nio.file.DirectoryNotEmptyException: [REDACTED]/target/tmp/j h16565971146678333138/users/Fred_10744520479289247763
        at java.base/sun.nio.fs.UnixFileSystemProvider.implDelete(UnixFileSystemProvider.java:289)
        at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:109)
        at java.base/java.nio.file.Files.deleteIfExists(Files.java:1191)
        at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:142)
        at org.jvnet.hudson.test.TemporaryDirectoryAllocator.dispose(TemporaryDirectoryAllocator.java:100)
        at org.jvnet.hudson.test.TestEnvironment.dispose(TestEnvironment.java:84)
        at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:586)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:724)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.lang.Thread.run(Thread.java:1583)
        Suppressed: java.io.IOException: These files still exist : config.xml
                at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:146)
                ... 6 more
```

Manually tested with the following patch to produce non-empty directories.

```diff
Index: src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java	(revision 3b5659834a066c27a991c742649d976b535dc18a)
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java	(date 1723541060918)
@@ -126,13 +126,6 @@
 
     private void delete(Path p) throws IOException {
         LOGGER.fine(() -> "deleting " + p);
-        if (Files.isDirectory(p, LinkOption.NOFOLLOW_LINKS)) {
-            try (DirectoryStream<Path> children = Files.newDirectoryStream(p)) {
-                for (Path child : children) {
-                    delete(child);
-                }
-            }
-        }
         try {
             if (isWindows()) {
                 // Windows throws an access denied exception when deleting read-only files

```

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
