### PR TITLE
Tolerate `BindException` in `createWebServer`

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -124,6 +124,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.net.BindException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
@@ -135,6 +136,7 @@ import java.nio.channels.ClosedByInterruptException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -793,11 +795,26 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      */
     protected ServletContext createWebServer2() throws Exception {
         JettyProvider jp = findJettyProvider();
-        JettyProvider.Context jpc = jp.createWebServer(localPort, contextPath, this::configureUserRealm);
+        JettyProvider.Context jpc;
+        try {
+            jpc = jp.createWebServer(localPort, contextPath, this::configureUserRealm);
+        } catch (Exception x) {
+            if (hasBindException(x)) {
+                LOGGER.log(Level.WARNING, "Socket may be open from a previous test; will retry", x);
+                Thread.sleep(Duration.ofSeconds(15).toMillis());
+                jpc = jp.createWebServer(localPort, contextPath, this::configureUserRealm);
+            } else {
+                throw x;
+            }
+        }
         localPort = jpc.localPort();
         server = jpc.server();
         LOGGER.log(Level.INFO, "Running on {0}", getURL());
         return jpc.servletContext();
+    }
+
+    private static boolean hasBindException(Throwable t) {
+        return t instanceof BindException || t != null && hasBindException(t.getCause());
     }
 
     private static JettyProvider findJettyProvider() {


### PR DESCRIPTION
As of https://github.com/jenkinsci/kubernetes-plugin/commit/07ad3c6ad8995c755604204d2e81c24179ed3e2a merged with https://github.com/jenkinsci/kubernetes-plugin/commit/2153d3ce in https://github.com/jenkinsci/kubernetes-plugin/pull/2837 sped up a bit with

```diff
diff --git src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
index dc353d20..6674f2aa 100644
--- src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
+++ src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
@@ -74,7 +74,11 @@ public abstract class AbstractKubernetesPipelineTest {
     protected KubernetesCloud cloud;
 
     @Rule
-    public JenkinsRule r = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule() {
+        {
+            timeout = 60;
+        }
+    };
 
     @Rule
     public LoggerRule logs = new LoggerRule()
```

```bash
mvnd test -Pktunnel -Dtest=KubernetesPipelineTest#runWithEnvVariablesInContext,KubernetesPipelineTest#runInPodWithLivenessProbe
```

fails both tests even though it is only the former that fails by timing out; the latter passes in isolation:

```
…
[WARNING] [stderr]   57.645 [id=268]	FINE	hudson.model.AsyncPeriodicWork#lambda$doRun$0: Finished Garbage collection of orphaned Kubernetes pods. 0 ms
[WARNING] [stderr]   60.001 [id=3]	WARNING	o.j.hudson.test.JenkinsRule$2#evaluate: Test timed out (after 60 seconds).
[WARNING] [stderr]   60.043 [id=67]	WARNING	o.c.j.p.k.p.KubernetesPipelineTest#allDead: Had to interrupt run With Env Variables In Context #1
[WARNING] [stderr] "ForkJoinPool.commonPool-worker-1" Id=159 Group=InnocuousForkJoinWorkerThreadGroup TIMED_WAITING on java.util.concurrent.ForkJoinPool@30af23fd
…
[WARNING] [stderr] "Signal Dispatcher" Id=13 Group=system RUNNABLE
[WARNING] [stderr] 
[WARNING] [stderr] 
[INFO] [stdout] === Starting runInPodWithLivenessProbe(org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesPipelineTest)
[WARNING] [stderr]    0.001 [id=269]	WARNING	o.jvnet.hudson.test.JenkinsRule#before: Jenkins.theInstance was not cleared by a previous test, doing that now
[WARNING] [stderr]    0.006 [run With Env Variables In Context #1] Sending interrupt signal to process
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 61.23 s <<< FAILURE! -- in org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesPipelineTest
[ERROR] org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesPipelineTest.runWithEnvVariablesInContext -- Time elapsed: 60.28 s <<< ERROR!
org.junit.runners.model.TestTimedOutException: test timed out after 60 seconds
	at java.base/java.lang.Object.wait0(Native Method)
	at java.base/java.lang.Object.wait(Object.java:389)
	at java.base/java.lang.Object.wait(Object.java:351)
	at hudson.remoting.AsyncFutureImpl.get(AsyncFutureImpl.java:80)
	at org.jvnet.hudson.test.JenkinsRule.waitForCompletion(JenkinsRule.java:1577)
	at org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesPipelineTest.runWithEnvVariablesInContext(KubernetesPipelineTest.java:420)
[ERROR] org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesPipelineTest.runInPodWithLivenessProbe -- Time elapsed: 0.006 s <<< ERROR!
java.io.IOException: Failed to bind to localhost/127.0.0.1:8000
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:349)
	at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:313)
	at org.eclipse.jetty.server.Server.lambda$doStart$0(Server.java:617)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:186)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:153)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:176)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:632)
	at org.eclipse.jetty.server.Server.doStart(Server.java:613)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:92)
	at org.jvnet.hudson.test.jetty.Jetty12EE9Provider.createWebServer(Jetty12EE9Provider.java:75)
	at org.jvnet.hudson.test.JenkinsRule.createWebServer2(JenkinsRule.java:796)
	at org.jvnet.hudson.test.JenkinsRule.newHudson(JenkinsRule.java:745)
	at org.jvnet.hudson.test.JenkinsRule.before(JenkinsRule.java:403)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:653)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.net.BindException: Address already in use
	at java.base/sun.nio.ch.Net.bind0(Native Method)
	at java.base/sun.nio.ch.Net.bind(Net.java:522)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.netBind(ServerSocketChannelImpl.java:335)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:297)
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:344)
	... 21 more
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   KubernetesPipelineTest.runInPodWithLivenessProbe » IO Failed to bind to localhost/127.0.0.1:8000
[ERROR]   KubernetesPipelineTest.runWithEnvVariablesInContext:420->Object.wait:351->Object.wait:389->Object.wait0:-2 » TestTimedOut test timed out after 60 seconds
[INFO] 
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0
```

Normally the Jenkins server port is randomized so this is not an issue, but in this plugin due to the needs of the Kubernetes tunnel we fix a port and so it is important to handle the case that the prior server process is still shutting down and has not released the socket cleanly yet. With `-Djenkins-test-harness.version=999999-SNAPSHOT` the second test passes as expected:

```
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 88.89 s <<< FAILURE! -- in org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesPipelineTest
[ERROR] org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesPipelineTest.runWithEnvVariablesInContext -- Time elapsed: 60.32 s <<< ERROR!
org.junit.runners.model.TestTimedOutException: test timed out after 60 seconds
	at java.base/java.lang.Object.wait0(Native Method)
	at java.base/java.lang.Object.wait(Object.java:389)
	at java.base/java.lang.Object.wait(Object.java:351)
	at hudson.remoting.AsyncFutureImpl.get(AsyncFutureImpl.java:80)
	at org.jvnet.hudson.test.JenkinsRule.waitForCompletion(JenkinsRule.java:1594)
	at org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesPipelineTest.runWithEnvVariablesInContext(KubernetesPipelineTest.java:420)
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   KubernetesPipelineTest.runWithEnvVariablesInContext:420->Object.wait:351->Object.wait:389->Object.wait0:-2 » TestTimedOut test timed out after 60 seconds
[INFO] 
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0
```

Note that this shows only `Jetty12EE9Provider`. I guess #941 was just preparing for https://github.com/jenkinsci/jenkins/issues/16714 but the effect on `Jetty12EE10Provider` cannot easily be tested yet.