### PR TITLE
`RealJenkinsRule.run(ErrorCollector, Step)`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -126,6 +126,7 @@ import org.apache.commons.io.IOUtils;
 import org.htmlunit.WebClient;
 import org.junit.AssumptionViolatedException;
 import org.junit.rules.DisableOnDebug;
+import org.junit.rules.ErrorCollector;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
@@ -1260,6 +1261,23 @@ public final class RealJenkinsRule implements TestRule {
      */
     public void run(Step step) throws Throwable {
         runRemotely(step);
+    }
+
+    /**
+     * Run a step on the remote system, but do not immediately fail, just record any error.
+     * Same as {@link ErrorCollector#checkSucceeds} but more concise to call.
+     */
+    public void run(ErrorCollector errors, Step step) {
+        errors.checkSucceeds(() -> {
+            try {
+                run(step);
+                return null;
+            } catch (Exception x) {
+                throw x;
+            } catch (Throwable x) {
+                throw new Exception(x);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Found to be useful in some tests in CloudBees CI.