### PR TITLE
Revert `WithPluginManager` constructor behavior

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/recipes/WithPluginManager.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/WithPluginManager.java
@@ -90,7 +90,7 @@ public @interface WithPluginManager {
         public void decorateHome(JenkinsRule jenkinsRule, File home) throws Exception {
             Class<? extends PluginManager> c = recipe.value();
             Constructor<? extends PluginManager> ctr = c.getDeclaredConstructor(File.class);
-            jenkinsRule.setPluginManager(ctr.newInstance(new File(home, "plugins")));
+            jenkinsRule.setPluginManager(ctr.newInstance(home));
         }
     }
 }


### PR DESCRIPTION
Reverting https://github.com/jenkinsci/jenkins-test-harness/pull/838#discussion_r1765579500 as it seems to cause a regression I do not understand in `hudson.PluginManagerTest.uberClassLoaderIsAvailableDuringStart`. The nature of the `rootDir` parameter passed reflectively is undocumented generally, but `LocalPluginManager` expects it to be `$JENKINS_HOME` not `$JENKINS_HOME/plugins`.