### PR TITLE
Prefer `Path.of(uri)` to `new File(uri)`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -134,6 +134,7 @@ import java.net.URLConnection;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1080,7 +1081,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                                 ? " -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=" + (SLAVE_DEBUG_PORT + sz)
                                 : "",
                         "-Djava.awt.headless=true",
-                        new File(jenkins.getJnlpJars("slave.jar").getURL().toURI()).getAbsolutePath()),
+                        Path.of(jenkins.getJnlpJars("slave.jar").getURL().toURI())),
                 env);
     }
 


### PR DESCRIPTION
While trying to reproduce https://github.com/jenkinsci/jenkins/pull/11102#issuecomment-3330920932 on Java 21 in a Windows Server machine running on Vagrant using sources mounted as a file share, I got a different (earlier) failure

```
java.lang.IllegalArgumentException: URI has an authority component
	at java.base/java.io.File.<init>(File.java:425)
	at org.jvnet.hudson.test.JenkinsRule.createComputerLauncher(JenkinsRule.java:1083)
	at org.jvnet.hudson.test.JenkinsRule.createSlave(JenkinsRule.java:1040)
	at org.jvnet.hudson.test.JenkinsRule.createSlave(JenkinsRule.java:1029)
	at org.jvnet.hudson.test.JenkinsRule.createSlave(JenkinsRule.java:935)
	at hudson.model.ComputerTest.computerIconDependsOnOfflineCause(ComputerTest.java:154)
```

which is solved by this patch.

https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/io/File.html#%3Cinit%3E(java.net.URI) is not deprecated but does note that the authority must not be specified, and similarly for https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/io/File.html#toURI() if this were generated by https://github.com/jenkinsci/jenkins/blob/cfebcec2e8f3ed6d3c60ac1572eaf2f735f90328/core/src/main/java/hudson/model/Slave.java#L523 though I was using `-pl test surefire:test` and perhaps it was using https://github.com/jenkinsci/jenkins/blob/cfebcec2e8f3ed6d3c60ac1572eaf2f735f90328/core/src/main/java/hudson/model/Slave.java#L503 which might have been going through https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/nio/file/Path.html#toUri() which like https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/nio/file/Path.html#of(java.net.URI) permits an authority:

> Whether the authority component is defined or not is implementation dependent. There is no guarantee that the `URI` may be used to construct a `java.io.File`. In particular, if this path represents a Universal Naming Convention (UNC) path, then the UNC server name may be encoded in the authority component of the resulting URI.

In general (I feel like this needs to go into some sort of org-wide `agents.md`),

* do not assume that the path of a URL/URI corresponds to a filesystem path when the protocol/scheme is `file` (for starters, it may have encoded non-URL-safe characters like spaces or `#`)
* prefer `URI` to `URL` for round-tripping filesystem paths
* prefer `Path` to `File` for these round trips
