### PR TITLE
[JENKINS-75174] Web fragments support

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -634,7 +634,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         };
         context.setResourceBase(explodedWarDir.getPath());
         context.setClassLoader(getClass().getClassLoader());
-        context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
+        context.setConfigurationDiscovered(true);
         context.addBean(new NoListenerConfiguration2(context));
         context.setServer(server);
         String compression = System.getProperty("jth.compression", "gzip");

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -942,7 +942,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             }
         };
         context.setClassLoader(classLoader);
-        context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
+        context.setConfigurationDiscovered(true);
         context.addBean(new NoListenerConfiguration2(context));
         context.setServer(server);
         String compression = System.getProperty("jth.compression", "gzip");
@@ -1075,7 +1075,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             }
         };
         context.setClassLoader(classLoader);
-        context.setConfigurations(new org.eclipse.jetty.ee8.webapp.Configuration[]{new org.eclipse.jetty.ee8.webapp.WebXmlConfiguration()});
+        context.setConfigurationDiscovered(true);
         context.addBean(new NoListenerConfiguration(context));
         context.setServer(server);
         String compression = System.getProperty("jth.compression", "gzip");


### PR DESCRIPTION
Backporting #905 to the last version before dropping ee8.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
