### PR TITLE
Decouple `InboundAgentRule.Options.name` from `-jnlpUrl`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -42,6 +42,7 @@ import hudson.util.VersionNumber;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,6 +54,7 @@ import java.util.UUID;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.util.JavaEnvUtils;
 import org.junit.rules.ExternalResource;
@@ -331,10 +333,11 @@ public final class InboundAgentRule extends ExternalResource {
             cmd.add("Xrunjdwp:transport=dt_socket,server=y,address=" + (JenkinsRule.SLAVE_DEBUG_PORT + agentArguments.numberOfNodes - 1));
         }
         cmd.addAll(List.of("-jar", agentArguments.agentJar.getAbsolutePath()));
-        if (agentArguments.agentJnlpUrl.endsWith("computer/" + options.getName() + "/slave-agent.jnlp") && remotingVersion(agentArguments.agentJar).isNewerThanOrEqualTo(new VersionNumber("3186.vc3b_7249b_87eb_"))) {
-            cmd.addAll(List.of("-url", agentArguments.agentJnlpUrl.replaceAll("computer/" + options.getName() + "/slave-agent.jnlp$", "")));
+        var m = Pattern.compile("(.+)computer/([^/]+)/slave-agent[.]jnlp").matcher(agentArguments.agentJnlpUrl);
+        if (m.matches() && remotingVersion(agentArguments.agentJar).isNewerThanOrEqualTo(new VersionNumber("3186.vc3b_7249b_87eb_"))) {
+            cmd.addAll(List.of("-url", m.group(1)));
             cmd.addAll(List.of("-secret", agentArguments.secret));
-            cmd.addAll(List.of("-name", options.getName()));
+            cmd.addAll(List.of("-name", URI.create(m.group(2)).getPath()));
             if (options.isWebSocket()) {
                 cmd.add("-webSocket");
             }


### PR DESCRIPTION
For some purposes in CloudBees CI it is necessary to run multiple agent processes with the same `-name`. This was not possible because `InboundAgentRule.start` presumed that the `Options.name` was in fact the URL component of the deprecated `-jnlpUrl`, and also treated `Options.name` as a unique key for purposes of process management.