### PR TITLE
Add a new method to force shutdown a RealJenkinsRule instance

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -1156,6 +1156,19 @@ public final class RealJenkinsRule implements TestRule {
     }
 
     /**
+     * Stops Jenkins abruptly, without giving it a chance to shut down cleanly.
+     * If Jenkins is already stopped then invoking this method has no effect.
+     */
+    public void stopJenkinsForcibly() {
+        if (proc != null) {
+            var _proc = proc;
+            proc = null;
+            System.err.println("Killing the Jenkins process as requested");
+            _proc.destroyForcibly();
+        }
+    }
+
+    /**
      * Runs one or more steps on the remote system.
      * (Compared to multiple calls, passing a series of steps is slightly more efficient
      * as only one network call is made.)


### PR DESCRIPTION
I need to simulate a hard shutdown, without executing the usual Jenkins clean up sequence.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
