### PR TITLE
Move to renovate parent config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    ":dependencyDashboard"
+    "github>jenkinsci/renovate-config"
   ],
   "enabledManagers": [
     "custom.regex"


### PR DESCRIPTION
The change proposed moves the existing renovate config to our [parent config](https://github.com/jenkinsci/renovate-config) to ease maintenance.

Custom configurations, if available, are still effective.