### PR TITLE
Use `URLClassLoader2` where possible

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -108,7 +108,6 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -134,6 +133,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsAdaptor;
 import jenkins.model.JenkinsLocationConfiguration;
+import jenkins.util.URLClassLoader2;
 import junit.framework.TestCase;
 import net.sf.json.JSONObject;
 import org.acegisecurity.AuthenticationException;
@@ -1807,7 +1807,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             if (dir.exists() && MetaClassLoader.debugLoader == null) {
                 try {
                     MetaClassLoader.debugLoader = new MetaClassLoader(
-                            new URLClassLoader(new URL[] {dir.toURI().toURL()}));
+                            new URLClassLoader2(new URL[] {dir.toURI().toURL()}));
                 } catch (MalformedURLException e) {
                     throw new AssertionError(e);
                 }

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -129,7 +129,6 @@ import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.charset.Charset;
@@ -172,6 +171,7 @@ import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.security.ApiTokenProperty;
 import jenkins.security.MasterToSlaveCallable;
+import jenkins.util.URLClassLoader2;
 import net.sf.json.JSON;
 import net.sf.json.JSONObject;
 import org.apache.commons.beanutils.PropertyUtils;
@@ -2955,7 +2955,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             if (dir.exists() && MetaClassLoader.debugLoader == null) {
                 try {
                     MetaClassLoader.debugLoader = new MetaClassLoader(
-                            new URLClassLoader(new URL[] {dir.toURI().toURL()}));
+                            new URLClassLoader2(new URL[] {dir.toURI().toURL()}));
                 } catch (MalformedURLException e) {
                     throw new AssertionError(e);
                 }

--- a/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/RealJenkinsRule.java
@@ -58,7 +58,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -119,6 +118,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.test.https.KeyStoreManager;
 import jenkins.util.Timer;
+import jenkins.util.URLClassLoader2;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.htmlunit.WebClient;
@@ -1626,7 +1626,7 @@ public final class RealJenkinsRule implements TestRule {
             Object pluginManager = jenkins.getClass().getField("pluginManager").get(jenkins);
             ClassLoader uberClassLoader = (ClassLoader)
                     pluginManager.getClass().getField("uberClassLoader").get(pluginManager);
-            ClassLoader tests = new URLClassLoader(
+            ClassLoader tests = new URLClassLoader2(
                     Files.readAllLines(
                                     Paths.get(System.getProperty("RealJenkinsRule.classpath")), StandardCharsets.UTF_8)
                             .stream()

--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/RealJenkinsExtension.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/RealJenkinsExtension.java
@@ -77,6 +77,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.test.https.KeyStoreManager;
 import jenkins.util.Timer;
+import jenkins.util.URLClassLoader2;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.htmlunit.WebClient;
@@ -1583,7 +1584,7 @@ public class RealJenkinsExtension implements BeforeEachCallback, AfterEachCallba
             Object pluginManager = jenkins.getClass().getField("pluginManager").get(jenkins);
             ClassLoader uberClassLoader = (ClassLoader)
                     pluginManager.getClass().getField("uberClassLoader").get(pluginManager);
-            ClassLoader tests = new URLClassLoader(
+            ClassLoader tests = new URLClassLoader2(
                     Files.readAllLines(
                                     Paths.get(System.getProperty("RealJenkinsExtension.classpath")),
                                     StandardCharsets.UTF_8)


### PR DESCRIPTION
Prior to https://github.com/jenkinsci/jenkins/pull/10659, there was not a specific need to use `URLClassLoader2`, as it didn't behave any differently from `URLClassLoader`. As of that PR, its `getClassLoadingLock` method behaves differently, so it's worth exercising that code in our tests.

### Testing done

Will run PCT.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
