### PR TITLE
[JENKINS-73616] Log spam from `AnnotationParser#parseClass`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -32,6 +32,7 @@ import static org.jvnet.hudson.test.QueryUtils.waitUntilStringIsNotPresent;
 
 import com.google.inject.Injector;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.CloseProofOutputStream;
 import hudson.DescriptorExtensionList;
 import hudson.EnvVars;
@@ -546,6 +547,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      * Prepares a webapp hosting environment to get {@link ServletContext} implementation
      * that we need for testing.
      */
+    @SuppressFBWarnings(value = "LG_LOST_LOGGER_DUE_TO_WEAK_REFERENCE", justification = "TODO needs triage")
     protected ServletContext createWebServer2() throws Exception {
         QueuedThreadPool qtp = new QueuedThreadPool();
         qtp.setName("Jetty (HudsonTestCase)");
@@ -587,6 +589,11 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         connector.setHost("localhost");
 
         server.addConnector(connector);
+
+        // JENKINS-73616: Turn down log level of annotation parser
+        Logger logger = Logger.getLogger("org.eclipse.jetty.ee9.annotations.AnnotationParser");
+        logger.setLevel(Level.SEVERE);
+
         server.start();
 
         localPort = connector.getLocalPort();

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -39,6 +39,7 @@ import static org.jvnet.hudson.test.QueryUtils.waitUntilStringIsNotPresent;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.CloseProofOutputStream;
 import hudson.DescriptorExtensionList;
 import hudson.EnvVars;
@@ -848,6 +849,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * @return                         the {@link Server}
      * @since 2.50
      */
+    @SuppressFBWarnings(value = "LG_LOST_LOGGER_DUE_TO_WEAK_REFERENCE", justification = "TODO needs triage")
     public static WebAppContext _createWebAppContext2(
             String contextPath,
             Consumer<Integer> portSetter,
@@ -902,6 +904,11 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         if (contextAndServerConsumer != null) {
             contextAndServerConsumer.accept(context, server);
         }
+
+        // JENKINS-73616: Turn down log level of annotation parser
+        Logger logger = Logger.getLogger("org.eclipse.jetty.ee9.annotations.AnnotationParser");
+        logger.setLevel(Level.SEVERE);
+
         server.start();
 
         portSetter.accept(connector.getLocalPort());


### PR DESCRIPTION
On the EE 10 branch I started seeing the same log spam in tests as had been reported in [JENKINS-73616](https://issues.jenkins.io/browse/JENKINS-73616) in production. Worked around the issue in the same way as https://github.com/jenkinsci/winstone/pull/409 by side-porting that PR to this repository. In the long term the need for this workaround should be obviated by [JENKINS-68691](https://issues.jenkins.io/browse/JENKINS-68691). Pushing this to trunk (EE 9) even though it is not strictly needed there since it is harmless on EE 9 and reduces the size of the EE 10 diff to get this into trunk sooner.

### Testing done

On the EE 10 branch, reproduced JENKINS-73616 before this PR and failed to reproduce it after this PR.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
