### PR TITLE
Avoid calling `Jenkins.setNoUsageStatistics` unless necessary

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -1345,7 +1345,9 @@ public final class RealJenkinsRule implements TestRule {
         public CustomJenkinsRule(URL url) throws Exception {
             this.jenkins = Jenkins.get();
             this.url = url;
-            jenkins.setNoUsageStatistics(true); // cannot use JenkinsRule._configureJenkinsForTest earlier because it tries to save config before loaded
+            if (jenkins.isUsageStatisticsCollected()) {
+                jenkins.setNoUsageStatistics(true); // cannot use JenkinsRule._configureJenkinsForTest earlier because it tries to save config before loaded
+            }
             if (JenkinsLocationConfiguration.get().getUrl() == null) {
                 JenkinsLocationConfiguration.get().setUrl(url.toExternalForm());
             }


### PR DESCRIPTION
Unlike the situation in #512, this call was a no-op after the first step, yet [the implementation](https://github.com/jenkinsci/jenkins/blob/3767f78ae32b0170089d3537039d31f89a6441c9/core/src/main/java/jenkins/model/Jenkins.java#L1475) still saved `$JENKINS_HOME/config.xml`, causing churn and noise. (Extracted from #827.)