### PR TITLE
Add `RealJenkinsRule.SyntheticPlugin` constructors not requiring `Package`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -1774,10 +1774,30 @@ public final class RealJenkinsRule implements TestRule {
          * Creates a new synthetic plugin builder.
          * @see RealJenkinsRule#addSyntheticPlugin
          * @see RealJenkinsRule#createSyntheticPlugin
+         * @param exampleClass an example of a class from the Java package containing any classes and resources you want included
+         */
+        public SyntheticPlugin(Class<?> exampleClass) {
+            this(exampleClass.getPackage());
+        }
+
+        /**
+         * Creates a new synthetic plugin builder.
+         * @see RealJenkinsRule#addSyntheticPlugin
+         * @see RealJenkinsRule#createSyntheticPlugin
          * @param pkg the Java package containing any classes and resources you want included
          */
         public SyntheticPlugin(Package pkg) {
-            this.pkg = pkg.getName();
+            this(pkg.getName());
+        }
+
+        /**
+         * Creates a new synthetic plugin builder.
+         * @see RealJenkinsRule#addSyntheticPlugin
+         * @see RealJenkinsRule#createSyntheticPlugin
+         * @param pkg the name of a Java package containing any classes and resources you want included
+         */
+        public SyntheticPlugin(String pkg) {
+            this.pkg = pkg;
             shortName = "synthetic-" + this.pkg.replace('.', '-');
         }
 

--- a/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleSyntheticPluginTest.java
+++ b/src/test/java/org/jvnet/hudson/test/RealJenkinsRuleSyntheticPluginTest.java
@@ -41,7 +41,7 @@ public final class RealJenkinsRuleSyntheticPluginTest {
     @Rule public RealJenkinsRule rr = new RealJenkinsRule().prepareHomeLazily(true);
 
     @Test public void smokes() throws Throwable {
-        rr.addSyntheticPlugin(new SyntheticPlugin(Stuff.class.getPackage()));
+        rr.addSyntheticPlugin(new SyntheticPlugin(Stuff.class));
         rr.then(RealJenkinsRuleSyntheticPluginTest::_smokes);
     }
 
@@ -51,7 +51,7 @@ public final class RealJenkinsRuleSyntheticPluginTest {
     }
 
     @Test public void classFilter() throws Throwable {
-        rr.addSyntheticPlugin(new SyntheticPlugin(CustomJobProperty.class.getPackage())).withLogger(ClassFilterImpl.class, Level.FINE);
+        rr.addSyntheticPlugin(new SyntheticPlugin(CustomJobProperty.class)).withLogger(ClassFilterImpl.class, Level.FINE);
         rr.then(r -> {
             var p = r.createFreeStyleProject();
             p.addProperty(new CustomJobProperty("expected in XML"));
@@ -60,7 +60,7 @@ public final class RealJenkinsRuleSyntheticPluginTest {
     }
 
     @Test public void dynamicLoad() throws Throwable {
-        var pluginJpi = rr.createSyntheticPlugin(new SyntheticPlugin(Stuff.class.getPackage()));
+        var pluginJpi = rr.createSyntheticPlugin(new SyntheticPlugin(Stuff.class));
         rr.then(r -> {
             r.jenkins.pluginManager.dynamicLoad(pluginJpi);
             assertThat(r.createWebClient().goTo("stuff", "text/plain").getWebResponse().getContentAsString(),


### PR DESCRIPTION
All that is really needed is the package name. A @cloudbees proprietary test involved a dummy plugin with no Java class, just a `package-info.java`, and `Package.get` and related methods would not load it, forcing a convoluted workaround.