### PR TITLE
Simplify `JavaNetReverseProxy2`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy2.java
+++ b/src/main/java/org/jvnet/hudson/test/JavaNetReverseProxy2.java
@@ -18,7 +18,6 @@ import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 /**
@@ -43,11 +42,9 @@ public class JavaNetReverseProxy2 extends HttpServlet {
         qtp.setName("Jetty (JavaNetReverseProxy)");
         server = new Server(qtp);
 
-        ContextHandlerCollection contexts = new ContextHandlerCollection();
-        server.setHandler(contexts);
-
-        ServletContextHandler root = new ServletContextHandler(contexts, "/", ServletContextHandler.SESSIONS);
-        root.addServlet(new ServletHolder(this), "/");
+        ServletContextHandler context = new ServletContextHandler();
+        context.addServlet(new ServletHolder(this), "/");
+        server.setHandler(context);
 
         ServerConnector connector = new ServerConnector(server);
         server.addConnector(connector);


### PR DESCRIPTION
Extracted from #941, as this change can be merged and released proactively. Simplify our usage by removing `ContextHandlerCollection`, which isn't needed and works differently in EE 10. The simpler version of the code works fine in EE 9 and EE 10.

### Testing done

Stepped through the servlet code in both EE 9 and EE 10 to make sure it functions as before without regression.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
