### PR TITLE
[JENKINS-75572] Add support for Jakarta EE 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,24 @@ THE SOFTWARE.
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-bom</artifactId>
         <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <!-- Pull in servlet API based on Jenkins core in use -->
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-bom</artifactId>
+        <version>${jenkins.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -126,9 +141,70 @@ THE SOFTWARE.
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-webapp</artifactId>
+      <exclusions>
+        <!-- Provided by plugin parent POM at Jenkins core version -->
+        <exclusion>
+          <groupId>jakarta.servlet</groupId>
+          <artifactId>jakarta.servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.toolchain</groupId>
+          <artifactId>jetty-jakarta-servlet-api</artifactId>
+        </exclusion>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
+      <!-- or jetty-ee10-websocket-javax-server -->
+      <exclusions>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
+        </exclusion>
+        <!-- Provided by plugin parent POM at Jenkins core version -->
+        <exclusion>
+          <groupId>jakarta.servlet</groupId>
+          <artifactId>jakarta.servlet-api</artifactId>
+        </exclusion>
+        <!-- Not shipped in Winstone either and causes unnecessary log spam -->
+        <exclusion>
+          <groupId>org.eclipse.jetty.ee10</groupId>
+          <artifactId>jetty-ee10-annotations</artifactId>
+        </exclusion>
+        <!-- Provided by plugin parent POM at Jenkins core version -->
+        <exclusion>
+          <groupId>org.eclipse.jetty.toolchain</groupId>
+          <artifactId>jetty-jakarta-servlet-api</artifactId>
+        </exclusion>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.ee9</groupId>
       <artifactId>jetty-ee9-webapp</artifactId>
       <exclusions>
+        <!-- Provided by plugin parent POM at Jenkins core version -->
+        <exclusion>
+          <groupId>jakarta.servlet</groupId>
+          <artifactId>jakarta.servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.toolchain</groupId>
+          <artifactId>jetty-jakarta-servlet-api</artifactId>
+        </exclusion>
         <!-- Provided by Jenkins core -->
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -146,6 +222,16 @@ THE SOFTWARE.
           <groupId>jakarta.annotation</groupId>
           <artifactId>jakarta.annotation-api</artifactId>
         </exclusion>
+        <!-- Provided by plugin parent POM at Jenkins core version -->
+        <exclusion>
+          <groupId>jakarta.servlet</groupId>
+          <artifactId>jakarta.servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.toolchain</groupId>
+          <artifactId>jetty-jakarta-servlet-api</artifactId>
+        </exclusion>
+        <!-- Provided by Jenkins core -->
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
@@ -198,6 +284,11 @@ THE SOFTWARE.
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kohsuke.metainf-services</groupId>
+      <artifactId>metainf-services</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.netbeans.modules</groupId>
       <artifactId>org-netbeans-insane</artifactId>
       <version>RELEASE200</version>
@@ -211,6 +302,11 @@ THE SOFTWARE.
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
+++ b/src/main/java/jenkins/benchmark/jmh/JmhBenchmarkState.java
@@ -8,18 +8,21 @@ import jakarta.servlet.ServletContext;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Iterator;
 import java.util.Objects;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
-import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
 import org.jvnet.hudson.test.JavaNetReverseProxy2;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
 import org.jvnet.hudson.test.TestPluginManager;
+import org.jvnet.hudson.test.jetty.JettyProvider;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -93,15 +96,12 @@ public abstract class JmhBenchmarkState implements RootAction {
     }
 
     private void launchInstance() throws Exception {
-        WebAppContext context = JenkinsRule._createWebAppContext2(
-                contextPath,
-                localPort::set,
-                getClass().getClassLoader(),
-                localPort.get(),
-                JenkinsRule::_configureUserRealm);
-        server = context.getServer();
+        JettyProvider jp = findJettyProvider();
+        JettyProvider.Context jpc = jp.createWebServer(localPort.get(), contextPath, JenkinsRule::_configureUserRealm);
+        localPort.set(jpc.localPort());
+        server = jpc.server();
 
-        ServletContext webServer = context.getServletContext();
+        ServletContext webServer = jpc.servletContext();
 
         jenkins = new Hudson(temporaryDirectoryAllocator.allocate(), webServer, TestPluginManager.INSTANCE);
         JenkinsRule._configureJenkinsForTest(jenkins);
@@ -111,6 +111,18 @@ public abstract class JmhBenchmarkState implements RootAction {
         String url = Objects.requireNonNull(getJenkinsURL()).toString();
         Objects.requireNonNull(JenkinsLocationConfiguration.get()).setUrl(url);
         LOGGER.log(Level.INFO, "Running on {0}", url);
+    }
+
+    private static JettyProvider findJettyProvider() {
+        Iterator<JettyProvider> it = ServiceLoader.load(JettyProvider.class).iterator();
+        while (it.hasNext()) {
+            try {
+                return it.next();
+            } catch (ServiceConfigurationError e) {
+                LOGGER.log(Level.FINE, null, e);
+            }
+        }
+        return null;
     }
 
     private URL getJenkinsURL() throws MalformedURLException {

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -117,6 +117,8 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
@@ -140,21 +142,11 @@ import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.commons.beanutils.PropertyUtils;
-import org.eclipse.jetty.ee9.webapp.WebAppContext;
-import org.eclipse.jetty.ee9.websocket.server.config.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.http.HttpCompliance;
-import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.UserStore;
-import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.gzip.GzipHandler;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.security.Password;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.htmlunit.AjaxController;
 import org.htmlunit.AlertHandler;
 import org.htmlunit.BrowserVersion;
@@ -185,6 +177,7 @@ import org.htmlunit.javascript.host.xml.XMLHttpRequest;
 import org.htmlunit.util.NameValuePair;
 import org.htmlunit.xml.XmlPage;
 import org.jvnet.hudson.test.HudsonHomeLoader.CopyExisting;
+import org.jvnet.hudson.test.jetty.JettyProvider;
 import org.jvnet.hudson.test.recipes.Recipe;
 import org.jvnet.hudson.test.recipes.Recipe.Runner;
 import org.jvnet.hudson.test.recipes.WithPlugin;
@@ -547,51 +540,25 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      * that we need for testing.
      */
     protected ServletContext createWebServer2() throws Exception {
-        QueuedThreadPool qtp = new QueuedThreadPool();
-        qtp.setName("Jetty (HudsonTestCase)");
-        server = new Server(qtp);
+        JettyProvider jp = findJettyProvider();
+        JettyProvider.Context jpc = jp.createWebServer(localPort, contextPath, this::configureUserRealm);
+        localPort = jpc.localPort();
+        server = jpc.server();
+        explodedWarDir = jpc.explodedWarDir();
+        LOGGER.log(Level.INFO, "Running on {0}", getURL());
+        return jpc.servletContext();
+    }
 
-        explodedWarDir = WarExploder.getExplodedDir();
-        WebAppContext context = new WebAppContext(explodedWarDir.getPath(), contextPath) {
-            @Override
-            protected ClassLoader configureClassLoader(ClassLoader loader) {
-                // Use flat classpath in tests
-                return loader;
+    private static JettyProvider findJettyProvider() {
+        Iterator<JettyProvider> it = ServiceLoader.load(JettyProvider.class).iterator();
+        while (it.hasNext()) {
+            try {
+                return it.next();
+            } catch (ServiceConfigurationError e) {
+                LOGGER.log(Level.FINE, null, e);
             }
-        };
-        context.setBaseResource(ResourceFactory.of(context).newResource(explodedWarDir.getPath()));
-        context.setClassLoader(getClass().getClassLoader());
-        context.setConfigurationDiscovered(true);
-        context.addBean(new NoListenerConfiguration2(context));
-        context.setServer(server);
-        String compression = System.getProperty("jth.compression", "gzip");
-        if (compression.equals("gzip")) {
-            GzipHandler gzipHandler = new GzipHandler();
-            gzipHandler.setHandler(context);
-            server.setHandler(gzipHandler);
-        } else if (compression.equals("none")) {
-            server.setHandler(context);
-        } else {
-            throw new IllegalArgumentException("Unexpected compression scheme: " + compression);
         }
-        JettyWebSocketServletContainerInitializer.configure(context, null);
-        context.getSecurityHandler().setLoginService(configureUserRealm());
-
-        ServerConnector connector = new ServerConnector(server);
-
-        HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();
-        // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
-        config.setRequestHeaderSize(12 * 1024);
-        config.setHttpCompliance(HttpCompliance.RFC7230);
-        config.setUriCompliance(UriCompliance.LEGACY);
-        connector.setHost("localhost");
-
-        server.addConnector(connector);
-        server.start();
-
-        localPort = connector.getLocalPort();
-
-        return context.getServletContext();
+        return null;
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -146,6 +146,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -155,9 +157,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.jar.Manifest;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Filter;
@@ -176,23 +175,11 @@ import net.sf.json.JSON;
 import net.sf.json.JSONObject;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.io.FileUtils;
-import org.eclipse.jetty.ee9.webapp.Configuration;
-import org.eclipse.jetty.ee9.webapp.WebAppContext;
-import org.eclipse.jetty.ee9.webapp.WebXmlConfiguration;
-import org.eclipse.jetty.ee9.websocket.server.config.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.http.HttpCompliance;
-import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.UserStore;
-import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.gzip.GzipHandler;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.security.Password;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.htmlunit.AjaxController;
 import org.htmlunit.BrowserVersion;
 import org.htmlunit.DefaultCssErrorHandler;
@@ -239,6 +226,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 import org.junit.runners.model.TestTimedOutException;
+import org.jvnet.hudson.test.jetty.JettyProvider;
 import org.jvnet.hudson.test.recipes.Recipe;
 import org.jvnet.hudson.test.recipes.WithTimeout;
 import org.jvnet.hudson.test.rhino.JavaScriptDebugger;
@@ -792,121 +780,24 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * that we need for testing.
      */
     protected ServletContext createWebServer2() throws Exception {
-        return createWebServer2(null);
-    }
-
-    /**
-     * Prepares a webapp hosting environment to get {@link jakarta.servlet.ServletContext} implementation
-     * that we need for testing.
-     * 
-     * @param contextAndServerConsumer configures the {@link WebAppContext} and the {@link Server} for the instance, before they are started
-     * @since 2.63
-     */
-    protected ServletContext createWebServer2(@CheckForNull BiConsumer<WebAppContext, Server> contextAndServerConsumer)
-            throws Exception {
-        WebAppContext context = _createWebAppContext2(
-                contextPath,
-                (x) -> localPort = x,
-                getClass().getClassLoader(),
-                localPort,
-                this::configureUserRealm,
-                contextAndServerConsumer);
-        server = context.getServer();
+        JettyProvider jp = findJettyProvider();
+        JettyProvider.Context jpc = jp.createWebServer(localPort, contextPath, this::configureUserRealm);
+        localPort = jpc.localPort();
+        server = jpc.server();
         LOGGER.log(Level.INFO, "Running on {0}", getURL());
-        return context.getServletContext();
+        return jpc.servletContext();
     }
 
-    /**
-     * Creates a web server on which Jenkins can run
-     *
-     * @param contextPath          the context path at which to put Jenkins
-     * @param portSetter           the port on which the server runs will be set using this function
-     * @param classLoader          the class loader for the {@link WebAppContext}
-     * @param localPort            port on which the server runs
-     * @param loginServiceSupplier configures the {@link LoginService} for the instance
-     * @return                     the {@link Server}
-     * @since 2.50
-     */
-    public static WebAppContext _createWebAppContext2(
-            String contextPath,
-            Consumer<Integer> portSetter,
-            ClassLoader classLoader,
-            int localPort,
-            Supplier<LoginService> loginServiceSupplier)
-            throws Exception {
-        return _createWebAppContext2(contextPath, portSetter, classLoader, localPort, loginServiceSupplier, null);
-    }
-    /**
-     * Creates a web server on which Jenkins can run
-     *
-     * @param contextPath              the context path at which to put Jenkins
-     * @param portSetter               the port on which the server runs will be set using this function
-     * @param classLoader              the class loader for the {@link WebAppContext}
-     * @param localPort                port on which the server runs
-     * @param loginServiceSupplier     configures the {@link LoginService} for the instance
-     * @param contextAndServerConsumer configures the {@link WebAppContext} and the {@link Server} for the instance, before they are started
-     * @return                         the {@link Server}
-     * @since 2.50
-     */
-    public static WebAppContext _createWebAppContext2(
-            String contextPath,
-            Consumer<Integer> portSetter,
-            ClassLoader classLoader,
-            int localPort,
-            Supplier<LoginService> loginServiceSupplier,
-            @CheckForNull BiConsumer<WebAppContext, Server> contextAndServerConsumer)
-            throws Exception {
-        QueuedThreadPool qtp = new QueuedThreadPool();
-        qtp.setName("Jetty (JenkinsRule)");
-        Server server = new Server(qtp);
-
-        WebAppContext context = new WebAppContext(WarExploder.getExplodedDir().getPath(), contextPath) {
-            @Override
-            protected ClassLoader configureClassLoader(ClassLoader loader) {
-                // Use flat classpath in tests
-                return loader;
+    private static JettyProvider findJettyProvider() {
+        Iterator<JettyProvider> it = ServiceLoader.load(JettyProvider.class).iterator();
+        while (it.hasNext()) {
+            try {
+                return it.next();
+            } catch (ServiceConfigurationError e) {
+                LOGGER.log(Level.FINE, null, e);
             }
-        };
-        context.setClassLoader(classLoader);
-        context.setConfigurationDiscovered(true);
-        context.addBean(new NoListenerConfiguration2(context));
-        context.setServer(server);
-        String compression = System.getProperty("jth.compression", "gzip");
-        if (compression.equals("gzip")) {
-            GzipHandler gzipHandler = new GzipHandler();
-            gzipHandler.setHandler(context);
-            server.setHandler(gzipHandler);
-        } else if (compression.equals("none")) {
-            server.setHandler(context);
-        } else {
-            throw new IllegalArgumentException("Unexpected compression scheme: " + compression);
         }
-        JettyWebSocketServletContainerInitializer.configure(context, null);
-        context.getSecurityHandler().setLoginService(loginServiceSupplier.get());
-        context.setBaseResource(ResourceFactory.of(context).newResource(WarExploder.getExplodedDir().getPath()));
-
-        ServerConnector connector = new ServerConnector(server);
-        HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();
-        // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
-        config.setRequestHeaderSize(12 * 1024);
-        config.setHttpCompliance(HttpCompliance.RFC7230);
-        config.setUriCompliance(UriCompliance.LEGACY);
-        connector.setHost("localhost");
-        if (System.getProperty("port") != null) {
-            connector.setPort(Integer.parseInt(System.getProperty("port")));
-        } else if (localPort != 0) {
-            connector.setPort(localPort);
-        }
-
-        server.addConnector(connector);
-        if (contextAndServerConsumer != null) {
-            contextAndServerConsumer.accept(context, server);
-        }
-        server.start();
-
-        portSetter.accept(connector.getLocalPort());
-
-        return context;
+        return null;
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/test/jetty/Jetty12EE10Provider.java
+++ b/src/main/java/org/jvnet/hudson/test/jetty/Jetty12EE10Provider.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.test.jetty;
+
+import jakarta.servlet.ServletRequest;
+import java.io.File;
+import java.util.function.Supplier;
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.jvnet.hudson.test.NoListenerConfiguration2;
+import org.jvnet.hudson.test.WarExploder;
+import org.kohsuke.MetaInfServices;
+
+@MetaInfServices(JettyProvider.class)
+public final class Jetty12EE10Provider extends JettyProvider {
+
+    public Jetty12EE10Provider() {
+        try {
+            ServletRequest.class.getDeclaredMethod("getRequestId");
+        } catch (NoSuchMethodException e) {
+            NoSuchMethodError error = new NoSuchMethodError();
+            error.initCause(e);
+            throw error;
+        }
+    }
+
+    @Override
+    public Context createWebServer(int localPort, String contextPath, Supplier<LoginService> loginServiceSupplier)
+            throws Exception {
+        createServer();
+
+        File explodedWarDir = WarExploder.getExplodedDir();
+        WebAppContext context = new WebAppContext(explodedWarDir.getPath(), contextPath) {
+            @Override
+            public void preConfigure() throws Exception {
+                super.preConfigure();
+                getServletHandler().setDecodeAmbiguousURIs(true);
+            }
+
+            @Override
+            protected ClassLoader configureClassLoader(ClassLoader loader) {
+                // Use flat classpath in tests
+                return loader;
+            }
+        };
+        context.setBaseResource(ResourceFactory.of(context).newResource(explodedWarDir.getPath()));
+        context.setClassLoader(getClass().getClassLoader());
+        context.setConfigurationDiscovered(true);
+        context.addBean(new NoListenerConfiguration2(context));
+        context.setServer(server);
+        context.getSecurityHandler().setLoginService(loginServiceSupplier.get());
+        JettyWebSocketServletContainerInitializer.configure(context, null);
+
+        configureCompression(context);
+        ServerConnector connector = createConnector(localPort);
+        server.start();
+        return new Context(context.getServletContext(), connector.getLocalPort(), server, explodedWarDir);
+    }
+}

--- a/src/main/java/org/jvnet/hudson/test/jetty/Jetty12EE9Provider.java
+++ b/src/main/java/org/jvnet/hudson/test/jetty/Jetty12EE9Provider.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.test.jetty;
+
+import jakarta.servlet.ServletRequest;
+import java.io.File;
+import java.util.function.Supplier;
+import org.eclipse.jetty.ee9.webapp.WebAppContext;
+import org.eclipse.jetty.ee9.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.jvnet.hudson.test.NoListenerConfiguration2;
+import org.jvnet.hudson.test.WarExploder;
+import org.kohsuke.MetaInfServices;
+
+@MetaInfServices(JettyProvider.class)
+public final class Jetty12EE9Provider extends JettyProvider {
+
+    public Jetty12EE9Provider() {
+        try {
+            ServletRequest.class.getDeclaredMethod("getRealPath", String.class);
+        } catch (NoSuchMethodException e) {
+            NoSuchMethodError error = new NoSuchMethodError();
+            error.initCause(e);
+            throw error;
+        }
+    }
+
+    @Override
+    public Context createWebServer(int localPort, String contextPath, Supplier<LoginService> loginServiceSupplier)
+            throws Exception {
+        createServer();
+
+        File explodedWarDir = WarExploder.getExplodedDir();
+        WebAppContext context = new WebAppContext(explodedWarDir.getPath(), contextPath) {
+            @Override
+            protected ClassLoader configureClassLoader(ClassLoader loader) {
+                // Use flat classpath in tests
+                return loader;
+            }
+        };
+        context.setBaseResource(ResourceFactory.of(context).newResource(explodedWarDir.getPath()));
+        context.setClassLoader(getClass().getClassLoader());
+        context.setConfigurationDiscovered(true);
+        context.addBean(new NoListenerConfiguration2(context));
+        context.setServer(server);
+        context.getSecurityHandler().setLoginService(loginServiceSupplier.get());
+        JettyWebSocketServletContainerInitializer.configure(context, null);
+
+        configureCompression(context.get());
+        ServerConnector connector = createConnector(localPort);
+        server.start();
+        return new Context(context.getServletContext(), connector.getLocalPort(), server, explodedWarDir);
+    }
+}

--- a/src/main/java/org/jvnet/hudson/test/jetty/JettyProvider.java
+++ b/src/main/java/org/jvnet/hudson/test/jetty/JettyProvider.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.test.jetty;
+
+import jakarta.servlet.ServletContext;
+import java.io.File;
+import java.util.function.Supplier;
+import org.eclipse.jetty.http.HttpCompliance;
+import org.eclipse.jetty.http.UriCompliance;
+import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Defines a way for {@link JenkinsRule} to run Jetty. This permits the test harness to select the appropriate Jakarta
+ * EE version based on the version of Jenkins core under test. The constructor should try to link against everything
+ * necessary so any errors are thrown up front.
+ *
+ * @author Basil Crow
+ */
+public abstract class JettyProvider {
+
+    protected Server server;
+
+    public record Context(ServletContext servletContext, int localPort, Server server, File explodedWarDir) {}
+
+    /**
+     * Prepares a webapp hosting environment and returns a context containing the {@link ServletContext}, port, and
+     * server for testing.
+     */
+    public abstract Context createWebServer(
+            int localPort, String contextPath, Supplier<LoginService> loginServiceSupplier) throws Exception;
+
+    protected final void createServer() {
+        QueuedThreadPool qtp = new QueuedThreadPool();
+        qtp.setName("Jetty (JenkinsRule)");
+        server = new Server(qtp);
+    }
+
+    protected final ServerConnector createConnector(int localPort) {
+        ServerConnector connector = new ServerConnector(server);
+        HttpConfiguration config =
+                connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();
+        // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
+        config.setRequestHeaderSize(12 * 1024);
+        config.setHttpCompliance(HttpCompliance.RFC7230);
+        config.setUriCompliance(UriCompliance.LEGACY);
+        connector.setHost("localhost");
+        if (System.getProperty("port") != null) {
+            connector.setPort(Integer.parseInt(System.getProperty("port")));
+        } else if (localPort != 0) {
+            connector.setPort(localPort);
+        }
+        server.addConnector(connector);
+        return connector;
+    }
+
+    protected final void configureCompression(Handler handler) {
+        String compression = System.getProperty("jth.compression", "gzip");
+        if (compression.equals("gzip")) {
+            GzipHandler gzipHandler = new GzipHandler();
+            gzipHandler.setHandler(handler);
+            server.setHandler(gzipHandler);
+        } else if (compression.equals("none")) {
+            server.setHandler(handler);
+        } else {
+            throw new IllegalArgumentException("Unexpected compression scheme: " + compression);
+        }
+    }
+}


### PR DESCRIPTION
### Context

Part of the following series of PRs:

- https://github.com/jenkinsci/jelly/pull/140
- https://github.com/jenkinsci/stapler/pull/617
- https://github.com/jenkinsci/winstone/pull/422
- https://github.com/jenkinsci/jenkins/pull/10461
- https://github.com/jenkinsci/jenkins-test-harness/pull/941

### Problem

The test harness only supports EE 9, precluding an eventual upgrade to EE 10.

### Solution

Support both EE 9 and EE 10 in the test harness, dynamically selecting the version of Jakarta EE based on the Jenkins core under test. This is similar at a high level to a previous PR that added support for both EE 8 and EE 9, though the details are different: in this case, the same `jakarta.servlet` types are in use, and the implementation is much cleaner.

#### Servlet API

Normally, the test harness is consumed in the plugin parent POM, which also [adds a `provided` dependency on the Jakarta EE servlet API](https://github.com/jenkinsci/plugin-pom/blob/2c1afb0bbc95879e4288967c457e1c40d3e5d633/pom.xml#L260-L265). The plugin parent POM does not declare a version, so the version comes from the Jenkins core BOM.

Prior to this PR, the test harness also declared a (transitive) dependency on the Jakarta EE servlet API via Jetty. When we supported both EE 8 and EE 9 concurrently in this repository, there was no conflict because the two Maven packages used different coordinates. In this PR, `jakarta.servlet:jakarta.servlet-api` and its close relative `org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api` exist for both EE 9 and EE 10 with different version numbers, so a conflict has to be resolved. We have resolved it by excluding `jakarta.servlet:jakarta.servlet-api` and `org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api` from being pulled in transitively by Jetty and instead declaring a direct `provided` dependency on `jakarta.servlet:jakarta.servlet-api`, as does the plugin parent POM. Jenkins core's test suite is not implemented like the plugin parent POM, so we also have to add a `provided` dependency there, as in https://github.com/jenkinsci/jenkins/pull/10554. For the Jenkins test harness's own test suite, we need to support different core versions, so we also pull in the core BOM here so that when testing the test harness we get the correct Jakarta EE JAR for the Jenkins core under test. The end result of all of this is:

- `jakarta.servlet:jakarta.servlet-api` is provided by core at the Jakarta EE version matching Winstone
- The test harness uses the above to figure out which Jetty web application context to load (EE 9 vs EE 10)
- The dependency pattern is consistent between the plugin parent POM, the Jenkins core test suite, and the Jenkins test harness test suite.

#### Refactoring

There were two copies of this code already, one for `HudsonTestCase` and one for `JenkinsRule`. Rather than multiply that into four copies (as we did when adding support for EE 8 and EE 9 concurrently), we took this opportunity to refactor the code into a more sustainable pattern.

There is now a `JettyProvider` class that contains a single copy of the common code. `JenkinsRule` and `HudsonTestCase` delegate to this. The two implementations are in `Jetty12EE9Provider` and `Jetty12EE10Provider` which contain the EE 9/10 specific bits, calling up to their parent class for common code. The concrete classes are indexed in `META-INF/services` and loaded by `ServiceLoader`; the constructor's job is to test whether the class is applicable to the given EE version and to throw an exception if it is not.

### Testing done

- Core EE 9: https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10554/1/
- Core EE 10: https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10461/19/ (single failure was a flake)
- Plugins EE 9: https://ci.jenkins.io/job/Tools/job/bom/job/PR-4900/1/
- Plugins EE 10: https://ci.jenkins.io/job/Tools/job/bom/job/PR-4779/13/