### PR TITLE
Fixes `@LocalData` when being used on a test method in superclass

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/recipes/LocalData.java
+++ b/src/main/java/org/jvnet/hudson/test/recipes/LocalData.java
@@ -102,7 +102,7 @@ public @interface LocalData {
             Method testMethod;
 
             try {
-                testMethod = desc.getTestClass().getDeclaredMethod(desc.getMethodName());
+                testMethod = desc.getTestClass().getMethod(desc.getMethodName());
             } catch (NoSuchMethodException ex) {
                 testMethod = desc.getTestClass().getDeclaredMethod(desc.getMethodName(), JenkinsRule.class);
             }

--- a/src/test/java/org/jvnet/hudson/test/recipes/LocalDataExtendedTest.java
+++ b/src/test/java/org/jvnet/hudson/test/recipes/LocalDataExtendedTest.java
@@ -1,0 +1,8 @@
+package org.jvnet.hudson.test.recipes;
+
+
+/**
+ * Illustrates a case where a test class extends another test class that has test methods using the LocalData recipe.
+ */
+public class LocalDataExtendedTest extends LocalDataZipTest {
+}


### PR DESCRIPTION
By switching to `getDeclaredMethod` in #900, this broke this use case that is currently exercised in email-ext plugin
(`ScriptContentSecureTest>ScriptContentTest#testTemplateShouldBeLoadedFromTheClosestExistingFolderConfigInTheHierarchyUpToGlobalConfig`)

The provided test breaks without this patch.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
