### PR TITLE
Remove deprecated reviewers configuration option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
-    reviewers:
-      - jglick
     ignore:
       - dependency-name: io.jenkins.plugins*
       - dependency-name: org.jenkins-ci.main:jenkins-bom


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/