### PR TITLE
Fix RealJenkinsRule to properly set contextPath when using withPrefix…

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -1651,6 +1651,8 @@ public final class RealJenkinsRule implements TestRule {
         public CustomJenkinsRule(URL url) throws Exception {
             this.jenkins = Jenkins.get();
             this.url = url;
+            // Set the contextPath to match the URL path
+            this.contextPath = url.getPath().replaceAll("/$", "");
             if (jenkins.isUsageStatisticsCollected()) {
                 jenkins.setNoUsageStatistics(true); // cannot use JenkinsRule._configureJenkinsForTest earlier because it tries to save config before loaded
             }

--- a/src/test/java/org/jvnet/hudson/test/ContextPathTest.java
+++ b/src/test/java/org/jvnet/hudson/test/ContextPathTest.java
@@ -1,0 +1,23 @@
+package org.jvnet.hudson.test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RealJenkinsRule;
+
+public class ContextPathTest {
+    @Rule
+    public RealJenkinsRule rjr = new RealJenkinsRule().withPrefix("");
+
+    @Test
+    public void test() throws Throwable {
+        rjr.then(ContextPathTest::_test);
+    }
+
+    public static void _test(JenkinsRule jr) throws Exception {
+        assertThat(jr.contextPath, is(""));
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR fixes an issue where `RealJenkinsRule` doesn't properly set the `contextPath` field in `CustomJenkinsRule` when `withPrefix("")` is used. The current implementation doesn't propagate the empty prefix to the `contextPath` field of `JenkinsRule`. Closes #933 


### Testing done

A test case `ContextPathTest` has been added that verifies the fix works correctly. The test:
1. Creates a `RealJenkinsRule` instance with `withPrefix("")`
2. Asserts that the resulting `JenkinsRule` instance has an empty string in its `contextPath` field

The test passes with the fix, but would fail without it.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
