### PR TITLE
Provide Hamcrest matchers as alternatives to built-in JenkinsRule run assertions

### DIFF
--- a/src/main/java/jenkins/test/RunMatchers.java
+++ b/src/main/java/jenkins/test/RunMatchers.java
@@ -60,6 +60,13 @@ public final class RunMatchers {
         return new RunLogMatcher(message);
     }
 
+    /**
+     * Creates a matcher checking whether a build has completed.
+     */
+    public static Matcher<Run<?,?>> completed() {
+        return new CompletedRunMatcher();
+    }
+
     private static class RunResultMatcher extends TypeSafeMatcher<Run<?,?>> {
         @NonNull
         private final Result expectedResult;
@@ -114,6 +121,18 @@ public final class RunMatchers {
         @Override
         public void describeTo(Description description) {
             description.appendText("log containing ").appendValue(message);
+        }
+    }
+
+    private static class CompletedRunMatcher extends TypeSafeMatcher<Run<?, ?>> {
+        @Override
+        protected boolean matchesSafely(Run<?, ?> run) {
+            return !run.isLogUpdated();
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("a completed build");
         }
     }
 }

--- a/src/main/java/jenkins/test/RunMatchers.java
+++ b/src/main/java/jenkins/test/RunMatchers.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.test;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Result;
+import hudson.model.Run;
+import java.io.IOException;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Matchers for {@link Run} objects.
+ */
+public final class RunMatchers {
+    private RunMatchers() {}
+
+    /**
+     * Creates a matcher checking whether a build is successful.
+     */
+    public static Matcher<Run<?,?>> isSuccessful() {
+        return new RunResultMatcher(Result.SUCCESS);
+    }
+
+    /**
+     * Creates a matcher checking whether a build has a specific outcome.
+     */
+    public static Matcher<Run<?,?>> hasStatus(Result result) {
+        return new RunResultMatcher(result);
+    }
+
+    /**
+     * Creates a matcher checking whether build logs contain a specific message.
+     * @param message the expected message
+     */
+    public static Matcher<Run<?,?>> logContains(String message) {
+        return new RunLogMatcher(message);
+    }
+
+    private static class RunResultMatcher extends TypeSafeMatcher<Run<?,?>> {
+        @NonNull
+        private final Result expectedResult;
+
+        public RunResultMatcher(@NonNull Result expectedResult) {
+            this.expectedResult = expectedResult;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("a build with result " + expectedResult);
+        }
+
+        @Override
+        protected boolean matchesSafely(Run run) {
+            return run.getResult() == expectedResult;
+        }
+
+        @Override
+        protected void describeMismatchSafely(Run<?, ?> item, Description mismatchDescription) {
+            mismatchDescription.appendText("was ").appendValue(item.getResult());
+        }
+    }
+
+    private static class RunLogMatcher extends TypeSafeMatcher<Run<?, ?>> {
+        @NonNull
+        private final String message;
+
+        private RunLogMatcher(@NonNull String message) {
+            this.message = message;
+        }
+
+        @Override
+        protected boolean matchesSafely(Run<?, ?> run) {
+            try {
+                return JenkinsRule.getLog(run).contains(message);
+            } catch (IOException x) {
+                return false;
+            }
+        }
+
+        @Override
+        protected void describeMismatchSafely(Run<?, ?> item, Description mismatchDescription) {
+            mismatchDescription.appendText("was \n");
+            try {
+                mismatchDescription.appendText(JenkinsRule.getLog(item));
+            } catch (IOException e) {
+                mismatchDescription.appendText("<unreadable>");
+            }
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("log containing ").appendValue(message);
+        }
+    }
+}

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1619,6 +1619,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     /**
      * Waits for a build to complete.
      * Useful in conjunction with {@link BuildWatcher}.
+     * <p>
+     * As an alternative, if using <a href="https://github.com/awaitility/awaitility">Awaitibility</a>, you can use {@code await().until(() -> r, RunMatchers.completed());}
+     *
      * @return the same build, once done
      * @since 1.607
      */
@@ -1635,7 +1638,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                 }
             }
         }
-        // Could be using com.jayway.awaitility:awaitility but it seems like overkill here.
         while (r.isLogUpdated()) {
             Thread.sleep(100);
         }

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1509,6 +1509,8 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
     /**
      * Asserts that the outcome of the build is a specific outcome.
+     * <p>
+     * Consider {@link jenkins.test.RunMatchers#hasStatus(Result)} as an alternative.
      */
     public <R extends Run> R assertBuildStatus(Result status, R r) throws Exception {
         if (status == r.getResult()) {
@@ -1583,6 +1585,8 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
     /**
      * Asserts that the console output of the build contains the given substring.
+     * <p>
+     * Consider {@link jenkins.test.RunMatchers#logContains(String)} as an alternative.
      */
     public void assertLogContains(String substring, Run run) throws IOException {
         assertThat(getLog(run), containsString(substring));
@@ -1590,6 +1594,8 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
     /**
      * Asserts that the console output of the build does not contain the given substring.
+     * <p>
+     * Consider {@link org.hamcrest.Matchers#not} and {@link jenkins.test.RunMatchers#logContains(String)} as an alternative.
      */
     public void assertLogNotContains(String substring, Run run) throws IOException {
         assertThat(getLog(run), not(containsString(substring)));

--- a/src/test/java/jenkins/test/RunMatchersTest.java
+++ b/src/test/java/jenkins/test/RunMatchersTest.java
@@ -23,6 +23,7 @@
  */
 package jenkins.test;
 
+import static jenkins.test.RunMatchers.completed;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.not;
@@ -49,7 +50,7 @@ public class RunMatchersTest {
         var p = j.createFreeStyleProject();
         p.getBuildersList().add(new SleepBuilder(1000));
         var b = p.scheduleBuild2(0).waitForStart();
-        assertThat(j.waitForCompletion(b), isSuccessful());
+        assertThat(j.waitForCompletion(b), allOf(completed(), isSuccessful()));
     }
 
     @Test

--- a/src/test/java/jenkins/test/RunMatchersTest.java
+++ b/src/test/java/jenkins/test/RunMatchersTest.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
+import static jenkins.test.RunMatchers.logContains;
+import static jenkins.test.RunMatchers.hasStatus;
+import static jenkins.test.RunMatchers.isSuccessful;
+
+import hudson.Functions;
+import hudson.model.Result;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.FailureBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.SleepBuilder;
+
+public class RunMatchersTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void buildSuccessful() throws Exception {
+        var p = j.createFreeStyleProject();
+        p.getBuildersList().add(new SleepBuilder(1000));
+        var b = p.scheduleBuild2(0).waitForStart();
+        assertThat(j.waitForCompletion(b), isSuccessful());
+    }
+
+    @Test
+    public void buildFailure() throws Exception {
+        var p = j.createFreeStyleProject();
+        p.getBuildersList().add(new FailureBuilder());
+        var b = p.scheduleBuild2(0).waitForStart();
+        assertThat(j.waitForCompletion(b), hasStatus(Result.FAILURE));
+    }
+
+    @Test
+    public void assertThatLogContains() throws Exception {
+        var p = j.createFreeStyleProject();
+        p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo hello") : new Shell("echo hello"));
+        var b = p.scheduleBuild2(0).get();
+        System.out.println(b.getDisplayName() + " completed");
+        assertThat(b, allOf(logContains("echo hello"), not(logContains("echo bye"))));
+    }
+}


### PR DESCRIPTION
Plays nicely with Awaitability as well as in combination with other matchers.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
