### PR TITLE
Do not let `TailLog.waitForCompletion` block forever

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/TailLog.java
+++ b/src/main/java/org/jvnet/hudson/test/TailLog.java
@@ -32,8 +32,10 @@ import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.input.Tailer;
 import org.apache.commons.io.input.TailerListenerAdapter;
+import static org.junit.Assert.assertTrue;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
@@ -116,7 +118,7 @@ public final class TailLog implements AutoCloseable {
     }
 
     public void waitForCompletion() throws InterruptedException {
-        finished.acquire();
+        assertTrue(finished.tryAcquire(1, TimeUnit.MINUTES));
     }
 
     @Override


### PR DESCRIPTION
The symptom of #835 is a test case hanging _forever_, despite other timeouts such as in `RealJenkinsRule`. `waitForCompletion` is designed just to capture any final log output after a test has already asserted build completion with status, so it should time out. (Extracted from #827.)