### PR TITLE
Generalize catch to `SocketException`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -51,10 +51,10 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
-import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -933,8 +933,8 @@ public final class RealJenkinsRule implements TestRule {
             if (_proc.isAlive()) {
                 try {
                     endpoint("exit").openStream().close();
-                } catch (ConnectException e) {
-                    System.err.println("Unable to connect to the Jenkins process to stop it.");
+                } catch (SocketException e) {
+                    System.err.println("Unable to connect to the Jenkins process to stop it: " + e);
                 }
             } else {
                 System.err.println("Jenkins process was already terminated.");


### PR DESCRIPTION
Amending #613 due to apparent flake in #838 https://github.com/jenkinsci/jenkins-test-harness/pull/838/checks?check_run_id=30338002288

```
java.net.SocketException: Connection reset
```
