### PR TITLE
[JENKINS-75174] Allow webapp context configuration to be discovered via Servlet 3.0 discovery

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -867,7 +867,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             }
         };
         context.setClassLoader(classLoader);
-        context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
+        context.setConfigurationDiscovered(true);
         context.addBean(new NoListenerConfiguration2(context));
         context.setServer(server);
         String compression = System.getProperty("jth.compression", "gzip");


### PR DESCRIPTION
This will allow Jenkins to leverage `web-fragment.xml` and Servlet 3.0 annotations.

[JENKINS-75174](https://issues.jenkins.io/browse/JENKINS-75174)

Downstream change
* https://github.com/jenkinsci/jenkins/pull/10185

### Testing done

Checked that JenkinsRule-based tests still run as expected, and are able to pick up web fragments when defined and allowed by web.xml (e.g. `metadata-complete="false"` or missing)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
