### PR TITLE
test(harness): detect Jenkins-booting tests via PostDiscoveryFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ See https://javadoc.jenkins.io/component/jenkins-test-harness/
 
 * See [GitHub Releases](https://github.com/jenkinsci/jenkins-test-harness/releases).
 * For releases before `2.49`, see [this archive](./docs/CHANGELOG-OLD.md)
+
+## Fast-tests opt-in filter
+
+A JUnit Platform PostDiscoveryFilter is provided to allow excluding tests that boot a real Jenkins instance
+(i.e., tests annotated with `@WithJenkins` or `@WithJenkinsConfiguredWithCode`). To enable exclusion set
+`-Djenkins.tests.excludeJenkins=true` in Surefire/Failsafe when running tests (opt-in). By default the filter is disabled.

--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ See https://javadoc.jenkins.io/component/jenkins-test-harness/
 ## Fast-tests opt-in filter
 
 A JUnit Platform PostDiscoveryFilter is provided to allow excluding tests that boot a real Jenkins instance
-(i.e., tests annotated with `@WithJenkins` or `@WithJenkinsConfiguredWithCode`). To enable exclusion set
-`-Djenkins.tests.excludeJenkins=true` in Surefire/Failsafe when running tests (opt-in). By default the filter is disabled.
+(i.e., tests annotated with `@WithJenkins` or `@WithJenkinsConfiguredWithCode` whose method declares the
+corresponding rule parameter). To enable exclusion set `-Djenkins.tests.excludeJenkins=true` in Surefire/Failsafe
+when running tests (opt-in). By default the filter is disabled.

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,10 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-suite</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkinsci/test/JenkinsBootTestFilter.java
+++ b/src/main/java/org/jenkinsci/test/JenkinsBootTestFilter.java
@@ -1,16 +1,15 @@
 package org.jenkinsci.test;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
-import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.launcher.PostDiscoveryFilter;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.Optional;
 
 /**
  * PostDiscoveryFilter that excludes tests (when enabled) which are annotated with

--- a/src/main/java/org/jenkinsci/test/JenkinsBootTestFilter.java
+++ b/src/main/java/org/jenkinsci/test/JenkinsBootTestFilter.java
@@ -1,0 +1,117 @@
+package org.jenkinsci.test;
+
+import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+/**
+ * PostDiscoveryFilter that excludes tests (when enabled) which are annotated with
+ * org.jvnet.hudson.test.WithJenkins or org.jvnet.hudson.test.WithJenkinsConfiguredWithCode.
+ *
+ * Enabled by setting -Djenkins.tests.excludeJenkins=true (opt-in). By default the filter is a no-op.
+ */
+public class JenkinsBootTestFilter implements PostDiscoveryFilter {
+    private static final String WITH_JENKINS = "org.jvnet.hudson.test.WithJenkins";
+    private static final String WITH_JENKINS_CONFIGURED = "org.jvnet.hudson.test.WithJenkinsConfiguredWithCode";
+
+    private static final boolean EXCLUDE = Boolean.getBoolean("jenkins.tests.excludeJenkins");
+
+    @Override
+    public FilterResult apply(TestDescriptor descriptor) {
+        if (!EXCLUDE) {
+            return FilterResult.included("filter disabled");
+        }
+        Optional<TestSource> sourceOpt = descriptor.getSource();
+        if (!sourceOpt.isPresent()) {
+            return FilterResult.included("no source");
+        }
+        TestSource source = sourceOpt.get();
+        String className = null;
+        String methodName = null;
+        if (source instanceof MethodSource) {
+            MethodSource ms = (MethodSource) source;
+            className = ms.getClassName();
+            methodName = ms.getMethodName();
+        } else if (source instanceof ClassSource) {
+            ClassSource cs = (ClassSource) source;
+            className = cs.getClassName();
+        }
+
+        if (className == null) {
+            return FilterResult.included("unknown source");
+        }
+
+        try {
+            Class<?> cls = Class.forName(className);
+            if (hasJenkinsAnnotationOnClass(cls)) {
+                return FilterResult.excluded("class annotated with WithJenkins or WithJenkinsConfiguredWithCode");
+            }
+            if (methodName != null) {
+                Method m = findMethod(cls, methodName);
+                if (m != null && hasJenkinsAnnotationOnMethod(m)) {
+                    return FilterResult.excluded("method annotated with WithJenkins or WithJenkinsConfiguredWithCode");
+                }
+            }
+        } catch (Throwable t) {
+            // If any reflection error occurs, include the test rather than risk excluding wrongly
+            return FilterResult.included("error while checking annotations: " + t.getMessage());
+        }
+
+        return FilterResult.included("no Jenkins annotations detected");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean hasJenkinsAnnotationOnClass(Class<?> cls) {
+        try {
+            Class<? extends Annotation> a1 = (Class<? extends Annotation>) Class.forName(WITH_JENKINS);
+            Class<? extends Annotation> a2 = (Class<? extends Annotation>) Class.forName(WITH_JENKINS_CONFIGURED);
+            if (AnnotationSupport.isAnnotated(cls, a1) || AnnotationSupport.isAnnotated(cls, a2)) {
+                return true;
+            }
+            Class<?> sup = cls.getSuperclass();
+            while (sup != null && sup != Object.class) {
+                if (AnnotationSupport.isAnnotated(sup, a1) || AnnotationSupport.isAnnotated(sup, a2)) {
+                    return true;
+                }
+                sup = sup.getSuperclass();
+            }
+        } catch (ClassNotFoundException e) {
+            // Annotation types not present on classpath; treat as not annotated
+            return false;
+        }
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean hasJenkinsAnnotationOnMethod(Method m) {
+        try {
+            Class<? extends Annotation> a1 = (Class<? extends Annotation>) Class.forName(WITH_JENKINS);
+            Class<? extends Annotation> a2 = (Class<? extends Annotation>) Class.forName(WITH_JENKINS_CONFIGURED);
+            return AnnotationSupport.isAnnotated(m, a1) || AnnotationSupport.isAnnotated(m, a2);
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    private static Method findMethod(Class<?> cls, String methodName) {
+        for (Method m : cls.getDeclaredMethods()) {
+            if (m.getName().equals(methodName)) {
+                return m;
+            }
+        }
+        for (Method m : cls.getMethods()) {
+            if (m.getName().equals(methodName)) {
+                return m;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/jenkinsci/test/JenkinsBootTestFilter.java
+++ b/src/main/java/org/jenkinsci/test/JenkinsBootTestFilter.java
@@ -1,7 +1,9 @@
 package org.jenkinsci.test;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.Optional;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.engine.FilterResult;
@@ -10,22 +12,32 @@ import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.jvnet.hudson.test.JenkinsRule;
 
 /**
- * PostDiscoveryFilter that excludes tests (when enabled) which are annotated with
- * org.jvnet.hudson.test.WithJenkins or org.jvnet.hudson.test.WithJenkinsConfiguredWithCode.
+ * PostDiscoveryFilter that excludes tests (when enabled) which boot a real Jenkins instance via
+ * {@code org.jvnet.hudson.test.junit.jupiter.WithJenkins} or
+ * {@code io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode}.
  *
  * Enabled by setting -Djenkins.tests.excludeJenkins=true (opt-in). By default the filter is a no-op.
+ *
+ * Both annotations only boot Jenkins for a method that declares the corresponding rule parameter
+ * ({@link JenkinsRule} / {@code JenkinsConfiguredWithCodeRule}); per their own javadoc, an
+ * annotated method without that parameter behaves as if it were not annotated, so the filter
+ * mirrors that check instead of excluding every method in an annotated class.
  */
 public class JenkinsBootTestFilter implements PostDiscoveryFilter {
-    private static final String WITH_JENKINS = "org.jvnet.hudson.test.WithJenkins";
-    private static final String WITH_JENKINS_CONFIGURED = "org.jvnet.hudson.test.WithJenkinsConfiguredWithCode";
+    private static final String WITH_JENKINS = "org.jvnet.hudson.test.junit.jupiter.WithJenkins";
+    private static final String WITH_JENKINS_CONFIGURED =
+            "io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode";
+    private static final String JENKINS_CONFIGURED_WITH_CODE_RULE =
+            "io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule";
 
-    private static final boolean EXCLUDE = Boolean.getBoolean("jenkins.tests.excludeJenkins");
+    private static final String EXCLUDE_PROPERTY = "jenkins.tests.excludeJenkins";
 
     @Override
     public FilterResult apply(TestDescriptor descriptor) {
-        if (!EXCLUDE) {
+        if (!Boolean.getBoolean(EXCLUDE_PROPERTY)) {
             return FilterResult.included("filter disabled");
         }
         Optional<TestSource> sourceOpt = descriptor.getSource();
@@ -33,31 +45,21 @@ public class JenkinsBootTestFilter implements PostDiscoveryFilter {
             return FilterResult.included("no source");
         }
         TestSource source = sourceOpt.get();
-        String className = null;
-        String methodName = null;
-        if (source instanceof MethodSource) {
-            MethodSource ms = (MethodSource) source;
-            className = ms.getClassName();
-            methodName = ms.getMethodName();
-        } else if (source instanceof ClassSource) {
-            ClassSource cs = (ClassSource) source;
-            className = cs.getClassName();
-        }
-
-        if (className == null) {
-            return FilterResult.included("unknown source");
-        }
 
         try {
-            Class<?> cls = Class.forName(className);
-            if (hasJenkinsAnnotationOnClass(cls)) {
-                return FilterResult.excluded("class annotated with WithJenkins or WithJenkinsConfiguredWithCode");
-            }
-            if (methodName != null) {
-                Method m = findMethod(cls, methodName);
-                if (m != null && hasJenkinsAnnotationOnMethod(m)) {
-                    return FilterResult.excluded("method annotated with WithJenkins or WithJenkinsConfiguredWithCode");
+            if (source instanceof MethodSource) {
+                MethodSource ms = (MethodSource) source;
+                if (bootsJenkins(ms.getJavaClass(), ms.getJavaMethod())) {
+                    return FilterResult.excluded(
+                            "method boots Jenkins via WithJenkins or WithJenkinsConfiguredWithCode");
                 }
+            } else if (source instanceof ClassSource) {
+                Class<?> cls = ((ClassSource) source).getJavaClass();
+                if (isAnnotated(cls, WITH_JENKINS) || isAnnotated(cls, WITH_JENKINS_CONFIGURED)) {
+                    return FilterResult.excluded("class annotated with WithJenkins or WithJenkinsConfiguredWithCode");
+                }
+            } else {
+                return FilterResult.included("unsupported source");
             }
         } catch (Throwable t) {
             // If any reflection error occurs, include the test rather than risk excluding wrongly
@@ -67,50 +69,46 @@ public class JenkinsBootTestFilter implements PostDiscoveryFilter {
         return FilterResult.included("no Jenkins annotations detected");
     }
 
-    @SuppressWarnings("unchecked")
-    private static boolean hasJenkinsAnnotationOnClass(Class<?> cls) {
-        try {
-            Class<? extends Annotation> a1 = (Class<? extends Annotation>) Class.forName(WITH_JENKINS);
-            Class<? extends Annotation> a2 = (Class<? extends Annotation>) Class.forName(WITH_JENKINS_CONFIGURED);
-            if (AnnotationSupport.isAnnotated(cls, a1) || AnnotationSupport.isAnnotated(cls, a2)) {
+    private static boolean bootsJenkins(Class<?> cls, Method method) {
+        boolean withJenkins = isAnnotated(cls, WITH_JENKINS) || isAnnotated(method, WITH_JENKINS);
+        if (withJenkins && hasParameterOfType(method, JenkinsRule.class.getName())) {
+            return true;
+        }
+        boolean withJenkinsConfigured =
+                isAnnotated(cls, WITH_JENKINS_CONFIGURED) || isAnnotated(method, WITH_JENKINS_CONFIGURED);
+        return withJenkinsConfigured && hasParameterOfType(method, JENKINS_CONFIGURED_WITH_CODE_RULE);
+    }
+
+    private static boolean hasParameterOfType(Method method, String parameterTypeName) {
+        for (Parameter parameter : method.getParameters()) {
+            if (parameter.getType().getName().equals(parameterTypeName)) {
                 return true;
             }
-            Class<?> sup = cls.getSuperclass();
-            while (sup != null && sup != Object.class) {
-                if (AnnotationSupport.isAnnotated(sup, a1) || AnnotationSupport.isAnnotated(sup, a2)) {
-                    return true;
-                }
-                sup = sup.getSuperclass();
-            }
-        } catch (ClassNotFoundException e) {
-            // Annotation types not present on classpath; treat as not annotated
-            return false;
         }
         return false;
     }
 
     @SuppressWarnings("unchecked")
-    private static boolean hasJenkinsAnnotationOnMethod(Method m) {
+    private static boolean isAnnotated(AnnotatedElement element, String annotationClassName) {
         try {
-            Class<? extends Annotation> a1 = (Class<? extends Annotation>) Class.forName(WITH_JENKINS);
-            Class<? extends Annotation> a2 = (Class<? extends Annotation>) Class.forName(WITH_JENKINS_CONFIGURED);
-            return AnnotationSupport.isAnnotated(m, a1) || AnnotationSupport.isAnnotated(m, a2);
+            Class<? extends Annotation> annotationClass =
+                    (Class<? extends Annotation>) Class.forName(annotationClassName);
+            if (AnnotationSupport.isAnnotated(element, annotationClass)) {
+                return true;
+            }
+            if (element instanceof Class) {
+                Class<?> sup = ((Class<?>) element).getSuperclass();
+                while (sup != null && sup != Object.class) {
+                    if (AnnotationSupport.isAnnotated(sup, annotationClass)) {
+                        return true;
+                    }
+                    sup = sup.getSuperclass();
+                }
+            }
+            return false;
         } catch (ClassNotFoundException e) {
+            // Annotation type not present on classpath (e.g. the optional Configuration as Code dependency)
             return false;
         }
-    }
-
-    private static Method findMethod(Class<?> cls, String methodName) {
-        for (Method m : cls.getDeclaredMethods()) {
-            if (m.getName().equals(methodName)) {
-                return m;
-            }
-        }
-        for (Method m : cls.getMethods()) {
-            if (m.getName().equals(methodName)) {
-                return m;
-            }
-        }
-        return null;
     }
 }

--- a/src/main/resources/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
+++ b/src/main/resources/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
@@ -1,0 +1,1 @@
+org.jenkinsci.test.JenkinsBootTestFilter

--- a/src/test/java/org/jenkinsci/test/JenkinsBootTestFilterTest.java
+++ b/src/test/java/org/jenkinsci/test/JenkinsBootTestFilterTest.java
@@ -1,0 +1,155 @@
+package org.jenkinsci.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+class JenkinsBootTestFilterTest {
+
+    private static final String PROPERTY = "jenkins.tests.excludeJenkins";
+
+    @AfterEach
+    void clearProperty() {
+        System.clearProperty(PROPERTY);
+    }
+
+    @Test
+    void includesEverythingWhenFilterDisabled() throws Exception {
+        System.clearProperty(PROPERTY);
+        FilterResult result = new JenkinsBootTestFilter()
+                .apply(methodDescriptor(WithJenkinsSamples.class, "withRule", JenkinsRule.class));
+        assertTrue(result.included());
+    }
+
+    @Test
+    void excludesMethodAnnotatedDirectlyWithRuleParameter() throws Exception {
+        System.setProperty(PROPERTY, "true");
+        FilterResult result = new JenkinsBootTestFilter()
+                .apply(methodDescriptor(WithJenkinsSamples.class, "withRule", JenkinsRule.class));
+        assertFalse(result.included());
+    }
+
+    @Test
+    void includesAnnotatedMethodWithoutRuleParameter() throws Exception {
+        System.setProperty(PROPERTY, "true");
+        FilterResult result =
+                new JenkinsBootTestFilter().apply(methodDescriptor(WithJenkinsSamples.class, "withoutRule"));
+        assertTrue(result.included());
+    }
+
+    @Test
+    void excludesClassLevelAnnotatedMethodWithRuleParameter() throws Exception {
+        System.setProperty(PROPERTY, "true");
+        FilterResult result = new JenkinsBootTestFilter()
+                .apply(methodDescriptor(ClassLevelSample.class, "withRule", JenkinsRule.class));
+        assertFalse(result.included());
+    }
+
+    @Test
+    void includesClassLevelAnnotatedMethodWithoutRuleParameter() throws Exception {
+        System.setProperty(PROPERTY, "true");
+        FilterResult result =
+                new JenkinsBootTestFilter().apply(methodDescriptor(ClassLevelSample.class, "withoutRule"));
+        assertTrue(result.included());
+    }
+
+    @Test
+    void resolvesOverloadedMethodByItsOwnParameterTypes() throws Exception {
+        System.setProperty(PROPERTY, "true");
+        FilterResult withParam = new JenkinsBootTestFilter()
+                .apply(methodDescriptor(WithJenkinsSamples.class, "overloaded", JenkinsRule.class));
+        FilterResult withoutParam =
+                new JenkinsBootTestFilter().apply(methodDescriptor(WithJenkinsSamples.class, "overloaded"));
+
+        assertFalse(withParam.included());
+        assertTrue(withoutParam.included());
+    }
+
+    @Test
+    void detectsWithJenkinsEvenWhenOptionalCasCAnnotationIsAbsentFromClasspath() throws Exception {
+        // io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode is not a
+        // dependency of this module, so resolving it throws ClassNotFoundException; that must not
+        // prevent detection of the always-available @WithJenkins annotation.
+        System.setProperty(PROPERTY, "true");
+        FilterResult result = new JenkinsBootTestFilter()
+                .apply(methodDescriptor(WithJenkinsSamples.class, "withRule", JenkinsRule.class));
+        assertFalse(result.included());
+    }
+
+    @Test
+    void includesUnannotatedClass() throws Exception {
+        System.setProperty(PROPERTY, "true");
+        FilterResult result = new JenkinsBootTestFilter().apply(classDescriptor(JenkinsBootTestFilterTest.class));
+        assertTrue(result.included());
+    }
+
+    @Test
+    void excludesAnnotatedClassSource() throws Exception {
+        System.setProperty(PROPERTY, "true");
+        FilterResult result = new JenkinsBootTestFilter().apply(classDescriptor(ClassLevelSample.class));
+        assertFalse(result.included());
+    }
+
+    @Test
+    void isRegisteredAsPostDiscoveryFilterViaServiceLoader() {
+        boolean found = false;
+        for (PostDiscoveryFilter filter : ServiceLoader.load(PostDiscoveryFilter.class)) {
+            if (filter instanceof JenkinsBootTestFilter) {
+                found = true;
+            }
+        }
+        assertTrue(found, "JenkinsBootTestFilter must be discoverable via META-INF/services");
+    }
+
+    private static TestDescriptor methodDescriptor(Class<?> testClass, String methodName, Class<?>... paramTypes)
+            throws NoSuchMethodException {
+        Method method = testClass.getDeclaredMethod(methodName, paramTypes);
+        return sourcedDescriptor(MethodSource.from(testClass, method));
+    }
+
+    private static TestDescriptor classDescriptor(Class<?> testClass) {
+        return sourcedDescriptor(ClassSource.from(testClass));
+    }
+
+    private static TestDescriptor sourcedDescriptor(TestSource source) {
+        TestDescriptor descriptor = mock(TestDescriptor.class);
+        when(descriptor.getSource()).thenReturn(Optional.of(source));
+        return descriptor;
+    }
+
+    static class WithJenkinsSamples {
+        @WithJenkins
+        void withRule(JenkinsRule r) {}
+
+        @WithJenkins
+        void withoutRule() {}
+
+        @WithJenkins
+        void overloaded() {}
+
+        @WithJenkins
+        void overloaded(JenkinsRule r) {}
+    }
+
+    @WithJenkins
+    static class ClassLevelSample {
+        void withRule(JenkinsRule r) {}
+
+        void withoutRule() {}
+    }
+}


### PR DESCRIPTION
Adds a JUnit Platform PostDiscoveryFilter to detect tests that boot a real Jenkins instance
(that are annotated with `@WithJenkins` or `@WithJenkinsConfiguredWithCode`) and exclude them when
`-Djenkins.tests.excludeJenkins=true` is set. The filter is registered via `META-INF/services` so
it is auto-discovered by the JUnit Platform. This is opt-in and does not change default test runs.

Addresses request to provide a harness-side helper so plugins can opt-in to fast-tests.

--- 

Real benefit of JenkinsBootTestFilter, at two scales:

#### Org-wide (jenkinsci top-level CI)

The Jenkins ecosystem has 1,800+ plugin repos, most of which pull in jenkins-test-harness and use @WithJenkins/JenkinsRule for integration tests. That population shares CI infrastructure (ci.jenkins.io agents, GitHub Actions minutes) and, more importantly, a shared pipeline template most plugins build from (the jenkins-infra "buildplan"/reusable workflow). That's the leverage point:

- **Zero-migration, org-wide rollout.** 
 
Because the classification is derived from an annotation every plugin already uses for functional reasons - not a tag/exclude list every maintainer has to hand-write and keep in sync - the shared pipeline template could add a "fast tests" pre-stage once, centrally, and every consuming plugin gets it for free on their next jenkins-test-harness bump. No 1,800-repo migration effort, no opt-in campaign, no risk of individual repos drifting out of sync with a tagging convention.

- **A cheap, universal PR-feedback tier**. 
 
Org infra could standardize on: fast-tests stage runs on every push (seconds, no Jenkins boot, immediate signal on logic bugs), full matrix (multi-JDK, Jenkins-booting ITs) runs afterward or gates merge. That's a latency win applied uniformly across the ecosystem rather than plugin-by-plugin reinvention.

- **Ecosystem-level visibility.** 
 
Since the filter's decision is mechanical and consistent, infra tooling could aggregate "fraction of test time spent booting Jenkins" across all plugin repos, useful data for prioritizing infra investment (e.g., is it worth funding faster JenkinsRule boot / container reuse, or parallelizing agents) instead of guessing.

- **Consistency of meaning.** 
 
"Fast tests" means _the same thing in every plugin repo that adopts it_, because the source of truth is the harness annotation, not each repo's bespoke Surefire <excludes>/tag convention (which today differ or don't exist at all in most plugins).

#### Per-plugin CI / local dev loop

- **Faster inner loop for contributors.** 
 
JenkinsRule boot (Jetty + PluginManager + full extension list init) is usually the dominant per-test cost. A contributor fixing a pure logic bug (validators, model classes, parsers) can run -Djenkins.tests.excludeJenkins=true locally and get feedback in seconds instead of minutes, without needing to know which tests are "safe" to skip.

- **A pre-merge fast-fail gate without rewriting the test suite.** 
 
A plugin's own CI can add a quick "fast tests" job ahead of the full build, catching obvious breakage before spending agent time on the expensive Jenkins-booting suite —pline for maintainers to adopt or forget.

- **No drift risk.** 

The alternative (manually tagging/excluding tests) requires maintainers to remember to tag every new Jenkins-booting test going forward; miss one and the "fast" run either silently boots Jenkins anyway or wrongly  it's automatically and permanently correct as long as the annotationis used correctly.

- **Test-pyramid nudge.** 

Visibility into the fast/Jenkins-booting split output) gives plugin authors a concrete signal to push more logic into pure unit tests rather than always reaching for @WithJenkins.
