### PR TITLE
`JenkinsRule#restart` preserves the original root path

### DIFF
--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleTest.java
@@ -3,7 +3,6 @@ package org.jvnet.hudson.test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -446,7 +445,7 @@ public class JenkinsRuleTest {
         // validate properties and configuration were preserved
         assertThat(j.getURL(), equalTo(previousUrl));
         assertThat(j.testDescription, equalTo(previousTestDescription));
-        assertThat(j.jenkins.getRootDir(), not(previousRoot));
+        assertThat(j.jenkins.getRootDir(), equalTo(previousRoot));
         assertThat(j.jenkins.getJobNames(), hasSize(1));
 
         // validate restarted instance is working

--- a/src/test/java/org/jvnet/hudson/test/junit/jupiter/JUnit5JenkinsRuleTest.java
+++ b/src/test/java/org/jvnet/hudson/test/junit/jupiter/JUnit5JenkinsRuleTest.java
@@ -8,7 +8,6 @@ import java.net.URL;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 /**
@@ -34,7 +33,7 @@ class JUnit5JenkinsRuleTest {
         // validate properties and configuration were preserved
         assertThat(rule.getURL(), equalTo(previousUrl));
         assertThat(rule.getTestDescription(), equalTo(previousTestDescription));
-        assertThat(rule.jenkins.getRootDir(), not(previousRoot));
+        assertThat(rule.jenkins.getRootDir(), equalTo(previousRoot));
         assertThat(rule.jenkins.getJobNames(), hasSize(1));
 
         // validate restarted instance is working


### PR DESCRIPTION
My initial implementation of `JenkinsRule#restart` in https://github.com/jenkinsci/jenkins-test-harness/pull/716 seems to be flawed in a sense that the underlying Jenkins instance is restored with a copy of the original `JENKINS_HOME` under a *new* path.

In https://github.com/jenkinsci/throttle-concurrent-builds-plugin/pull/302 in became clear that this impacts some corner cases where this path is actually relevant for some plugins (see https://github.com/jenkinsci/throttle-concurrent-builds-plugin/pull/302#issuecomment-2718877688).

This PR aims to remove this flaw. Now `JenkinsRule#restart` will start a new instance with a copy of the original `JENKINS_HOME` under the *same* path as the previous instance. This is achieved by creating a `backup.zip` from the current `JENKINS_HOME` before shutting it down and starting a new instance from the unzipped backup that has the same path as before.

I do not assume that this change will cause any incompatibilities as I can not find evidence of a tests validating / building upon the flaws of the initial implementation.

Ping @basil @jglick Your input would be very welcome.

### Testing done

Adapted the existing tests. 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue