### PR TITLE
More robustness for `JenkinsRule.after`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -495,22 +495,22 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
             // cancel asynchronous operations as best as we can
             for (WebClient client : clients) {
-                // Adapt to https://github.com/HtmlUnit/htmlunit/issues/627
-                // See https://github.com/jenkinsci/jenkins-test-harness/pull/664
-                if (client.getJavaScriptEngine() != null) {
-                    // wait until current asynchronous operations have finished executing
-                    WebClientUtil.waitForJSExec(client);
-                }
-                // unload the page to prevent new asynchronous operations from being scheduled
                 try (client) {
+                    // Adapt to https://github.com/HtmlUnit/htmlunit/issues/627
+                    // See https://github.com/jenkinsci/jenkins-test-harness/pull/664
+                    if (client.getJavaScriptEngine() != null) {
+                        // wait until current asynchronous operations have finished executing
+                        WebClientUtil.waitForJSExec(client);
+                    }
+                    // unload the page to prevent new asynchronous operations from being scheduled
                     // Adapt to https://github.com/HtmlUnit/htmlunit/issues/627
                     // See https://github.com/jenkinsci/jenkins-test-harness/pull/664
                     if (client.getCurrentWindow() != null) {
                         client.getPage("about:blank");
+                        client.close();
                     }
-                } catch (IOException e) {
-                    // should never happen when loading "about:blank"
-                    throw new UncheckedIOException(e);
+                } catch (Exception x) {
+                    LOGGER.log(Level.WARNING, "failure to clean up", x);
                 }
             }
             clients.clear();


### PR DESCRIPTION
Could not reproduce https://github.com/jenkinsci/workflow-job-plugin/pull/538/checks?check_run_id=43199647096 (from unrelated https://github.com/jenkinsci/workflow-job-plugin/pull/538) running this rather slow test (introduced in https://github.com/jenkinsci/workflow-job-plugin/pull/75) 15× in a row. Maybe some race condition in HtmlUnit somewhere? I see that #492 (amended in #664) tried to defend against this class of failure, but apparently it is not working in all cases. Would be nicer to track down and fix the root cause but in the meantime this whole block of `after` just seems to be here to avoid unspecified flakes in other tests (in the same class/JVM?) so it does not seem helpful to make _this_ test flake if the attempt does not work out.