### PR TITLE
Deleting orphaned `index.jelly` from `RealJenkinsRuleInit`

### DIFF
--- a/RealJenkinsRuleInit/src/main/resources/index.jelly
+++ b/RealJenkinsRuleInit/src/main/resources/index.jelly
@@ -1,4 +1,0 @@
-<?jelly escape-by-default='true'?>
-<div>
-    RealJenkinsRule initialization wrapper
-</div>


### PR DESCRIPTION
Apparently forgotten in #782.