### PR TITLE
Introduce `RealJenkinsRule.createSyntheticPlugin` to allow synthetic plugins to be installed dynamically and break compatibility for existing callers of `RealJenkinsRule.addSyntheticPlugin`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -308,6 +308,7 @@ public final class RealJenkinsRule implements TestRule {
      * @param plugin the configured {@link SyntheticPlugin}
      * @return the JPI file for the plugin
      */
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "irrelevant, this is test code")
     public File createSyntheticPlugin(SyntheticPlugin plugin) throws IOException, URISyntaxException {
         File pluginJpi = new File(tmp.allocate("synthetic-plugin"), plugin.shortName + ".jpi");
         if (war == null) {


### PR DESCRIPTION
Needed for https://github.com/jenkinsci/jenkins/pull/10240.

Backwards-incompatible for most existing callers of `RealJenkinsRule.addSyntheticPlugin`.

### Testing done

New automated test case added.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
