### PR TITLE
Try using `forkCount`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
  * easy Linux/Windows testing and produces incrementals. The only feature that relates to plugins is
  * allowing one to test against multiple Jenkins versions.
  */
-buildPlugin(useContainerAgent: true, configurations: [
+buildPlugin(useContainerAgent: true, forkCount: '1C', configurations: [
   [platform: 'linux', jdk: 17],
   [platform: 'windows', jdk: 17],
   [platform: 'linux', jdk: 21, jenkins: '2.477']


### PR DESCRIPTION
https://ci.jenkins.io/job/Core/job/jenkins-test-harness/job/PR-837/1/ took 12m vs. https://ci.jenkins.io/job/Core/job/jenkins-test-harness/job/master/764/ 24m. If you just measure the `mvn` commands, so setting aside build queue time and so forth, 4.5m Linux / 9m Win vs. previous 8.5m / 19m. Either way, seems to make CI roughly twice as fast.