### PR TITLE
Make `NoListenerConfiguration2` agnostic to EE version

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/NoListenerConfiguration2.java
+++ b/src/main/java/org/jvnet/hudson/test/NoListenerConfiguration2.java
@@ -26,7 +26,6 @@ package org.jvnet.hudson.test;
 import hudson.WebAppMain;
 import jakarta.servlet.ServletContextListener;
 import java.util.EventListener;
-import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 
 /**
@@ -39,9 +38,9 @@ import org.eclipse.jetty.util.component.AbstractLifeCycle;
  * @author Kohsuke Kawaguchi
  */
 public class NoListenerConfiguration2 extends AbstractLifeCycle {
-    private final WebAppContext context;
+    private final AbstractLifeCycle context;
 
-    public NoListenerConfiguration2(WebAppContext context) {
+    public NoListenerConfiguration2(AbstractLifeCycle context) {
         this.context = context;
     }
 


### PR DESCRIPTION
Extracted from #941, as this change can be merged and released proactively. Today we hard-code EE 9 in `NoListenerConfiguration2` by importing `org.eclipse.jetty.ee9.webapp.WebAppContext`, making it difficult to support both EE 9 and EE 10 in the future as we would like to do in #941. By choosing the type `AbstractLifeCycle` (a common superclass of both `org.eclipse.jetty.ee9.webapp.WebAppContext` and `org.eclipse.jetty.ee10.webapp.WebAppContext` that still has the methods we need), we make this class agnostic to EE version and ease future maintenance.

### Testing done

CI build. Also tested in the context of #941 with both EE 9 and EE 10 cores in a plugin's test suite.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
