### PR TITLE
[JENKINS-75278] Upgrade Jetty 12.0.17 which restore UriCompliance.LEGACY previous behaviour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ THE SOFTWARE.
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
     <!-- Normally filled in by "maven-hpi-plugin" with the path to "org-netbeans-insane-hook.jar" extracted from this repository -->
     <jenkins.insaneHook>--patch-module=java.base=${project.build.outputDirectory}/netbeans/harness/modules/ext/org-netbeans-insane-hook.jar --add-exports=java.base/org.netbeans.insane.hook=ALL-UNNAMED</jenkins.insaneHook>
-    <jetty.version>12.0.16</jetty.version>
+    <jetty.version>12.0.17</jetty.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -584,7 +584,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
         config.setRequestHeaderSize(12 * 1024);
         config.setHttpCompliance(HttpCompliance.RFC7230);
-        config.setUriCompliance(UriCompliance.LEGACY);
+        config.setUriCompliance(UriCompliance.LEGACY.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS));
         connector.setHost("localhost");
 
         server.addConnector(connector);

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -584,7 +584,11 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
         config.setRequestHeaderSize(12 * 1024);
         config.setHttpCompliance(HttpCompliance.RFC7230);
-        config.setUriCompliance(UriCompliance.LEGACY.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS));
+        UriCompliance compliance = UriCompliance.LEGACY;
+        if (!Boolean.getBoolean("winstone.DENY_SUSPICIOUS_PATH_CHARACTERS")) {
+            compliance = compliance.with("jenkins", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS);
+        }
+        config.setUriCompliance(compliance);
         connector.setHost("localhost");
 
         server.addConnector(connector);

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -140,9 +140,7 @@ import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.commons.beanutils.PropertyUtils;
-import org.eclipse.jetty.ee9.webapp.Configuration;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
-import org.eclipse.jetty.ee9.webapp.WebXmlConfiguration;
 import org.eclipse.jetty.ee9.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.UriCompliance;
@@ -584,11 +582,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
         config.setRequestHeaderSize(12 * 1024);
         config.setHttpCompliance(HttpCompliance.RFC7230);
-        UriCompliance compliance = UriCompliance.LEGACY;
-        if (!Boolean.getBoolean("winstone.DENY_SUSPICIOUS_PATH_CHARACTERS")) {
-            compliance = compliance.with("jenkins", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS);
-        }
-        config.setUriCompliance(compliance);
+        config.setUriCompliance(UriCompliance.LEGACY);
         connector.setHost("localhost");
 
         server.addConnector(connector);

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -889,7 +889,11 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
         config.setRequestHeaderSize(12 * 1024);
         config.setHttpCompliance(HttpCompliance.RFC7230);
-        config.setUriCompliance(UriCompliance.LEGACY.with("jenkins", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS));
+        UriCompliance compliance = UriCompliance.LEGACY;
+        if (!Boolean.getBoolean("winstone.DENY_SUSPICIOUS_PATH_CHARACTERS")) {
+            compliance = compliance.with("jenkins", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS);
+        }
+        config.setUriCompliance(compliance);
         connector.setHost("localhost");
         if (System.getProperty("port") != null) {
             connector.setPort(Integer.parseInt(System.getProperty("port")));

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -889,11 +889,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
         config.setRequestHeaderSize(12 * 1024);
         config.setHttpCompliance(HttpCompliance.RFC7230);
-        UriCompliance compliance = UriCompliance.LEGACY;
-        if (!Boolean.getBoolean("winstone.DENY_SUSPICIOUS_PATH_CHARACTERS")) {
-            compliance = compliance.with("jenkins", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS);
-        }
-        config.setUriCompliance(compliance);
+        config.setUriCompliance(UriCompliance.LEGACY);
         connector.setHost("localhost");
         if (System.getProperty("port") != null) {
             connector.setPort(Integer.parseInt(System.getProperty("port")));

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -889,7 +889,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
         config.setRequestHeaderSize(12 * 1024);
         config.setHttpCompliance(HttpCompliance.RFC7230);
-        config.setUriCompliance(UriCompliance.LEGACY);
+        config.setUriCompliance(UriCompliance.LEGACY.with("jenkins", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS));
         connector.setHost("localhost");
         if (System.getProperty("port") != null) {
             connector.setPort(Integer.parseInt(System.getProperty("port")));


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
