### PR TITLE
Raise default permissions of `JUnit5JenkinsRule`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/JUnit5JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/JUnit5JenkinsRule.java
@@ -2,6 +2,8 @@ package org.jvnet.hudson.test.junit.jupiter;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.lang.reflect.Method;
+
+import hudson.security.ACL;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.runner.Description;
@@ -26,6 +28,9 @@ class JUnit5JenkinsRule extends JenkinsRule {
 
     @Override
     public void recipe() throws Exception {
+        // so that test code has all the access to the system
+        ACL.as2(ACL.SYSTEM2);
+
         JenkinsRecipe jenkinsRecipe =
                 context.findAnnotation(JenkinsRecipe.class).orElse(null);
         if (jenkinsRecipe != null) {

--- a/src/test/java/org/jvnet/hudson/test/JenkinsRulePermissionTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRulePermissionTest.java
@@ -1,0 +1,54 @@
+package org.jvnet.hudson.test;
+
+import hudson.security.Permission;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.jupiter.api.Assertions;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Validates that JUnit4 and JUnit5 based {@link JenkinsRule} implementations have the same default authorization and permissions.
+ */
+@SuppressWarnings("deprecation")
+public class JenkinsRulePermissionTest {
+
+    @Rule
+    public JenkinsRule junit4rule = new JenkinsRule();
+
+    @org.junit.Test
+    public void junit4() {
+        MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
+        junit4rule.getInstance().setAuthorizationStrategy(strategy);
+
+        // basic permissions
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.READ));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.WRITE));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.CREATE));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.UPDATE));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.DELETE));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.CONFIGURE));
+
+        // admin permissions
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.FULL_CONTROL));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.HUDSON_ADMINISTER));
+    }
+
+    @org.junit.jupiter.api.Test
+    @WithJenkins
+    void junit5(JenkinsRule junit5rule) {
+        MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
+        junit5rule.getInstance().setAuthorizationStrategy(strategy);
+
+        // basic permissions
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.READ));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.WRITE));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.CREATE));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.UPDATE));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.DELETE));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.CONFIGURE));
+
+        // admin permissions
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.FULL_CONTROL));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.HUDSON_ADMINISTER));
+    }
+}


### PR DESCRIPTION
Fixes #901

This PR raises the default permissions of `JUnit5JenkinsRule` to align with their JUnit4 counterparts.
It is important to notice that this change is breaking and will cause _some_ JUnit5 based plugin tests to fail in case they rely on the fact that the default user / permission is `Unauthenticated`.

The alternative would be to leave the permissions as they are but make users aware of the differences in JUnit4 and JUnit5.

### Migration

JUnit5 based tests may fail due to this change (as they expect to run in an `Unauthenticated` context) - like for example:

```java
@Test
void testUnauthenticated(JenkinsRule r) throws Exception {
    DummySecurityRealm realm = r.createDummySecurityRealm();
    r.jenkins.setSecurityRealm(realm);

    MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
    r.jenkins.setAuthorizationStrategy(strategy);

    assertThrows(AccessDeniedException.class, () -> somethingUnauthenticatedUsersCanNotDo());
}
```

To restore the previous behavior tests need to explicitly impersonate an `ANONYMOUS` user like so:

```java
@Test
void testUnauthenticated(JenkinsRule r) throws Exception {
    DummySecurityRealm realm = r.createDummySecurityRealm();
    r.jenkins.setSecurityRealm(realm);

    MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
    r.jenkins.setAuthorizationStrategy(strategy);

    try (ACLContext ignored = ACL.as2(Jenkins.ANONYMOUS2)) {
        assertThrows(AccessDeniedException.class, () -> somethingUnauthenticatedUsersCanNotDo());
    }
}
```


### Testing done

Added `org.jvnet.hudson.test.JenkinsRulePermissionTest` to validate the behavior.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
