### PR TITLE
Deprecate `JenkinsRule.restart`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -3056,7 +3056,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
     /**
      * Restart the current instance with the same port and a copy of its {@code JENKINS_HOME}.
+     * @deprecated Rewrite to {@link RealJenkinsRule} and use {@link RealJenkinsRule#stopJenkinsForcibly}.
      */
+    @Deprecated
     public void restart() throws Throwable {
         // create backup of current instance as zip
         File source = jenkins.getRootDir();


### PR DESCRIPTION
This may be convenient as a stopgap for migration from `RestartableJenkinsRule` but should not be encouraged.