### PR TITLE
Deprecating `JenkinsRule.setQuietPeriod`

### DIFF
--- a/src/main/java/jenkins/model/JenkinsAdaptor.java
+++ b/src/main/java/jenkins/model/JenkinsAdaptor.java
@@ -1,8 +1,9 @@
 package jenkins.model;
 
 /**
- * Access the package protected quiet period
+ * @deprecated use {@link Jenkins#setQuietPeriod}
  */
+@Deprecated
 public class JenkinsAdaptor {
     public static void setQuietPeriod(Jenkins jenkins, int quietPeriod) {
         jenkins.quietPeriod = quietPeriod;

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1888,6 +1888,10 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         }
     }
 
+    /**
+     * @deprecated use {@link Jenkins#setQuietPeriod}
+     */
+    @Deprecated
     public void setQuietPeriod(int qp) {
         JenkinsAdaptor.setQuietPeriod(jenkins, qp);
     }


### PR DESCRIPTION
Was apparently necessary as of https://github.com/jenkinsci/jenkins/pull/152 but was superseded a few weeks later by https://github.com/jenkinsci/jenkins/commit/f350227c25edf1d3682ffa2030a2f1e37431a1e6.