### PR TITLE
remove obsolete RUN_SCRIPTS permission

### DIFF
--- a/src/test/java/org/jvnet/hudson/test/MockAuthorizationStrategyTest.java
+++ b/src/test/java/org/jvnet/hudson/test/MockAuthorizationStrategyTest.java
@@ -69,11 +69,10 @@ public class MockAuthorizationStrategyTest {
                 .onFolders(d)
                 .to("dev"));
         try (ACLContext ctx = ACL.as(User.get("root"))) {
-            assertTrue(r.jenkins.hasPermission(Jenkins.RUN_SCRIPTS));
+            assertTrue(r.jenkins.hasPermission(Jenkins.ADMINISTER));
             assertTrue(p.hasPermission(Item.DELETE));
         }
         try (ACLContext ctx = ACL.as(User.get("admin"))) {
-            assertFalse(r.jenkins.hasPermission(Jenkins.RUN_SCRIPTS));
             assertTrue(r.jenkins.hasPermission(Jenkins.ADMINISTER));
             assertFalse(p.hasPermission(Item.DELETE));
             assertTrue(p.hasPermission(Item.READ));
@@ -97,7 +96,7 @@ public class MockAuthorizationStrategyTest {
             assertTrue(p.hasPermission(Item.READ));
             assertFalse(p.hasPermission(Item.EXTENDED_READ));
         }
-        assertTrue("SYSTEM has everything", r.jenkins.hasPermission(Jenkins.RUN_SCRIPTS)); // handled by SidACL
+        assertTrue("SYSTEM has everything", r.jenkins.hasPermission(Jenkins.ADMINISTER)); // handled by SidACL
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

`Jenkins.RUN_SCRIPTS` was deprecated in 2.222 and is scheduled for removal in a future version.  Remove the permission from the test.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
