### PR TITLE
Replace 'slave' with 'agent' in comments and log messages

### DIFF
--- a/src/main/java/hudson/slaves/DummyCloudImpl.java
+++ b/src/main/java/hudson/slaves/DummyCloudImpl.java
@@ -39,7 +39,7 @@ import org.jvnet.hudson.test.JenkinsRule;
  * {@link Cloud} implementation useful for testing.
  *
  * <p>
- * This implementation launches "java -jar slave.jar" on the localhost when provisioning a new slave.
+ * This implementation launches "java -jar agent.jar" on the localhost when provisioning a new agent.
  *
  * @author Kohsuke Kawaguchi
  */
@@ -47,7 +47,7 @@ public class DummyCloudImpl extends Cloud {
     private final transient JenkinsRule rule;
 
     /**
-     * Configurable delay between the {@link Cloud#provision(Label,int)} and the actual launch of a slave,
+     * Configurable delay between the {@link Cloud#provision(Label,int)} and the actual launch of a agent,
      * to emulate a real cloud that takes some time for provisioning a new system.
      *
      * <p>
@@ -118,11 +118,11 @@ public class DummyCloudImpl extends Cloud {
 
         @Override
         public Node call() throws Exception {
-            // simulate the delay in provisioning a new slave,
+            // simulate the delay in provisioning a new agent,
             // since it's normally some async operation.
             Thread.sleep(time);
 
-            System.out.println("launching slave");
+            System.out.println("launching agent");
             final DumbSlave slave = rule.createSlave(label);
             for (NodeProperty nodeProperty : nodeProperties) {
                 slave.getNodeProperties().add(updateWithNode(nodeProperty, slave));

--- a/src/main/java/org/jvnet/hudson/test/FakeLauncher.java
+++ b/src/main/java/org/jvnet/hudson/test/FakeLauncher.java
@@ -10,11 +10,11 @@ import java.io.OutputStream;
  * Fake a process launch.
  *
  * @author Kohsuke Kawaguchi
- * @see PretendSlave
+ * @see PretendAgent
  */
 public interface FakeLauncher {
     /**
-     * Called whenever a {@link PretendSlave} is asked to fork a new process.
+     * Called whenever a {@link PretendAgent} is asked to fork a new process.
      *
      * <p>
      * The callee can inspect the {@link ProcStarter} object to determine what process is being launched,

--- a/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -615,7 +615,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     }
 
     /**
-     * Creates and launches a new slave on the local host.
+     * Creates and launches a new agent on the local host.
      */
     public DumbSlave createSlave(Label l) throws Exception {
         return createSlave(l, null);
@@ -666,7 +666,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     }
 
     /**
-     * Creates a slave with certain additional environment variables
+     * Creates a agent with certain additional environment variables
      */
     public DumbSlave createSlave(String labels, EnvVars env) throws Exception {
         synchronized (jenkins) {
@@ -703,10 +703,10 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     }
 
     /**
-     * Creates a {@link ComputerLauncher} for launching a slave locally.
+     * Creates a {@link ComputerLauncher} for launching a agent locally.
      *
      * @param env
-     *      Environment variables to add to the slave process. Can be null.
+     *      Environment variables to add to the agent process. Can be null.
      */
     public ComputerLauncher createComputerLauncher(EnvVars env) throws URISyntaxException, IOException {
         int sz = jenkins.getNodes().size();
@@ -723,7 +723,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     }
 
     /**
-     * Create a new slave on the local host and wait for it to come online
+     * Create a new agent on the local host and wait for it to come online
      * before returning.
      */
     public DumbSlave createOnlineSlave() throws Exception {
@@ -731,7 +731,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     }
 
     /**
-     * Create a new slave on the local host and wait for it to come online
+     * Create a new agent on the local host and wait for it to come online
      * before returning.
      */
     public DumbSlave createOnlineSlave(Label l) throws Exception {
@@ -739,7 +739,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     }
 
     /**
-     * Create a new slave on the local host and wait for it to come online
+     * Create a new agent on the local host and wait for it to come online
      * before returning
      */
     @SuppressWarnings("deprecation")
@@ -1838,7 +1838,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     protected static final List<ToolProperty<?>> NO_PROPERTIES = List.of();
 
     /**
-     * Specify this to a TCP/IP port number to have slaves started with the debugger.
+     * Specify this to a TCP/IP port number to have agents started with the debugger.
      */
     public static int SLAVE_DEBUG_PORT = Integer.getInteger(HudsonTestCase.class.getName() + ".slaveDebugPort", -1);
 

--- a/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
+++ b/src/main/java/org/jvnet/hudson/test/InboundAgentRule.java
@@ -71,7 +71,7 @@ import org.junit.rules.ExternalResource;
  * <p>To avoid flakiness when tearing down the test, ensure that the agent has gone offline with:
  *
  * <pre>
- * Slave agent = inboundAgents.createAgent(r, […]);
+ * Agent agent = inboundAgents.createAgent(r, […]);
  * try {
  *     […]
  * } finally {
@@ -80,7 +80,7 @@ import org.junit.rules.ExternalResource;
  * </pre>
  *
  * @see JenkinsRule#createComputerLauncher
- * @see JenkinsRule#createSlave()
+ * @see JenkinsRule#createAgent()
  */
 public final class InboundAgentRule extends ExternalResource {
 
@@ -331,7 +331,7 @@ public final class InboundAgentRule extends ExternalResource {
     /**
      * Creates, attaches, and starts a new inbound agent.
      *
-     * @param name an optional {@link Slave#getNodeName}
+     * @param name an optional {@link Agent#getNodeName}
      */
     public Slave createAgent(@NonNull JenkinsRule r, @CheckForNull String name) throws Exception {
         return createAgent(r, Options.newBuilder().name(name).build());
@@ -662,7 +662,7 @@ public final class InboundAgentRule extends ExternalResource {
             throw new AssertionError("no such agent: " + name);
         }
         if (!(node instanceof Slave)) {
-            throw new AssertionError("agent is not a Slave: " + name);
+            throw new AssertionError("agent is not a Agent: " + name);
         }
         r.waitOnline((Slave) node);
         if (!loggers.isEmpty()) {
@@ -701,7 +701,7 @@ public final class InboundAgentRule extends ExternalResource {
         s.setLabelString(options.getLabel());
         s.setRetentionStrategy(RetentionStrategy.NOOP);
         r.jenkins.addNode(s);
-        // SlaveComputer#_connect runs asynchronously. Wait for it to finish for a more deterministic test.
+        // AgentComputer#_connect runs asynchronously. Wait for it to finish for a more deterministic test.
         Computer computer = s.toComputer();
         while (computer == null || computer.getOfflineCause() == null) {
             Thread.sleep(100);

--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -905,7 +905,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             long start = System.currentTimeMillis();
             while (slave.getChannel() == null) {
                 if (System.currentTimeMillis() > (start + 10000)) {
-                    throw new IllegalStateException("Timed out waiting on DumbSlave channel to connect.");
+                    throw new IllegalStateException("Timed out waiting on DumbAgent channel to connect.");
                 }
                 Thread.sleep(200);
             }
@@ -920,7 +920,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         long start = System.currentTimeMillis();
         while (slave.getChannel() != null) {
             if (System.currentTimeMillis() > (start + 10000)) {
-                throw new IllegalStateException("Timed out waiting on DumbSlave channel to disconnect.");
+                throw new IllegalStateException("Timed out waiting on DumbAgent channel to disconnect.");
             }
             Thread.sleep(200);
         }
@@ -936,7 +936,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     /**
-     * Creates and launches a new slave on the local host.
+     * Creates and launches a new agent on the local host.
      */
     @NonNull
     public DumbSlave createSlave(@CheckForNull Label l) throws Exception {
@@ -1020,7 +1020,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     /**
-     * Creates a slave with certain additional environment variables
+     * Creates a agent with certain additional environment variables
      */
     @NonNull
     public DumbSlave createSlave(@CheckForNull String labels, @CheckForNull EnvVars env) throws Exception {
@@ -1066,7 +1066,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * Creates a launcher for starting a local agent.
      * This is an outbound agent using {@link SimpleCommandLauncher}.
      * @param env
-     *      Environment variables to add to the slave process. Can be {@code null}.
+     *      Environment variables to add to the agent process. Can be {@code null}.
      * @see InboundAgentRule
      */
     @NonNull
@@ -1085,7 +1085,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     /**
-     * Create a new slave on the local host and wait for it to come online
+     * Create a new agent on the local host and wait for it to come online
      * before returning.
      */
     @NonNull
@@ -1094,7 +1094,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     /**
-     * Create a new slave on the local host and wait for it to come online
+     * Create a new agent on the local host and wait for it to come online
      * before returning.
      */
     @NonNull
@@ -1103,7 +1103,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     /**
-     * Create a new slave on the local host and wait for it to come online
+     * Create a new agent on the local host and wait for it to come online
      * before returning
      * @see #waitOnline
      */
@@ -1133,8 +1133,8 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     /**
-     * Waits for a newly created slave to come online.
-     * @see #createSlave()
+     * Waits for a newly created agent to come online.
+     * @see #createAgent()
      */
     public void waitOnline(Slave s) throws Exception {
         Computer computer = s.toComputer();
@@ -1166,14 +1166,14 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     }
 
     /**
-     * Same as {@link #showAgentLogs(Slave, Map)} but taking a preconfigured list of loggers as a convenience.
+     * Same as {@link #showAgentLogs(Agent, Map)} but taking a preconfigured list of loggers as a convenience.
      */
     public void showAgentLogs(Slave s, LoggerRule loggerRule) throws Exception {
         showAgentLogs(s, loggerRule.getRecordedLevels());
     }
 
     /**
-     * Same as {@link #showAgentLogs(Slave, Map)} but taking a preconfigured list of loggers as a convenience.
+     * Same as {@link #showAgentLogs(Agent, Map)} but taking a preconfigured list of loggers as a convenience.
      */
     public void showAgentLogs(Slave s, LogRecorder logRecorder) throws Exception {
         showAgentLogs(s, logRecorder.getRecordedLevels());
@@ -2986,7 +2986,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     public static final List<ToolProperty<?>> NO_PROPERTIES = List.of();
 
     /**
-     * Specify this to a TCP/IP port number to have slaves started with the debugger.
+     * Specify this to a TCP/IP port number to have Agents started with the debugger.
      */
     public static final int SLAVE_DEBUG_PORT =
             Integer.getInteger(HudsonTestCase.class.getName() + ".slaveDebugPort", -1);

--- a/src/main/java/org/jvnet/hudson/test/PretendSlave.java
+++ b/src/main/java/org/jvnet/hudson/test/PretendSlave.java
@@ -14,10 +14,10 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Slave that pretends to fork processes.
+ * Agent that pretends to fork processes.
  *
  * @author Kohsuke Kawaguchi
- * @see HudsonTestCase#createPretendSlave(FakeLauncher)
+ * @see HudsonTestCase#createPretendAgent(FakeLauncher)
  */
 public class PretendSlave extends Slave {
     private transient FakeLauncher faker;

--- a/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
+++ b/src/main/java/org/jvnet/hudson/test/TemporaryDirectoryAllocator.java
@@ -57,7 +57,7 @@ public class TemporaryDirectoryAllocator {
 
     /**
      * Whether there should be a space character in the allocated temporary directories names.
-     * It forces slaves created from a {@link JenkinsRule} to work inside a hazardous path,
+     * It forces agents created from a {@link JenkinsRule} to work inside a hazardous path,
      * which can help catching shell quoting bugs.<br>
      * If a particular test cannot be readily fixed to tolerate spaces, as a workaround try:
      * {@code @ClassRule public static TestRule noSpaceInTmpDirs = FlagRule.systemProperty("jenkins.test.noSpaceInTmpDirs", "true");}

--- a/src/main/java/org/jvnet/hudson/test/junit/jupiter/InboundAgentExtension.java
+++ b/src/main/java/org/jvnet/hudson/test/junit/jupiter/InboundAgentExtension.java
@@ -65,7 +65,7 @@ import org.jvnet.hudson.test.PrefixedOutputStream;
  * <p>To avoid flakiness when tearing down the test, ensure that the agent has gone offline with:
  *
  * <pre>
- * Slave agent = inboundAgents.createAgent(r, […]);
+ * Agent agent = inboundAgents.createAgent(r, […]);
  * try {
  *     […]
  * } finally {
@@ -74,7 +74,7 @@ import org.jvnet.hudson.test.PrefixedOutputStream;
  * </pre>
  *
  * @see JenkinsRule#createComputerLauncher
- * @see JenkinsRule#createSlave()
+ * @see JenkinsRule#createAgent()
  */
 public class InboundAgentExtension implements AfterEachCallback {
 
@@ -303,7 +303,7 @@ public class InboundAgentExtension implements AfterEachCallback {
     /**
      * Creates, attaches, and starts a new inbound agent.
      *
-     * @param name an optional {@link Slave#getNodeName}
+     * @param name an optional {@link Agent#getNodeName}
      */
     public Slave createAgent(@NonNull JenkinsRule r, @CheckForNull String name) throws Exception {
         return createAgent(r, Options.newBuilder().name(name).build());
@@ -630,7 +630,7 @@ public class InboundAgentExtension implements AfterEachCallback {
             throw new AssertionError("no such agent: " + name);
         }
         if (!(node instanceof Slave)) {
-            throw new AssertionError("agent is not a Slave: " + name);
+            throw new AssertionError("agent is not a Agent: " + name);
         }
         r.waitOnline((Slave) node);
         if (!loggers.isEmpty()) {
@@ -669,7 +669,7 @@ public class InboundAgentExtension implements AfterEachCallback {
         s.setLabelString(options.getLabel());
         s.setRetentionStrategy(RetentionStrategy.NOOP);
         r.jenkins.addNode(s);
-        // SlaveComputer#_connect runs asynchronously. Wait for it to finish for a more deterministic test.
+        // AgentComputer#_connect runs asynchronously. Wait for it to finish for a more deterministic test.
         Computer computer = s.toComputer();
         while (computer == null || computer.getOfflineCause() == null) {
             Thread.sleep(100);

--- a/src/test/java/org/jvnet/hudson/test/HudsonTestCaseShutdownSlaveTest.java
+++ b/src/test/java/org/jvnet/hudson/test/HudsonTestCaseShutdownSlaveTest.java
@@ -31,10 +31,10 @@ import hudson.slaves.SlaveComputer;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Test that slaves are cleanly shutdown when test finishes.
+ * Test that agents are cleanly shutdown when test finishes.
  * <p>
  * In Windows, temporary directories fail to be deleted
- * if log files of slaves are not closed.
+ * if log files of agents are not closed.
  * This causes failures of tests using HudsonTestCase,
  * for an exception occurs in tearDown().
  * <p>
@@ -56,7 +56,7 @@ public class HudsonTestCaseShutdownSlaveTest extends HudsonTestCase {
         assertNotNull(slave4);
         assertNotNull(slave5);
 
-        // A build runs on slave1 and finishes.
+        // A build runs on agent1 and finishes.
         {
             FreeStyleProject project1 = createFreeStyleProject();
             project1.setAssignedLabel(LabelExpression.parseExpression(slave1.getNodeName()));
@@ -64,7 +64,7 @@ public class HudsonTestCaseShutdownSlaveTest extends HudsonTestCase {
             assertBuildStatusSuccess(project1.scheduleBuild2(0));
         }
 
-        // A build runs on slave2 and finishes, then disconnect slave2
+        // A build runs on agent2 and finishes, then disconnect agent2
         {
             FreeStyleProject project2 = createFreeStyleProject();
             project2.setAssignedLabel(LabelExpression.parseExpression(slave2.getNodeName()));
@@ -76,7 +76,7 @@ public class HudsonTestCaseShutdownSlaveTest extends HudsonTestCase {
             computer2.waitUntilOffline();
         }
 
-        // A build runs on slave3 and does not finish.
+        // A build runs on agent3 and does not finish.
         // This build will be interrupted in tearDown().
         {
             FreeStyleProject project3 = createFreeStyleProject();


### PR DESCRIPTION
### Summary
This PR uses the term "agent" instead of the obsolete "slave" in comments, println statements, and error messages.
No functional code or API changes have been made.

### Checklist
- [x]  Only comments and messages updated.
- [x]  Verification build pass locally
- [x]  No behavioral changes introduced. 
