### PR TITLE
Reduce usage of deprecated Jetty methods

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -152,6 +152,7 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.security.Password;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.htmlunit.AjaxController;
@@ -558,7 +559,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
                 return loader;
             }
         };
-        context.setResourceBase(explodedWarDir.getPath());
+        context.setBaseResource(ResourceFactory.of(context).newResource(explodedWarDir.getPath()));
         context.setClassLoader(getClass().getClassLoader());
         context.setConfigurationDiscovered(true);
         context.addBean(new NoListenerConfiguration2(context));

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -190,6 +190,7 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.security.Password;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.htmlunit.AjaxController;
@@ -882,7 +883,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         }
         JettyWebSocketServletContainerInitializer.configure(context, null);
         context.getSecurityHandler().setLoginService(loginServiceSupplier.get());
-        context.setResourceBase(WarExploder.getExplodedDir().getPath());
+        context.setBaseResource(ResourceFactory.of(context).newResource(WarExploder.getExplodedDir().getPath()));
 
         ServerConnector connector = new ServerConnector(server);
         HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();


### PR DESCRIPTION
Extracted from https://github.com/jenkinsci/jenkins-test-harness/pull/941, as this change can be merged and released proactively. The `setResourceBase` method has been deprecated in favor of `setBaseResource`, and `setResourceBase` has been removed entirely in EE 10. So migrate to the new functionality proactively so that the code continues to compile in the future when we are on EE 10.

### Testing done

CI build, as well as testing `hpi:run` on an EE 10 core in a plugin as part of #941.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
