### PR TITLE
Revert "Bump org.jenkins-ci:jenkins from 1.122 to 1.123"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.123</version>
+    <version>1.122</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Reverts jenkinsci/jenkins-test-harness#844

Currently stumped by a JTH release failure. https://github.com/jenkinsci/jenkins-test-harness/actions/runs/11060243118/job/30730386885 complains about missing `org.jenkins-ci.main:jenkins-war:executable-war:2.476`. Indeed https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/2.476/ only has `jenkins-war-2.476.war` but that is by design; https://github.com/jenkinsci/maven-hpi-plugin/pull/65 + https://github.com/jenkinsci/jenkins-test-harness/pull/61 are supposed to look up the `*.war` and just add it to the Java classpath. https://github.com/jenkinsci/jenkins-test-harness/actions/runs/10966208526/job/30453668284 worked normally just a few days ago (using the same versions of Maven and Java), and the only POM change since then is https://github.com/jenkinsci/jenkins-test-harness/pull/844 which… hmm, https://github.com/jenkinsci/pom/releases/tag/jenkins-1.123 does not mention it but https://github.com/jenkinsci/pom/compare/jenkins-1.122...jenkins-1.123 does show this including https://github.com/jenkinsci/pom/pull/608 with a lot of changes in https://github.com/jenkinsci/maven-hpi-plugin/releases/tag/maven-hpi-plugin-3.58 like https://github.com/jenkinsci/maven-hpi-plugin/pull/649 which might be causing trouble somehow?

I failed to reproduce any problem locally with

```bash
docker run -ti --rm --name mvn -u $(id -u):$(id -g) -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven maven:3-eclipse-temurin-17 mvn -Duser.home=/tmp clean compile
```